### PR TITLE
feat(statusline): color-code Health/Spirit/Supply by value threshold

### DIFF
--- a/plugins/ironsworn/.claude-plugin/plugin.json
+++ b/plugins/ironsworn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ironsworn",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Solo Ironsworn GM companion — fiction-first, dice-driven, with a living lore graph",
   "author": {
     "name": "Karim Naguib"

--- a/plugins/ironsworn/commands/ironsworn-init.sh
+++ b/plugins/ironsworn/commands/ironsworn-init.sh
@@ -41,7 +41,7 @@ echo "────────────────────────�
 SETTINGS_CONTENT='{
   "statusLine": {
     "type": "command",
-    "command": "input=$(cat); cwd=$(echo \"$input\" | jq -r '"'"'.workspace.project_dir'"'"'); char=\"$cwd/campaigns/default/character.json\"; if [ ! -f \"$char\" ]; then exit 0; fi; name=$(jq -r '"'"'.name // \"Hero\"'"'"' \"$char\"); hp=$(jq -r '"'"'.health'"'"' \"$char\"); sp=$(jq -r '"'"'.spirit'"'"' \"$char\"); su=$(jq -r '"'"'.supply'"'"' \"$char\"); mo=$(jq -r '"'"'.momentum'"'"' \"$char\"); echo \"$name | HP:$hp Sp:$sp Su:$su Mo:$mo\""
+    "command": "input=$(cat); cwd=$(echo \"$input\" | jq -r '"'"'.workspace.project_dir'"'"'); char=\"$cwd/campaigns/default/character.json\"; if [ ! -f \"$char\" ]; then exit 0; fi; name=$(jq -r '"'"'.name // \"Hero\"'"'"' \"$char\"); hp=$(jq -r '"'"'.health'"'"' \"$char\"); sp=$(jq -r '"'"'.spirit'"'"' \"$char\"); su=$(jq -r '"'"'.supply'"'"' \"$char\"); mo=$(jq -r '"'"'.momentum'"'"' \"$char\"); colorval(){ v=$1; if [ \"$v\" -le 1 ] 2>/dev/null; then printf '"'"'\\033[31m%s\\033[0m'"'"' \"$v\"; elif [ \"$v\" -le 3 ] 2>/dev/null; then printf '"'"'\\033[33m%s\\033[0m'"'"' \"$v\"; else printf '"'"'\\033[32m%s\\033[0m'"'"' \"$v\"; fi; }; echo \"$name | HP:$(colorval $hp) Sp:$(colorval $sp) Su:$(colorval $su) Mo:$mo\""
   },
   "agent": "ironsworn-gm",
   "permissions": {


### PR DESCRIPTION
## Summary

- Red for value ≤ 1 (critical), yellow for 2–3 (low), green for ≥ 4 (healthy)
- Applied to Health, Spirit, and Supply in the status line
- Momentum left uncolored per issue scope

## Implementation

A `colorval()` shell function inlined into the `statusLine` command in `ironsworn-init.sh`. Uses standard ANSI escape codes.

## Test plan

- [ ] Run `/ironsworn-init` to regenerate `settings.json`
- [ ] Verify Health 1 = red, Spirit 2 = yellow, Supply 5 = green during play

Closes #61

🤖 Generated with [Claude Code](https://claude.ai/claude-code)