### PR TITLE
fix(scribe): resolve pre-existing TypeScript type errors (closes #30)

### DIFF
--- a/plugins/ironsworn/scribe/src/context/build.test.ts
+++ b/plugins/ironsworn/scribe/src/context/build.test.ts
@@ -11,7 +11,7 @@ const SAMPLE_CHAR = {
   momentum: 2, momentumReset: 2,
   health: 5, spirit: 5, supply: 3,
   debilities: Object.fromEntries(DEBILITIES.map(d => [d, false])),
-  assets: [], progressTracks: [], bonds: 0, customState: {},
+  assets: [], progressTracks: [], companions: [], bonds: 0, experience: 0, customState: {},
 };
 
 let campaignDir: string;

--- a/plugins/ironsworn/scribe/src/rag/query.envpath.test.ts
+++ b/plugins/ironsworn/scribe/src/rag/query.envpath.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
-import { resolveDbPath } from "./query.ts";
+import { resolveDbPath } from "./query.js";
 
 describe("query.ts — resolveDbPath", () => {
   const originalPluginRoot = process.env.SCRIBE_PLUGIN_ROOT;

--- a/plugins/ironsworn/scribe/src/rules/ironsworn/momentum.test.ts
+++ b/plugins/ironsworn/scribe/src/rules/ironsworn/momentum.test.ts
@@ -13,7 +13,9 @@ const makeChar = (momentum: number, momentumReset: number = 2): Character => ({
   debilities: Object.fromEntries(DEBILITIES.map(d => [d, false])),
   assets: [],
   progressTracks: [],
+  companions: [],
   bonds: 0,
+  experience: 0,
   customState: {},
 });
 

--- a/plugins/ironsworn/scribe/src/rules/ironsworn/moves.envpath.test.ts
+++ b/plugins/ironsworn/scribe/src/rules/ironsworn/moves.envpath.test.ts
@@ -29,7 +29,7 @@ describe("moves.ts — SCRIBE_PLUGIN_ROOT resolution", () => {
     const mod = await import("./moves.ts?t=" + Date.now());
     const moves = mod.getMoves();
     expect(Array.isArray(moves)).toBe(true);
-    const move = moves.find((m) => m.name === "Test Move");
+    const move = moves.find((m: { name: string }) => m.name === "Test Move");
     expect(move).toBeDefined();
     expect(move?.name).toBe("Test Move");
   });

--- a/plugins/ironsworn/scribe/src/state/character.test.ts
+++ b/plugins/ironsworn/scribe/src/state/character.test.ts
@@ -301,7 +301,7 @@ describe("experience field (issue #9)", () => {
 
   it("loadCharacter fills in experience=0 when field is missing (legacy data)", async () => {
     // Write a character JSON without the experience field (simulating old data)
-    const legacy = structuredClone(SAMPLE) as Record<string, unknown>;
+    const legacy = structuredClone(SAMPLE) as unknown as Record<string, unknown>;
     delete legacy.experience;
     await writeFile(join(campaignDir, "character.json"), JSON.stringify(legacy, null, 2), "utf-8");
 

--- a/plugins/ironsworn/scribe/src/state/threads.test.ts
+++ b/plugins/ironsworn/scribe/src/state/threads.test.ts
@@ -16,6 +16,7 @@ const SAMPLE_CHARACTER: Character = {
   debilities: Object.fromEntries(DEBILITIES.map((d) => [d, false])),
   assets: [],
   progressTracks: [],
+  companions: [],
   bonds: 0,
   experience: 0,
   customState: {},

--- a/plugins/ironsworn/scribe/src/tools/narrative.ts
+++ b/plugins/ironsworn/scribe/src/tools/narrative.ts
@@ -4,7 +4,7 @@ import { recordScene } from "../rag/scenes.js";
 import { openThread, closeThread } from "../state/threads.js";
 import { upsertNpc, getNpc } from "../state/npcs.js";
 import { getLore } from "../rag/lore.js";
-import { loadCharacter, saveCharacter } from "../state/character.js";
+import { loadCharacter, saveCharacter, ProgressTrack } from "../state/character.js";
 import { recordMutation } from "../checkpoint.js";
 
 // ---------------------------------------------------------------------------
@@ -93,10 +93,10 @@ export function register(server: McpServer, campaignPath: string): void {
         const thread = await openThread(campaignPath, title, kind, notes);
 
         // Issue #2: auto-create a matching progress track for vow threads
-        let track: { name: string; rank: string; kind: string; ticks: number; completed: boolean } | undefined;
+        let track: ProgressTrack | undefined;
         if (kind === "vow" && rank !== undefined) {
           const character = await loadCharacter(campaignPath);
-          track = { name: title, rank, kind: "vow", ticks: 0, completed: false };
+          track = { name: title, rank: rank as ProgressTrack["rank"], kind: "vow", ticks: 0, completed: false };
           character.progressTracks.push(track);
           await saveCharacter(campaignPath, character);
         }


### PR DESCRIPTION
## Summary
- Fixes all 7 pre-existing TypeScript type errors across 6 files
- Adds missing `companions`/`experience` fields to test Character literals
- Removes `.ts` extension from import path
- Adds explicit type annotation for implicit `any`
- Uses double-cast through `unknown` for Record conversion
- Asserts zod-validated rank as literal union type

## Test plan
- [x] `bunx tsc --noEmit` reports 0 errors
- [x] `bun test` passes (172/173, 1 pre-existing lore test unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)