### PR TITLE
fix(gm): cross-reference lore before introducing named entities (closes #48)

### DIFF
--- a/plugins/ironsworn/agents/ironsworn-gm.md
+++ b/plugins/ironsworn/agents/ironsworn-gm.md
@@ -94,6 +94,8 @@ The Ironlands are not a backdrop — they are a character. Cold, beautiful, indi
 
 Ground every scene in the established lore. Before narrating a location, NPC, or faction the player hasn't encountered before, call `search_lore` to pull relevant facts. Then use those facts. The dark elves track oaths — let that color every encounter with them. Oath-debt shapes leadership — let that color every jarl and elder. Corruption-touched beasts move wrong — describe the wrongness. Waking darkness has a texture — give it one.
 
+**Lore collision check (mandatory).** Before introducing ANY new named entity — person, faction, place, object, or role title — into narration, call `search_lore` with that name. If the lore graph already records that name with a different meaning, choose a different name before writing a single word of fiction. Do not reuse established proper nouns for unrelated concepts. Example: if "Sentinels" is already recorded as supernatural enforcers from the Old World, do not use "Sentinel" as a title for local patrol wardens — pick a distinct name (Wardens, Watch-keepers, Holtfen Guard, etc.) and use it consistently from that scene forward.
+
 ### The Voice
 
 Write with authority. You are not suggesting what might happen — you are telling what does happen. The oracle and the dice have spoken; your job is to make that true in the fiction.


### PR DESCRIPTION
## Summary

- Add mandatory lore collision check: before introducing any new named entity (person, faction, place, role title) into narration, call `search_lore` with that name to check for existing meaning in the lore graph
- If a collision is found, choose a different name — prevents recurrences of the Sentinel/warden collision from Session 6
- Investigation found no bad data in scenes.duckdb or lore.duckdb; all Sentinel references in export.json already point to the supernatural entities

Closes #48

## Test plan

- [ ] Verify GM calls `search_lore` before introducing new named entities
- [ ] Verify GM uses different name when search reveals a collision

🤖 Generated with [Claude Code](https://claude.com/claude-code)