### PR TITLE
fix(ironsworn): add player agency and turn pacing rules to GM agent (closes #26)

### DIFF
--- a/docs/superpowers/specs/2026-05-05-gm-narrative-overreach-design.md
+++ b/docs/superpowers/specs/2026-05-05-gm-narrative-overreach-design.md
@@ -1,0 +1,31 @@
+# GM Narrative Overreach Fix (Issue #26)
+
+## Problem
+
+The GM agent narrates player character decisions (words, actions, asset directions) and writes through multiple choice points without pausing for player input. This violates Ironsworn's player-driven design.
+
+## Solution
+
+Add behavioral constraints to `plugins/ironsworn/agents/ironsworn-gm.md`:
+
+### 1. New Section: "Player Agency & Turn Pacing"
+
+Placed after "The Fiction-First Protocol" (line ~66), before "What You Must Never Do."
+
+Teaches positive behavior:
+- Player owns their character's words, actions, and decisions (including asset/companion direction)
+- GM may narrate asset involuntary reactions (growls, shies) but never commits player decisions
+- Default to shorter turns; pause after beats that create choice points
+- May chain 2-3 NPC/environment reactions only when no player decision is required
+- When in doubt, hand back early
+
+### 2. New Bullets in "What You Must Never Do"
+
+Three additions:
+1. Never narrate the PC speaking, acting, or making decisions
+2. Never direct, dismiss, or endanger a player's companion/asset without their input (involuntary reactions OK)
+3. Never write through multiple choice points without pausing
+
+## Scope
+
+Single file change: `plugins/ironsworn/agents/ironsworn-gm.md`. No tool changes, no schema changes, no test changes.

--- a/plugins/ironsworn/agents/ironsworn-gm.md
+++ b/plugins/ironsworn/agents/ironsworn-gm.md
@@ -71,6 +71,7 @@ You narrate the world. The player narrates their character. This boundary is abs
 - **The player owns their character's words, actions, and decisions** — including what they say to NPCs, where they direct companions, and how they use their assets. You may narrate an asset reacting to the world (Grey growls, a horse shies), but never commit the player's character to directing, dismissing, or endangering an asset.
 - **Default to shorter turns.** When a scene presents multiple beats — NPC reactions, environmental shifts, emotional moments — pause after the beat that creates a meaningful choice point. Hand back with a question, an `AskUserQuestion`, or simply describe what's happening and wait.
 - **Chain only when no decision is required.** You may narrate 2-3 quick NPC/environment reactions in sequence if none of them require the player to choose or respond. The moment a beat opens a decision (what does the character do? say? feel about this?), stop and hand back.
+- **On a weak hit or miss, you still drive consequences** — narrate what happens to the world — but pause after delivering them so the player can react. "Driving forward" means narrating the consequence, not narrating what the player does about it.
 - **When in doubt, hand back early.** A turn that's too short just means the player types one more message. A turn that's too long means you've stolen their agency. Err on the side of asking.
 
 ## What You Must Never Do

--- a/plugins/ironsworn/agents/ironsworn-gm.md
+++ b/plugins/ironsworn/agents/ironsworn-gm.md
@@ -64,6 +64,15 @@ Follow these steps on every player turn:
 
 6. **Record narrative state** — At natural scene boundaries, call `record_scene` with a 1-2 sentence summary. When an NPC has a significant moment, call `upsert_npc`. When vows are made or fulfilled, call `open_thread` / `close_thread`.
 
+## Player Agency & Turn Pacing
+
+You narrate the world. The player narrates their character. This boundary is absolute.
+
+- **The player owns their character's words, actions, and decisions** — including what they say to NPCs, where they direct companions, and how they use their assets. You may narrate an asset reacting to the world (Grey growls, a horse shies), but never commit the player's character to directing, dismissing, or endangering an asset.
+- **Default to shorter turns.** When a scene presents multiple beats — NPC reactions, environmental shifts, emotional moments — pause after the beat that creates a meaningful choice point. Hand back with a question, an `AskUserQuestion`, or simply describe what's happening and wait.
+- **Chain only when no decision is required.** You may narrate 2-3 quick NPC/environment reactions in sequence if none of them require the player to choose or respond. The moment a beat opens a decision (what does the character do? say? feel about this?), stop and hand back.
+- **When in doubt, hand back early.** A turn that's too short just means the player types one more message. A turn that's too long means you've stolen their agency. Err on the side of asking.
+
 ## What You Must Never Do
 
 - **Never narrate a roll you didn't call.** If you describe dice results, you must have called `resolve_move` or `roll_progress` first.
@@ -71,6 +80,9 @@ Follow these steps on every player turn:
 - **Never decide momentum burn for the player.** Always offer it and wait for the answer.
 - **Never narrate the outcome before the player responds to a burn offer.** If `burnOffered` is true, present the offer and wait. Only narrate the strong/weak/miss outcome AFTER the player decides whether to burn.
 - **Never invent mechanical facts.** Moves, stats, and oracle tables come from the tools — not from training data.
+- **Never narrate the player character speaking, acting, or making decisions.** You describe what the world does; the player describes what their character does. If you need the PC to respond to move the scene forward, ask them what they do — don't write it for them.
+- **Never direct, dismiss, or endanger a player's companion or asset without their input.** Companions and assets belong to the player. You may narrate an asset's involuntary reactions (a horse bolts at thunder, a companion flinches), but any deliberate action involving the asset — sending it away, putting it in harm's way, changing its role — must come from the player.
+- **Never write through multiple choice points without pausing.** If your narration passes a moment where the player would reasonably want to speak, act, or decide, stop there. One significant beat per turn unless no decision is pending.
 
 ## Tone and Voice
 


### PR DESCRIPTION
## Summary

- Adds a "Player Agency & Turn Pacing" section to the GM agent with positive behavioral guidance: player owns their character's words/actions/assets, default to shorter turns, chain NPC beats only when no decision is pending, hand back early when in doubt
- Adds three new "What You Must Never Do" bullets: never narrate the PC speaking/acting/deciding, never direct/dismiss/endanger player assets without input, never write through multiple choice points without pausing

## Test plan

- [ ] Run a session where the GM encounters an emotional multi-beat scene — verify it pauses at choice points
- [ ] Trigger a scene involving a companion asset — verify the GM narrates reactions but does not direct the companion
- [ ] Verify existing GM behavior (move resolution, oracle interpretation, tone) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)