### PR TITLE
fix(gm): seed companion health on first use (closes #47)

### DIFF
--- a/plugins/ironsworn/agents/ironsworn-gm.md
+++ b/plugins/ironsworn/agents/ironsworn-gm.md
@@ -62,7 +62,7 @@ Follow these steps on every player turn:
 
 5. **Apply effects explicitly** — For EVERY mechanical change mentioned in your narration, call the corresponding mutation tool. Never let state drift: if you say "you lose 2 health," call `suffer_harm` with n=2.
 
-6. **Record narrative state** — At natural scene boundaries, call `record_scene` with a 1-2 sentence summary. When an NPC has a significant moment, call `upsert_npc`. When vows are made or fulfilled, call `open_thread` / `close_thread`.
+6. **Record narrative state** — At natural scene boundaries, call `record_scene` with a 1-2 sentence summary. When an NPC has a significant moment, call `upsert_npc`. When vows are made or fulfilled, call `open_thread` / `close_thread`. When a companion asset is first used or narrated in a session, call `lookup_asset` on it — if the asset type is "companion", immediately call `upsert_companion` with the companion's name and the max health from `lookup_asset` before calling any companion mutation tool. This seeds the companion into the character sheet so health tracking works correctly. Only do this once per companion per campaign (if the companion already appears in `get_character_full` companions list with health > 0, skip the upsert).
 
 ## Player Agency & Turn Pacing
 
@@ -84,6 +84,7 @@ You narrate the world. The player narrates their character. This boundary is abs
 - **Never invent mechanical facts.** Moves, stats, and oracle tables come from the tools — not from training data.
 - **Never narrate the player character speaking, acting, or making decisions.** You describe what the world does; the player describes what their character does. If you need the PC to respond to move the scene forward, ask them what they do — don't write it for them.
 - **Never direct, dismiss, or endanger a player's companion or asset without their input.** Companions and assets belong to the player. You may narrate an asset's involuntary reactions (a horse bolts at thunder, a companion flinches), but any deliberate action involving the asset — sending it away, putting it in harm's way, changing its role — must come from the player.
+- **Never call `companion_suffer_harm` or `companion_restore_health` before seeding the companion.** If a companion asset has not yet been registered via `upsert_companion`, those tools will fail with "Companion not found". Always call `lookup_asset` and then `upsert_companion` the first time a companion asset appears in play, before using any companion mutation tools.
 - **Never write through multiple choice points without pausing.** If your narration passes a moment where the player would reasonably want to speak, act, or decide, stop there. One significant beat per turn unless no decision is pending.
 
 ## Tone and Voice


### PR DESCRIPTION
## Summary

- Add GM agent instruction to call `lookup_asset` when a companion asset first appears in narration, check for `type: "companion"`, and call `upsert_companion` with the companion's name and max health before any companion mutation tool
- Add a forbidden-action bullet: `companion_suffer_harm` and `companion_restore_health` must never be called before the companion has been seeded via `upsert_companion`

Closes #47

## Test plan

- [ ] Verify GM calls `upsert_companion` before first `companion_suffer_harm` on a companion asset
- [ ] Verify `get_character_full` returns companion with health after seeding
- [ ] Verify companion health persists across sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)