### PR TITLE
fix(scribe): migrate existing DuckDB to add complication_theme column (closes #45)

### DIFF
--- a/plugins/ironsworn/scribe/src/rag/scenes.ts
+++ b/plugins/ironsworn/scribe/src/rag/scenes.ts
@@ -55,6 +55,10 @@ async function initDb(campaignPath: string): Promise<DuckDBInstance> {
     `);
 
     await conn.run(`
+      ALTER TABLE scenes ADD COLUMN IF NOT EXISTS complication_theme TEXT
+    `);
+
+    await conn.run(`
       CREATE INDEX IF NOT EXISTS scenes_embedding_idx
       ON scenes USING HNSW (embedding)
       WITH (metric = 'cosine')


### PR DESCRIPTION
## Summary

- Add DuckDB schema migration to add the complication_theme column to existing databases (#45)
- Ensures backward compatibility when loading databases created before this column was introduced

## Test plan

- [ ] Verify existing DuckDB databases are migrated successfully on startup
- [ ] Verify record_scene works with the complication_theme field after migration
- [ ] Verify databases already containing the column are unaffected

Generated with Claude Code