### PR TITLE
fix(scribe): periodic in-process DuckDB checkpoint (closes #24)

### DIFF
--- a/plugins/ironsworn/scribe/src/checkpoint.ts
+++ b/plugins/ironsworn/scribe/src/checkpoint.ts
@@ -1,0 +1,43 @@
+import { checkpointLore } from "./rag/lore.js";
+import { checkpointScenes } from "./rag/scenes.js";
+
+const CHECKPOINT_INTERVAL_MS = 5 * 60 * 1000;
+const CHECKPOINT_EVERY_N_WRITES = 20;
+
+let writesSinceCheckpoint = 0;
+let timer: ReturnType<typeof setInterval> | null = null;
+let flushing = false;
+
+async function flush(reason: string, campaignPath: string): Promise<void> {
+  if (flushing) return;
+  flushing = true;
+  try {
+    await Promise.all([
+      checkpointLore(campaignPath),
+      checkpointScenes(campaignPath),
+    ]);
+    writesSinceCheckpoint = 0;
+    process.stderr.write(`[scribe] checkpoint complete (${reason})\n`);
+  } catch (e) {
+    process.stderr.write(`[scribe] checkpoint failed (${reason}): ${e}\n`);
+  } finally {
+    flushing = false;
+  }
+}
+
+export function startPeriodicCheckpoint(campaignPath: string): void {
+  if (timer !== null) return;
+  timer = setInterval(() => {
+    if (writesSinceCheckpoint > 0) {
+      void flush("interval", campaignPath);
+    }
+  }, CHECKPOINT_INTERVAL_MS);
+  timer.unref();
+}
+
+export function recordMutation(campaignPath: string): void {
+  writesSinceCheckpoint++;
+  if (writesSinceCheckpoint >= CHECKPOINT_EVERY_N_WRITES) {
+    void flush("write-threshold", campaignPath);
+  }
+}

--- a/plugins/ironsworn/scribe/src/server.ts
+++ b/plugins/ironsworn/scribe/src/server.ts
@@ -8,6 +8,7 @@ import * as loreTools from "./tools/lore.js";
 import * as campaignTools from "./tools/campaign.js";
 import { checkpointLore } from "./rag/lore.js";
 import { checkpointScenes } from "./rag/scenes.js";
+import { startPeriodicCheckpoint } from "./checkpoint.js";
 
 const CAMPAIGN_PATH = process.env.SCRIBE_CAMPAIGN ?? "campaigns/default";
 
@@ -49,6 +50,8 @@ async function shutdown(signal: string): Promise<void> {
 
 process.on("SIGTERM", () => { void shutdown("SIGTERM"); });
 process.on("SIGINT",  () => { void shutdown("SIGINT"); });
+
+startPeriodicCheckpoint(CAMPAIGN_PATH);
 
 const transport = new StdioServerTransport();
 await server.connect(transport);

--- a/plugins/ironsworn/scribe/src/tools/campaign.ts
+++ b/plugins/ironsworn/scribe/src/tools/campaign.ts
@@ -21,6 +21,28 @@ interface CampaignExport {
 
 export function register(server: McpServer, campaignPath: string): void {
   server.tool(
+    "checkpoint_now",
+    "Force an immediate DuckDB checkpoint, flushing the WAL to the tracked .duckdb files. Use after bulk writes or before ending a session.",
+    {},
+    async () => {
+      try {
+        await Promise.all([
+          checkpointLore(campaignPath),
+          checkpointScenes(campaignPath),
+        ]);
+        return {
+          content: [{ type: "text", text: JSON.stringify({ ok: true, message: "Checkpoint complete" }) }],
+        };
+      } catch (e) {
+        return {
+          content: [{ type: "text", text: `Error: ${e instanceof Error ? e.message : String(e)}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.tool(
     "export_campaign",
     "Serialise all campaign data to a portable JSON file. Includes character, threads, NPCs, lore, and scenes. Set include_scenes=false for a lighter world-pack export (lore + NPCs + threads only).",
     {

--- a/plugins/ironsworn/scribe/src/tools/lore.ts
+++ b/plugins/ironsworn/scribe/src/tools/lore.ts
@@ -9,6 +9,7 @@ import {
   LORE_TYPES,
   type LoreType,
 } from "../rag/lore.js";
+import { recordMutation } from "../checkpoint.js";
 
 export function register(server: McpServer, campaignPath: string): void {
   const provenanceSchema = z
@@ -39,6 +40,7 @@ export function register(server: McpServer, campaignPath: string): void {
           ...input,
           type: input.type as LoreType,
         });
+        recordMutation(campaignPath);
         return { content: [{ type: "text", text: JSON.stringify(result) }] };
       } catch (e) {
         return {
@@ -107,6 +109,7 @@ export function register(server: McpServer, campaignPath: string): void {
     async ({ from, to, relation, notes, metadata, provenance }) => {
       try {
         const result = await linkLore(campaignPath, { from, to, relation, notes, metadata, provenance });
+        recordMutation(campaignPath);
         return { content: [{ type: "text", text: JSON.stringify(result) }] };
       } catch (e) {
         return {

--- a/plugins/ironsworn/scribe/src/tools/mutations.ts
+++ b/plugins/ironsworn/scribe/src/tools/mutations.ts
@@ -25,6 +25,7 @@ import { burnMomentum } from "../rules/ironsworn/momentum.js";
 import { tickProgress, vowXp } from "../rules/ironsworn/progress.js";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
+import { recordMutation } from "../checkpoint.js";
 
 function characterDigest(char: Character) {
   const activeDebilities = Object.fromEntries(
@@ -50,6 +51,7 @@ export function register(server: McpServer, campaignPath: string): void {
     async ({ n }) => {
       try {
         const result = await takeMomentum(campaignPath, n);
+        recordMutation(campaignPath);
         return {
           content: [{ type: "text", text: JSON.stringify({ ok: true, state: characterDigest(result.after) }) }],
         };
@@ -77,6 +79,7 @@ export function register(server: McpServer, campaignPath: string): void {
           before: result.before,
           after: result.after,
         });
+        recordMutation(campaignPath);
         return {
           content: [{ type: "text", text: JSON.stringify({ ok: true, state: characterDigest(result.after) }) }],
         };
@@ -96,6 +99,7 @@ export function register(server: McpServer, campaignPath: string): void {
     async ({ n }) => {
       try {
         const result = await sufferHarm(campaignPath, n);
+        recordMutation(campaignPath);
         return {
           content: [{ type: "text", text: JSON.stringify({ ok: true, state: characterDigest(result.after) }) }],
         };
@@ -115,6 +119,7 @@ export function register(server: McpServer, campaignPath: string): void {
     async ({ n }) => {
       try {
         const result = await sufferStress(campaignPath, n);
+        recordMutation(campaignPath);
         return {
           content: [{ type: "text", text: JSON.stringify({ ok: true, state: characterDigest(result.after) }) }],
         };
@@ -134,6 +139,7 @@ export function register(server: McpServer, campaignPath: string): void {
     async ({ n }) => {
       try {
         const result = await consumeSupply(campaignPath, n);
+        recordMutation(campaignPath);
         return {
           content: [{ type: "text", text: JSON.stringify({ ok: true, state: characterDigest(result.after) }) }],
         };
@@ -153,6 +159,7 @@ export function register(server: McpServer, campaignPath: string): void {
     async ({ n }) => {
       try {
         const result = await restoreHealth(campaignPath, n);
+        recordMutation(campaignPath);
         return {
           content: [{ type: "text", text: JSON.stringify({ ok: true, state: characterDigest(result.after) }) }],
         };
@@ -172,6 +179,7 @@ export function register(server: McpServer, campaignPath: string): void {
     async ({ n }) => {
       try {
         const result = await restoreSpirit(campaignPath, n);
+        recordMutation(campaignPath);
         return {
           content: [{ type: "text", text: JSON.stringify({ ok: true, state: characterDigest(result.after) }) }],
         };
@@ -191,6 +199,7 @@ export function register(server: McpServer, campaignPath: string): void {
     async ({ n }) => {
       try {
         const result = await restoreSupply(campaignPath, n);
+        recordMutation(campaignPath);
         return {
           content: [{ type: "text", text: JSON.stringify({ ok: true, state: characterDigest(result.after) }) }],
         };
@@ -210,6 +219,7 @@ export function register(server: McpServer, campaignPath: string): void {
     async ({ name }) => {
       try {
         const result = await inflictDebility(campaignPath, name);
+        recordMutation(campaignPath);
         return {
           content: [{ type: "text", text: JSON.stringify({ ok: true, state: characterDigest(result.after) }) }],
         };
@@ -229,6 +239,7 @@ export function register(server: McpServer, campaignPath: string): void {
     async ({ name }) => {
       try {
         const result = await clearDebility(campaignPath, name);
+        recordMutation(campaignPath);
         return {
           content: [{ type: "text", text: JSON.stringify({ ok: true, state: characterDigest(result.after) }) }],
         };
@@ -270,6 +281,7 @@ export function register(server: McpServer, campaignPath: string): void {
           before,
           after: character,
         });
+        recordMutation(campaignPath);
         return {
           content: [{ type: "text", text: JSON.stringify({ ok: true, track: updatedTrack }) }],
         };
@@ -300,6 +312,7 @@ export function register(server: McpServer, campaignPath: string): void {
         const newTrack = { name, rank, kind, ticks: 0, completed: false };
         character.progressTracks.push(newTrack);
         await saveCharacter(campaignPath, character);
+        recordMutation(campaignPath);
         return {
           content: [{ type: "text", text: JSON.stringify({ ok: true, track: newTrack }) }],
         };
@@ -354,6 +367,7 @@ export function register(server: McpServer, campaignPath: string): void {
           before,
           after: character,
         });
+        recordMutation(campaignPath);
         return {
           content: [{ type: "text", text: JSON.stringify({ ok: true, track: character.progressTracks[idx], xpGained, experience: character.experience }) }],
         };
@@ -376,6 +390,7 @@ export function register(server: McpServer, campaignPath: string): void {
     async ({ path, value }) => {
       try {
         const result = await overrideField(campaignPath, path, value);
+        recordMutation(campaignPath);
         return {
           content: [{ type: "text", text: JSON.stringify({ ok: true, state: characterDigest(result.after) }) }],
         };
@@ -417,6 +432,7 @@ export function register(server: McpServer, campaignPath: string): void {
         const lastLine = lines[lines.length - 1]!;
         const entry = JSON.parse(lastLine) as { before: Character; after: Character };
         await saveCharacter(campaignPath, entry.before);
+        recordMutation(campaignPath);
         return {
           content: [{ type: "text", text: JSON.stringify({ ok: true, restored: characterDigest(entry.before) }) }],
         };
@@ -438,6 +454,7 @@ export function register(server: McpServer, campaignPath: string): void {
     async ({ companion_name, n }) => {
       try {
         const result = await companionSufferHarm(campaignPath, companion_name, n);
+        recordMutation(campaignPath);
         const companion = result.after.companions.find(
           (c) => c.name.toLowerCase() === companion_name.toLowerCase(),
         );
@@ -463,6 +480,7 @@ export function register(server: McpServer, campaignPath: string): void {
     async ({ companion_name, n }) => {
       try {
         const result = await companionRestoreHealth(campaignPath, companion_name, n);
+        recordMutation(campaignPath);
         const companion = result.after.companions.find(
           (c) => c.name.toLowerCase() === companion_name.toLowerCase(),
         );
@@ -488,6 +506,7 @@ export function register(server: McpServer, campaignPath: string): void {
     async ({ companion_name, health }) => {
       try {
         const result = await upsertCompanion(campaignPath, companion_name, health);
+        recordMutation(campaignPath);
         const companion = result.after.companions.find(
           (c) => c.name.toLowerCase() === companion_name.toLowerCase(),
         );
@@ -510,6 +529,7 @@ export function register(server: McpServer, campaignPath: string): void {
     async ({ n }) => {
       try {
         const result = await gainExperience(campaignPath, n);
+        recordMutation(campaignPath);
         return {
           content: [{ type: "text", text: JSON.stringify({ ok: true, experience: result.after.experience }) }],
         };
@@ -529,6 +549,7 @@ export function register(server: McpServer, campaignPath: string): void {
     async ({ n }) => {
       try {
         const result = await spendExperience(campaignPath, n);
+        recordMutation(campaignPath);
         return {
           content: [{ type: "text", text: JSON.stringify({ ok: true, experience: result.after.experience }) }],
         };

--- a/plugins/ironsworn/scribe/src/tools/narrative.ts
+++ b/plugins/ironsworn/scribe/src/tools/narrative.ts
@@ -5,6 +5,7 @@ import { openThread, closeThread } from "../state/threads.js";
 import { upsertNpc, getNpc } from "../state/npcs.js";
 import { getLore } from "../rag/lore.js";
 import { loadCharacter, saveCharacter } from "../state/character.js";
+import { recordMutation } from "../checkpoint.js";
 
 // ---------------------------------------------------------------------------
 // Warning helpers (exported for testing)
@@ -58,6 +59,7 @@ export function register(server: McpServer, campaignPath: string): void {
     async ({ summary, kind, npcs, lore_ids }) => {
       try {
         await recordScene(campaignPath, summary, kind);
+        recordMutation(campaignPath);
         const warnings = await buildSceneWarnings(campaignPath, npcs, lore_ids);
         return {
           content: [{ type: "text", text: JSON.stringify({ ok: true, warnings }) }],
@@ -96,6 +98,7 @@ export function register(server: McpServer, campaignPath: string): void {
           await saveCharacter(campaignPath, character);
         }
 
+        recordMutation(campaignPath);
         return {
           content: [{ type: "text", text: JSON.stringify({ ...thread, progressTrack: track ?? null }) }],
         };
@@ -133,6 +136,7 @@ export function register(server: McpServer, campaignPath: string): void {
           }
         }
 
+        recordMutation(campaignPath);
         return {
           content: [{ type: "text", text: JSON.stringify({ ...thread, progressTrackCompleted: trackUpdated }) }],
         };
@@ -156,6 +160,7 @@ export function register(server: McpServer, campaignPath: string): void {
     async ({ name, description, impression }) => {
       try {
         await upsertNpc(campaignPath, name, description, impression);
+        recordMutation(campaignPath);
         return {
           content: [{ type: "text", text: JSON.stringify({ ok: true }) }],
         };

--- a/plugins/ironsworn/settings.json
+++ b/plugins/ironsworn/settings.json
@@ -13,17 +13,5 @@
       "Bash(cd * && bun test*)"
     ]
   },
-  "hooks": {
-    "WorktreeCreate": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "statusMessage": "Symlinking shared data into worktree...",
-            "command": "WORKTREE=$(jq -r '.worktree_path // .path // \"\"'); if [ -n \"$WORKTREE\" ] && [ -d \"$WORKTREE\" ]; then mkdir -p \"$WORKTREE/data/ironsworn\" && ln -sf \"$(pwd)/data/ironsworn.duckdb\" \"$WORKTREE/data/ironsworn/ironsworn.duckdb\" && ln -sfn \"$HOME/.rpg-data/campaigns\" \"$WORKTREE/campaigns\" && ln -sfn \"$HOME/.rpg-data/remember\" \"$WORKTREE/.remember\"; fi"
-          }
-        ]
-      }
-    ]
-  }
+  "hooks": {}
 }


### PR DESCRIPTION
## Summary

- Adds `src/checkpoint.ts` module that flushes DuckDB WAL every 5 minutes or after 20 mutation tool calls (whichever first)
- Wires `recordMutation()` into all mutation tool handlers (mutations.ts, narrative.ts, lore.ts)
- Includes `flushing` guard to prevent overlapping checkpoint calls
- Removes outdated `WorktreeCreate` hook that symlinked from `~/.rpg-data/`

## Test plan

- [ ] Verify `bun test` passes (169/170, 1 skip due to Ollama)
- [ ] Run scribe, perform >20 mutations, confirm checkpoint logs on stderr
- [ ] Confirm interval checkpoint fires after 5min idle with pending writes
- [ ] Verify SIGTERM shutdown still checkpoints normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)