### PR TITLE
feat(scribe): add upgrade_asset tool to unlock asset abilities (closes #41)

### DIFF
--- a/plugins/ironsworn/scribe/src/state/character.ts
+++ b/plugins/ironsworn/scribe/src/state/character.ts
@@ -345,3 +345,27 @@ export async function spendExperience(
     char.experience -= n;
   });
 }
+
+export async function upgradeAsset(
+  campaignPath: string,
+  assetName: string,
+  abilityIndex: number,
+): Promise<MutationResult> {
+  return mutate(campaignPath, "upgradeAsset", (char) => {
+    const asset = char.assets.find(
+      (a) => a.name.toLowerCase() === assetName.toLowerCase(),
+    );
+    if (!asset) {
+      throw new Error(`Asset not found: "${assetName}"`);
+    }
+    if (abilityIndex < 0 || abilityIndex >= asset.abilities.length) {
+      throw new Error(
+        `Ability index ${abilityIndex} out of range for asset "${assetName}" (has ${asset.abilities.length} abilities)`,
+      );
+    }
+    if (asset.abilities[abilityIndex]) {
+      throw new Error(`Ability ${abilityIndex} of "${assetName}" is already unlocked`);
+    }
+    asset.abilities[abilityIndex] = true;
+  });
+}

--- a/plugins/ironsworn/scribe/src/tools/mutations.ts
+++ b/plugins/ironsworn/scribe/src/tools/mutations.ts
@@ -19,6 +19,7 @@ import {
   companionSufferHarm,
   companionRestoreHealth,
   upsertCompanion,
+  upgradeAsset,
   Character,
 } from "../state/character.js";
 import { burnMomentum } from "../rules/ironsworn/momentum.js";
@@ -552,6 +553,32 @@ export function register(server: McpServer, campaignPath: string): void {
         recordMutation(campaignPath);
         return {
           content: [{ type: "text", text: JSON.stringify({ ok: true, experience: result.after.experience }) }],
+        };
+      } catch (e) {
+        return {
+          content: [{ type: "text", text: `Error: ${e instanceof Error ? e.message : String(e)}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.tool(
+    "upgrade_asset",
+    "Unlock an asset ability by index. Use after spend_experience to persist the upgrade to the character sheet.",
+    {
+      asset_name: z.string().describe("Name of the asset (case-insensitive, e.g. 'Hound', 'Swordmaster')"),
+      ability_index: z.coerce.number().int().min(0).describe("Zero-based index of the ability to unlock"),
+    },
+    async ({ asset_name, ability_index }) => {
+      try {
+        const result = await upgradeAsset(campaignPath, asset_name, ability_index);
+        recordMutation(campaignPath);
+        const asset = result.after.assets.find(
+          (a) => a.name.toLowerCase() === asset_name.toLowerCase(),
+        );
+        return {
+          content: [{ type: "text", text: JSON.stringify({ ok: true, asset }) }],
         };
       } catch (e) {
         return {


### PR DESCRIPTION
## Summary

- Add upgrade_asset tool to the Scribe MCP server (#41)
- Update character state to track unlocked asset abilities
- Register the new tool in mutations

## Test plan

- [ ] Verify upgrade_asset tool is accessible via MCP
- [ ] Verify unlocking an ability persists to character state
- [ ] Verify already-unlocked abilities cannot be unlocked again

Generated with Claude Code