### PR TITLE
fix(init): upsert statusLine on re-run and use orange for mid-range values

### DIFF
--- a/plugins/ironsworn/.claude-plugin/plugin.json
+++ b/plugins/ironsworn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ironsworn",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Solo Ironsworn GM companion — fiction-first, dice-driven, with a living lore graph",
   "author": {
     "name": "Karim Naguib"

--- a/plugins/ironsworn/commands/ironsworn-init.sh
+++ b/plugins/ironsworn/commands/ironsworn-init.sh
@@ -38,11 +38,13 @@ echo "────────────────────────�
 # ── Phase 1: Scaffold ─────────────────────────────────────────────────────────
 
 # .claude/settings.json
-SETTINGS_CONTENT='{
-  "statusLine": {
+# The statusLine command uses \\033 (double-escaped) so ANSI codes survive JSON embedding.
+STATUS_LINE_JSON='{
     "type": "command",
-    "command": "input=$(cat); cwd=$(echo \"$input\" | jq -r '"'"'.workspace.project_dir'"'"'); char=\"$cwd/campaigns/default/character.json\"; if [ ! -f \"$char\" ]; then exit 0; fi; name=$(jq -r '"'"'.name // \"Hero\"'"'"' \"$char\"); hp=$(jq -r '"'"'.health'"'"' \"$char\"); sp=$(jq -r '"'"'.spirit'"'"' \"$char\"); su=$(jq -r '"'"'.supply'"'"' \"$char\"); mo=$(jq -r '"'"'.momentum'"'"' \"$char\"); colorval(){ v=$1; if [ \"$v\" -le 1 ] 2>/dev/null; then printf '"'"'\\033[31m%s\\033[0m'"'"' \"$v\"; elif [ \"$v\" -le 3 ] 2>/dev/null; then printf '"'"'\\033[33m%s\\033[0m'"'"' \"$v\"; else printf '"'"'\\033[32m%s\\033[0m'"'"' \"$v\"; fi; }; echo \"$name | HP:$(colorval $hp) Sp:$(colorval $sp) Su:$(colorval $su) Mo:$mo\""
-  },
+    "command": "input=$(cat); cwd=$(echo \"$input\" | jq -r '"'"'.workspace.project_dir'"'"'); char=\"$cwd/campaigns/default/character.json\"; if [ ! -f \"$char\" ]; then exit 0; fi; name=$(jq -r '"'"'.name // \"Hero\"'"'"' \"$char\"); hp=$(jq -r '"'"'.health'"'"' \"$char\"); sp=$(jq -r '"'"'.spirit'"'"' \"$char\"); su=$(jq -r '"'"'.supply'"'"' \"$char\"); mo=$(jq -r '"'"'.momentum'"'"' \"$char\"); colorval(){ v=$1; if [ \"$v\" -le 1 ] 2>/dev/null; then printf '"'"'\\033[31m%s\\033[0m'"'"' \"$v\"; elif [ \"$v\" -le 3 ] 2>/dev/null; then printf '"'"'\\033[38;5;208m%s\\033[0m'"'"' \"$v\"; else printf '"'"'\\033[32m%s\\033[0m'"'"' \"$v\"; fi; }; echo \"$name | HP:$(colorval $hp) Sp:$(colorval $sp) Su:$(colorval $su) Mo:$mo\""
+  }'
+SETTINGS_TEMPLATE='{
+  "statusLine": '"$STATUS_LINE_JSON"',
   "agent": "ironsworn-gm",
   "permissions": {
     "allow": [
@@ -51,7 +53,17 @@ SETTINGS_CONTENT='{
     ]
   }
 }'
-safe_write "$CWD/.claude/settings.json" "$SETTINGS_CONTENT"
+SETTINGS_PATH="$CWD/.claude/settings.json"
+if [ -e "$SETTINGS_PATH" ]; then
+  # File already exists — upsert only the statusLine key, preserving all other keys.
+  mkdir -p "$(dirname "$SETTINGS_PATH")"
+  jq --argjson newval "$STATUS_LINE_JSON" '.statusLine = $newval' "$SETTINGS_PATH" > "$SETTINGS_PATH.tmp" && mv "$SETTINGS_PATH.tmp" "$SETTINGS_PATH"
+  created+=("$SETTINGS_PATH (statusLine upserted)")
+else
+  mkdir -p "$(dirname "$SETTINGS_PATH")"
+  printf '%s' "$SETTINGS_TEMPLATE" > "$SETTINGS_PATH"
+  created+=("$SETTINGS_PATH")
+fi
 
 # CLAUDE.md
 CLAUDE_MD_CONTENT='# Ironsworn Campaign


### PR DESCRIPTION
## Summary

- **Fix #64 — statusLine upsert on re-run**: `ironsworn-init.sh` previously used `safe_write` for `.claude/settings.json`, which silently skipped the file if it already existed. The script now does a targeted `jq` upsert of only the `statusLine` key, preserving all other existing keys in the file.
- **Fix #65 — orange instead of yellow for mid-range values**: The `colorval` helper used ANSI yellow (`\\033[33m`) for track values 2-3. In Claude Code's dimmed status bar, yellow is nearly indistinguishable from white. Replaced with 256-color orange (`\\033[38;5;208m`).
- **Escape safety**: ANSI escape sequences are embedded as `\\\\033` (double-escaped) so they survive JSON parsing.

Closes #64
Closes #65

## Test plan

- [ ] Run `ironsworn-init` in a fresh directory — `settings.json` is created with `statusLine`, `agent`, and `permissions` keys.
- [ ] Run `ironsworn-init` again in the same directory — `settings.json` is updated (only `statusLine` is refreshed); `agent` and `permissions` are preserved.
- [ ] Run `ironsworn-init` in a directory where `settings.json` has extra keys (e.g. `hooks`) — those keys survive the upsert.
- [ ] Verify status bar shows orange (not yellow) for a character with HP/Spirit/Supply of 2 or 3.

Generated with Claude Code