### PR TITLE
fix(scribe): add update_scene and delete_scene tools (closes #27)

### DIFF
--- a/plugins/ironsworn/scribe/src/rag/scenes.test.ts
+++ b/plugins/ironsworn/scribe/src/rag/scenes.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { recordScene, searchScenes, getRecentComplications } from "./scenes.js";
+import { recordScene, searchScenes, getRecentComplications, getScene, updateScene, deleteScene } from "./scenes.js";
 
 // Check if Ollama is running
 async function ollamaAvailable(): Promise<boolean> {
@@ -68,5 +68,91 @@ describe("getRecentComplications", () => {
     await recordScene(campaignDir, "Blizzard hit.", "exploration", "weather");
     const results = await getRecentComplications(campaignDir, 2);
     expect(results).toHaveLength(2);
+  });
+});
+
+describe("getScene", () => {
+  it("returns null for non-existent scene", async () => {
+    if (!(await ollamaAvailable())) return;
+    // Record a scene to initialize the DB
+    await recordScene(campaignDir, "A placeholder scene.");
+    const result = await getScene(campaignDir, "non-existent-id");
+    expect(result).toBeNull();
+  });
+
+  it("returns scene by ID after recording", async () => {
+    if (!(await ollamaAvailable())) return;
+    await recordScene(campaignDir, "The hero enters the dark cave.", "exploration");
+    const scenes = await searchScenes(campaignDir, "dark cave", 1);
+    expect(scenes.length).toBeGreaterThan(0);
+    const scene = await getScene(campaignDir, scenes[0].id);
+    expect(scene).not.toBeNull();
+    expect(scene!.text).toContain("dark cave");
+    expect(scene!.kind).toBe("exploration");
+  });
+});
+
+describe("updateScene", () => {
+  it("updates the summary text of an existing scene", async () => {
+    if (!(await ollamaAvailable())) return;
+    await recordScene(campaignDir, "Original scene text.", "combat");
+    const scenes = await searchScenes(campaignDir, "Original scene", 1);
+    const id = scenes[0].id;
+
+    await updateScene(campaignDir, id, { summary: "Updated scene text." });
+
+    const updated = await getScene(campaignDir, id);
+    expect(updated).not.toBeNull();
+    expect(updated!.text).toBe("Updated scene text.");
+  });
+
+  it("updates the kind of an existing scene", async () => {
+    if (!(await ollamaAvailable())) return;
+    await recordScene(campaignDir, "A quiet campfire.", "exploration");
+    const scenes = await searchScenes(campaignDir, "campfire", 1);
+    const id = scenes[0].id;
+
+    await updateScene(campaignDir, id, { kind: "social" });
+
+    const updated = await getScene(campaignDir, id);
+    expect(updated).not.toBeNull();
+    expect(updated!.kind).toBe("social");
+    // text unchanged
+    expect(updated!.text).toContain("campfire");
+  });
+
+  it("does nothing when no fields are provided", async () => {
+    if (!(await ollamaAvailable())) return;
+    await recordScene(campaignDir, "Unchanged scene.", "combat");
+    const scenes = await searchScenes(campaignDir, "Unchanged scene", 1);
+    const id = scenes[0].id;
+
+    await updateScene(campaignDir, id, {});
+
+    const unchanged = await getScene(campaignDir, id);
+    expect(unchanged).not.toBeNull();
+    expect(unchanged!.text).toBe("Unchanged scene.");
+  });
+});
+
+describe("deleteScene", () => {
+  it("removes a scene by ID", async () => {
+    if (!(await ollamaAvailable())) return;
+    await recordScene(campaignDir, "Scene to delete.", "exploration");
+    const scenes = await searchScenes(campaignDir, "Scene to delete", 1);
+    const id = scenes[0].id;
+
+    await deleteScene(campaignDir, id);
+
+    const deleted = await getScene(campaignDir, id);
+    expect(deleted).toBeNull();
+  });
+
+  it("does not fail when deleting non-existent ID", async () => {
+    if (!(await ollamaAvailable())) return;
+    // Initialize DB with a scene
+    await recordScene(campaignDir, "A scene.");
+    // deleteScene on non-existent ID should not throw
+    await deleteScene(campaignDir, "non-existent-id");
   });
 });

--- a/plugins/ironsworn/scribe/src/rag/scenes.ts
+++ b/plugins/ironsworn/scribe/src/rag/scenes.ts
@@ -163,6 +163,89 @@ export async function recordScene(
   }
 }
 
+export async function getScene(
+  campaignPath: string,
+  id: string,
+): Promise<Scene | null> {
+  const instance = await getDb(campaignPath);
+  const conn = await instance.connect();
+  try {
+    const rows = (
+      await conn.runAndReadAll(
+        `SELECT id, text, timestamp, kind, complication_theme FROM scenes WHERE id = ?`,
+        [id],
+      )
+    ).getRowObjectsJS() as Record<string, unknown>[];
+    if (rows.length === 0) return null;
+    const row = rows[0]!;
+    return {
+      id: String(row["id"]),
+      text: String(row["text"]),
+      timestamp: String(row["timestamp"]),
+      kind: String(row["kind"]),
+      complication_theme: row["complication_theme"] != null ? String(row["complication_theme"]) : undefined,
+    };
+  } finally {
+    conn.closeSync();
+  }
+}
+
+export async function updateScene(
+  campaignPath: string,
+  id: string,
+  fields: { summary?: string; kind?: string; complication_theme?: string },
+): Promise<void> {
+  const instance = await getDb(campaignPath);
+
+  // Build SET clauses for provided fields
+  const setClauses: string[] = [];
+  const params: unknown[] = [];
+
+  if (fields.summary !== undefined) {
+    // Re-embed when summary changes
+    const embedding = await getEmbedding(fields.summary);
+    const embeddingLiteral = `[${embedding.join(",")}]::FLOAT[768]`;
+    setClauses.push(`text = ?`);
+    params.push(fields.summary);
+    setClauses.push(`embedding = ${embeddingLiteral}`);
+  }
+  if (fields.kind !== undefined) {
+    setClauses.push(`kind = ?`);
+    params.push(fields.kind);
+  }
+  if (fields.complication_theme !== undefined) {
+    setClauses.push(`complication_theme = ?`);
+    params.push(fields.complication_theme);
+  }
+
+  if (setClauses.length === 0) return;
+
+  params.push(id);
+
+  const conn = await openWriteConn(instance);
+  try {
+    await conn.run(
+      `UPDATE scenes SET ${setClauses.join(", ")} WHERE id = ?`,
+      params,
+    );
+  } finally {
+    conn.closeSync();
+  }
+}
+
+export async function deleteScene(
+  campaignPath: string,
+  id: string,
+): Promise<void> {
+  const instance = await getDb(campaignPath);
+  const conn = await openWriteConn(instance);
+  try {
+    await conn.run(`DELETE FROM scenes WHERE id = ?`, [id]);
+  } finally {
+    conn.closeSync();
+  }
+}
+
 export interface SceneExport {
   id: string;
   text: string;

--- a/plugins/ironsworn/scribe/src/tools/narrative.ts
+++ b/plugins/ironsworn/scribe/src/tools/narrative.ts
@@ -1,6 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { recordScene } from "../rag/scenes.js";
+import { recordScene, getScene, updateScene, deleteScene } from "../rag/scenes.js";
 import { openThread, closeThread } from "../state/threads.js";
 import { upsertNpc, getNpc } from "../state/npcs.js";
 import { getLore } from "../rag/lore.js";
@@ -66,6 +66,69 @@ export function register(server: McpServer, campaignPath: string): void {
         const warnings = await buildSceneWarnings(campaignPath, npcs, lore_ids);
         return {
           content: [{ type: "text", text: JSON.stringify({ ok: true, warnings }) }],
+        };
+      } catch (e) {
+        return {
+          content: [{ type: "text", text: `Error: ${e instanceof Error ? e.message : String(e)}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.tool(
+    "update_scene",
+    "Update an existing scene record. Only provided fields are changed.",
+    {
+      id: z.string().describe("ID of the scene to update"),
+      summary: z.string().optional().describe("New summary text (replaces existing)"),
+      kind: z.string().optional().describe("New kind of scene"),
+      npcs: z.array(z.string()).optional().describe("NPC names to verify are recorded"),
+      lore_ids: z.array(z.string()).optional().describe("Lore entity IDs to verify are recorded"),
+    },
+    async ({ id, summary, kind, npcs, lore_ids }) => {
+      try {
+        const existing = await getScene(campaignPath, id);
+        if (existing === null) {
+          return {
+            content: [{ type: "text", text: `Error: Scene not found: ${id}` }],
+            isError: true,
+          };
+        }
+        await updateScene(campaignPath, id, { summary, kind });
+        recordMutation(campaignPath);
+        const warnings = await buildSceneWarnings(campaignPath, npcs, lore_ids);
+        return {
+          content: [{ type: "text", text: JSON.stringify({ ok: true, id, warnings }) }],
+        };
+      } catch (e) {
+        return {
+          content: [{ type: "text", text: `Error: ${e instanceof Error ? e.message : String(e)}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.tool(
+    "delete_scene",
+    "Delete a scene record by ID",
+    {
+      id: z.string().describe("ID of the scene to delete"),
+    },
+    async ({ id }) => {
+      try {
+        const existing = await getScene(campaignPath, id);
+        if (existing === null) {
+          return {
+            content: [{ type: "text", text: `Error: Scene not found: ${id}` }],
+            isError: true,
+          };
+        }
+        await deleteScene(campaignPath, id);
+        recordMutation(campaignPath);
+        return {
+          content: [{ type: "text", text: JSON.stringify({ ok: true, id }) }],
         };
       } catch (e) {
         return {


### PR DESCRIPTION
## Summary
- Adds `update_scene(id, summary?, kind?, npcs?, lore_ids?)` tool to amend existing scene records
- Adds `delete_scene(id)` tool to remove scene records
- Both validate scene exists before operating, call `recordMutation()` for checkpoint tracking
- Includes tests for both tools

## Test plan
- [x] `bun test` passes (179/180, 1 pre-existing lore test unrelated)
- [ ] Manual test: record a scene, update it, verify changes persist
- [ ] Manual test: record a scene, delete it, verify it's gone from search

🤖 Generated with [Claude Code](https://claude.com/claude-code)