### PR TITLE
feat(scribe): scene beats for multi-resolution narrative storage (closes #46)

### DIFF
--- a/plugins/ironsworn/agents/ironsworn-gm.md
+++ b/plugins/ironsworn/agents/ironsworn-gm.md
@@ -64,6 +64,15 @@ Follow these steps on every player turn:
 
 6. **Record narrative state** — At natural scene boundaries, call `record_scene` with a 1-2 sentence summary. When an NPC has a significant moment, call `upsert_npc`. When vows are made or fulfilled, call `open_thread` / `close_thread`. When a companion asset is first used or narrated in a session, call `lookup_asset` on it — if the asset type is "companion", immediately call `upsert_companion` with the companion's name and the max health from `lookup_asset` before calling any companion mutation tool. This seeds the companion into the character sheet so health tracking works correctly. Only do this once per companion per campaign (if the companion already appears in `get_character_full` companions list with health > 0, skip the upsert).
 
+   **Scene beats (optional but encouraged for significant scenes):** When a scene contains meaningful dialogue, NPC reveals, or move resolutions worth preserving verbatim, include a `beats` array in the same `record_scene` call. Each beat is one logical unit of fiction:
+   - `narration` — a descriptive paragraph or atmospheric detail
+   - `dialogue` — a single line of NPC speech (set `speaker` to the NPC name)
+   - `move` — a move resolution and its narration (set `metadata` to `{move, stat, outcome}`)
+   - `choice` — a meaningful player decision point
+   - `oracle` — an oracle result and its interpretation
+
+   Beats are stored separately from the summary and are **not** part of the default GM context. They are available on demand via `get_scene` (with `include_beats: true`) or `search_beats`. Use them for scenes where the verbatim texture matters — key NPC conversations, revelations, oath moments. Routine travel or mechanical scenes with no standout dialogue do not need beats.
+
 ## Player Agency & Turn Pacing
 
 You narrate the world. The player narrates their character. This boundary is absolute.

--- a/plugins/ironsworn/scribe/src/rag/scenes.test.ts
+++ b/plugins/ironsworn/scribe/src/rag/scenes.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { recordScene, searchScenes, getRecentComplications, getScene, updateScene, deleteScene } from "./scenes.js";
+import { recordScene, searchScenes, getRecentComplications, getScene, updateScene, deleteScene, recordBeats, getBeats, searchBeats, exportScenes, importScene } from "./scenes.js";
 
 let _ollamaReady: boolean | null = null;
 async function ollamaAvailable(): Promise<boolean> {
@@ -159,5 +159,221 @@ describe("deleteScene", () => {
     await recordScene(campaignDir, "A scene.");
     // deleteScene on non-existent ID should not throw
     await deleteScene(campaignDir, "non-existent-id");
+  });
+});
+
+describe("scene beats — round-trip", () => {
+  it("records beats alongside a scene and retrieves them", async () => {
+    if (!(await ollamaAvailable())) return;
+    const id = await recordScene(campaignDir, "Lona reveals ward-stone secrets.", "social", undefined, [
+      { kind: "narration", text: "The fire crackles between you and Lona." },
+      { kind: "dialogue", speaker: "Lona", text: "The ward-stones have held for three generations." },
+      { kind: "move", text: "You face danger to keep her trust.", metadata: { move: "Face Danger", stat: "heart", outcome: "weak_hit" } },
+    ]);
+
+    const beats = await getBeats(campaignDir, id);
+    expect(beats).toHaveLength(3);
+    expect(beats[0]!.kind).toBe("narration");
+    expect(beats[0]!.beat_index).toBe(0);
+    expect(beats[1]!.kind).toBe("dialogue");
+    expect(beats[1]!.speaker).toBe("Lona");
+    expect(beats[2]!.kind).toBe("move");
+    expect(beats[2]!.metadata).toEqual({ move: "Face Danger", stat: "heart", outcome: "weak_hit" });
+  });
+
+  it("recordScene without beats remains backward-compatible", async () => {
+    if (!(await ollamaAvailable())) return;
+    const id = await recordScene(campaignDir, "A quiet arrival at the village gates.", "exploration");
+    expect(typeof id).toBe("string");
+    expect(id.length).toBeGreaterThan(0);
+
+    const beats = await getBeats(campaignDir, id);
+    expect(beats).toHaveLength(0);
+
+    const scene = await getScene(campaignDir, id);
+    expect(scene).not.toBeNull();
+    expect(scene!.text).toContain("village gates");
+    // beats not requested — should be absent
+    expect(scene!.beats).toBeUndefined();
+  });
+
+  it("getScene with include_beats returns beats", async () => {
+    if (!(await ollamaAvailable())) return;
+    const id = await recordScene(campaignDir, "A tense negotiation.", "social", undefined, [
+      { kind: "dialogue", speaker: "Jarl", text: "You dare bring this oath to me?" },
+    ]);
+
+    const scene = await getScene(campaignDir, id, { include_beats: true });
+    expect(scene).not.toBeNull();
+    expect(scene!.beats).toHaveLength(1);
+    expect(scene!.beats![0]!.speaker).toBe("Jarl");
+  });
+
+  it("recordBeats appends to existing scene beats with sequential indices", async () => {
+    if (!(await ollamaAvailable())) return;
+    const id = await recordScene(campaignDir, "A two-part scene.", "social", undefined, [
+      { kind: "narration", text: "The hall falls silent." },
+    ]);
+
+    await recordBeats(campaignDir, id, [
+      { kind: "dialogue", speaker: "Elder", text: "Speak your vow." },
+    ]);
+
+    const beats = await getBeats(campaignDir, id);
+    expect(beats).toHaveLength(2);
+    expect(beats[0]!.beat_index).toBe(0);
+    expect(beats[1]!.beat_index).toBe(1);
+    expect(beats[1]!.kind).toBe("dialogue");
+  });
+
+  it("deleteScene also removes its beats", async () => {
+    if (!(await ollamaAvailable())) return;
+    const id = await recordScene(campaignDir, "Scene with beats.", "combat", undefined, [
+      { kind: "move", text: "You strike with iron resolve.", metadata: { move: "Strike", stat: "iron", outcome: "strong_hit" } },
+    ]);
+
+    await deleteScene(campaignDir, id);
+
+    const beats = await getBeats(campaignDir, id);
+    expect(beats).toHaveLength(0);
+  });
+});
+
+describe("searchBeats", () => {
+  it("finds the most relevant beat by semantic similarity", async () => {
+    if (!(await ollamaAvailable())) return;
+    const id = await recordScene(campaignDir, "A forest encounter.", "exploration", undefined, [
+      { kind: "narration", text: "Ravens circle overhead in the grey morning sky." },
+      { kind: "dialogue", speaker: "Stranger", text: "The iron bridge collapsed last winter." },
+      { kind: "move", text: "You track the beast through deep snow.", metadata: { move: "Face Danger", stat: "wits", outcome: "strong_hit" } },
+    ]);
+
+    expect(id).toBeTruthy();
+
+    const results = await searchBeats(campaignDir, "birds in the sky", 3);
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0]!.text).toContain("Ravens");
+  });
+
+  it("filters by kind", async () => {
+    if (!(await ollamaAvailable())) return;
+    await recordScene(campaignDir, "A mixed scene.", "social", undefined, [
+      { kind: "narration", text: "The longhouse smells of pine smoke." },
+      { kind: "dialogue", speaker: "NPC", text: "Welcome to Thornhaven." },
+    ]);
+
+    const dialogueOnly = await searchBeats(campaignDir, "greeting welcome", 5, { kind: "dialogue" });
+    expect(dialogueOnly.every((b) => b.kind === "dialogue")).toBe(true);
+  });
+
+  it("filters by scene_id", async () => {
+    if (!(await ollamaAvailable())) return;
+    const id1 = await recordScene(campaignDir, "Scene one.", "combat", undefined, [
+      { kind: "narration", text: "Blood on the snow." },
+    ]);
+    await recordScene(campaignDir, "Scene two.", "exploration", undefined, [
+      { kind: "narration", text: "A quiet morning." },
+    ]);
+
+    const results = await searchBeats(campaignDir, "snow blood", 5, { scene_id: id1 });
+    expect(results.every((b) => b.scene_id === id1)).toBe(true);
+  });
+
+  it("returns empty array when no beats recorded", async () => {
+    if (!(await ollamaAvailable())) return;
+    await recordScene(campaignDir, "A summary-only scene.");
+    const results = await searchBeats(campaignDir, "anything", 5);
+    expect(results).toEqual([]);
+  });
+});
+
+describe("export/import with beats", () => {
+  it("round-trips a scene with beats through export/import", async () => {
+    if (!(await ollamaAvailable())) return;
+    const id = await recordScene(campaignDir, "The ward-stone scene.", "social", undefined, [
+      { kind: "narration", text: "Frost gathers on the ancient stone." },
+      { kind: "dialogue", speaker: "Lona", text: "Do not touch it." },
+    ]);
+
+    const exported = await exportScenes(campaignDir);
+    const exportedScene = exported.find((s) => s.id === id);
+    expect(exportedScene).toBeDefined();
+    expect(exportedScene!.beats).toHaveLength(2);
+    expect(exportedScene!.beats![0]!.kind).toBe("narration");
+    expect(exportedScene!.beats![1]!.speaker).toBe("Lona");
+
+    // Import into a fresh campaign dir
+    const dir2 = await mkdtemp(join(tmpdir(), "scribe-import-test-"));
+    try {
+      const inserted = await importScene(
+        dir2,
+        exportedScene!.id,
+        exportedScene!.text,
+        exportedScene!.timestamp,
+        exportedScene!.kind,
+        exportedScene!.complication_theme,
+        exportedScene!.beats,
+      );
+      expect(inserted).toBe(true);
+
+      const reimported = await getScene(dir2, id, { include_beats: true });
+      expect(reimported).not.toBeNull();
+      expect(reimported!.beats).toHaveLength(2);
+      expect(reimported!.beats![0]!.text).toBe("Frost gathers on the ancient stone.");
+      expect(reimported!.beats![1]!.speaker).toBe("Lona");
+    } finally {
+      await rm(dir2, { recursive: true });
+    }
+  });
+
+  it("export/import without beats preserves backward compat", async () => {
+    if (!(await ollamaAvailable())) return;
+    const id = await recordScene(campaignDir, "A summary-only scene.", "exploration");
+
+    const exported = await exportScenes(campaignDir);
+    const exportedScene = exported.find((s) => s.id === id);
+    expect(exportedScene).toBeDefined();
+    expect(exportedScene!.beats).toBeUndefined();
+
+    const dir2 = await mkdtemp(join(tmpdir(), "scribe-import-nobeats-test-"));
+    try {
+      const inserted = await importScene(
+        dir2,
+        exportedScene!.id,
+        exportedScene!.text,
+        exportedScene!.timestamp,
+        exportedScene!.kind,
+      );
+      expect(inserted).toBe(true);
+
+      const reimported = await getScene(dir2, id, { include_beats: true });
+      expect(reimported).not.toBeNull();
+      expect(reimported!.beats).toHaveLength(0);
+    } finally {
+      await rm(dir2, { recursive: true });
+    }
+  });
+
+  it("re-importing same scene returns false (idempotent)", async () => {
+    if (!(await ollamaAvailable())) return;
+    const id = await recordScene(campaignDir, "Idempotent test scene.", "social", undefined, [
+      { kind: "narration", text: "Once recorded." },
+    ]);
+
+    const exported = await exportScenes(campaignDir);
+    const exportedScene = exported.find((s) => s.id === id)!;
+
+    // First import to a fresh dir succeeds
+    const dir2 = await mkdtemp(join(tmpdir(), "scribe-idempotent-test-"));
+    try {
+      const first = await importScene(dir2, exportedScene.id, exportedScene.text, exportedScene.timestamp, exportedScene.kind, undefined, exportedScene.beats);
+      expect(first).toBe(true);
+
+      // Second import of same scene returns false
+      const second = await importScene(dir2, exportedScene.id, exportedScene.text, exportedScene.timestamp, exportedScene.kind, undefined, exportedScene.beats);
+      expect(second).toBe(false);
+    } finally {
+      await rm(dir2, { recursive: true });
+    }
   });
 });

--- a/plugins/ironsworn/scribe/src/rag/scenes.ts
+++ b/plugins/ironsworn/scribe/src/rag/scenes.ts
@@ -1,4 +1,4 @@
-import { DuckDBInstance, DuckDBValue } from "@duckdb/node-api";
+import { DuckDBInstance, type DuckDBValue } from "@duckdb/node-api";
 import { mkdir } from "node:fs/promises";
 
 // ---------------------------------------------------------------------------
@@ -452,7 +452,7 @@ export async function searchBeats(
   const embeddingLiteral = `[${embedding.join(",")}]::FLOAT[768]`;
 
   const conditions: string[] = [];
-  const params: unknown[] = [];
+  const params: DuckDBValue[] = [];
 
   if (opts?.kind) {
     conditions.push(`kind = ?`);

--- a/plugins/ironsworn/scribe/src/rag/scenes.ts
+++ b/plugins/ironsworn/scribe/src/rag/scenes.ts
@@ -18,7 +18,40 @@ export interface Scene {
   timestamp: string;
   kind: string;
   complication_theme?: string;
+  beats?: Beat[];
   score?: number;
+}
+
+export type BeatKind = "narration" | "dialogue" | "move" | "choice" | "oracle";
+
+export interface BeatInput {
+  kind: BeatKind;
+  speaker?: string;
+  text: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface Beat {
+  id: string;
+  scene_id: string;
+  beat_index: number;
+  kind: BeatKind;
+  speaker?: string;
+  text: string;
+  metadata: Record<string, unknown>;
+  created_at: string;
+  score?: number;
+}
+
+export interface BeatExport {
+  id: string;
+  scene_id: string;
+  beat_index: number;
+  kind: string;
+  speaker?: string;
+  text: string;
+  metadata: Record<string, unknown>;
+  created_at: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -63,10 +96,36 @@ async function initDb(campaignPath: string): Promise<DuckDBInstance> {
       ALTER TABLE scenes ADD COLUMN IF NOT EXISTS complication_theme TEXT
     `);
 
+    await conn.run(`
+      CREATE TABLE IF NOT EXISTS scene_beats (
+        id          TEXT PRIMARY KEY,
+        scene_id    TEXT NOT NULL,
+        beat_index  INTEGER NOT NULL,
+        kind        TEXT NOT NULL,
+        speaker     TEXT,
+        text        TEXT NOT NULL,
+        embedding   FLOAT[768] NOT NULL,
+        metadata    TEXT NOT NULL DEFAULT '{}',
+        created_at  TEXT NOT NULL,
+        UNIQUE (scene_id, beat_index)
+      )
+    `);
+
+    await conn.run(`
+      CREATE INDEX IF NOT EXISTS scene_beats_scene_idx
+      ON scene_beats (scene_id, beat_index)
+    `);
+
     if (vssLoaded) {
       await conn.run(`
         CREATE INDEX IF NOT EXISTS scenes_embedding_idx
         ON scenes USING HNSW (embedding)
+        WITH (metric = 'cosine')
+      `);
+
+      await conn.run(`
+        CREATE INDEX IF NOT EXISTS scene_beats_embedding_idx
+        ON scene_beats USING HNSW (embedding)
         WITH (metric = 'cosine')
       `);
     }
@@ -146,7 +205,33 @@ async function getEmbedding(text: string): Promise<number[]> {
 }
 
 // ---------------------------------------------------------------------------
-// Public API
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function rowToBeat(row: Record<string, unknown>): Beat {
+  let metadata: Record<string, unknown> = {};
+  try {
+    metadata = JSON.parse(String(row["metadata"] ?? "{}")) as Record<string, unknown>;
+  } catch {
+    // ignore parse errors; leave metadata empty
+  }
+  return {
+    id: String(row["id"]),
+    scene_id: String(row["scene_id"]),
+    beat_index: Number(row["beat_index"]),
+    kind: String(row["kind"]) as BeatKind,
+    speaker: row["speaker"] != null ? String(row["speaker"]) : undefined,
+    text: String(row["text"]),
+    metadata,
+    created_at: String(row["created_at"]),
+    score: row["score"] != null
+      ? typeof row["score"] === "number" ? row["score"] : Number(row["score"])
+      : undefined,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Public API — scenes
 // ---------------------------------------------------------------------------
 
 export async function recordScene(
@@ -154,7 +239,8 @@ export async function recordScene(
   summary: string,
   kind?: string,
   complicationTheme?: string,
-): Promise<void> {
+  beats?: BeatInput[],
+): Promise<string> {
   const [embedding, instance] = await Promise.all([
     getEmbedding(summary),
     getDb(campaignPath),
@@ -176,14 +262,22 @@ export async function recordScene(
   } finally {
     conn.closeSync();
   }
+
+  if (beats && beats.length > 0) {
+    await recordBeats(campaignPath, id, beats);
+  }
+
+  return id;
 }
 
 export async function getScene(
   campaignPath: string,
   id: string,
+  opts?: { include_beats?: boolean },
 ): Promise<Scene | null> {
   const instance = await getDb(campaignPath);
   const conn = await instance.connect();
+  let scene: Scene | null = null;
   try {
     const rows = (
       await conn.runAndReadAll(
@@ -193,7 +287,7 @@ export async function getScene(
     ).getRowObjectsJS() as Record<string, unknown>[];
     if (rows.length === 0) return null;
     const row = rows[0]!;
-    return {
+    scene = {
       id: String(row["id"]),
       text: String(row["text"]),
       timestamp: String(row["timestamp"]),
@@ -203,6 +297,12 @@ export async function getScene(
   } finally {
     conn.closeSync();
   }
+
+  if (opts?.include_beats && scene) {
+    scene.beats = await getBeats(campaignPath, id);
+  }
+
+  return scene;
 }
 
 export async function updateScene(
@@ -255,11 +355,138 @@ export async function deleteScene(
   const instance = await getDb(campaignPath);
   const conn = await openWriteConn(instance);
   try {
+    await conn.run(`DELETE FROM scene_beats WHERE scene_id = ?`, [id]);
     await conn.run(`DELETE FROM scenes WHERE id = ?`, [id]);
   } finally {
     conn.closeSync();
   }
 }
+
+// ---------------------------------------------------------------------------
+// Public API — beats
+// ---------------------------------------------------------------------------
+
+export async function recordBeats(
+  campaignPath: string,
+  sceneId: string,
+  beats: BeatInput[],
+): Promise<void> {
+  if (beats.length === 0) return;
+
+  const [embeddings, instance] = await Promise.all([
+    Promise.all(beats.map((b) => getEmbedding(b.text))),
+    getDb(campaignPath),
+  ]);
+
+  // Determine start index from current max beat_index for this scene
+  const checkConn = await instance.connect();
+  let startIndex = 0;
+  try {
+    const rows = (
+      await checkConn.runAndReadAll(
+        `SELECT COALESCE(MAX(beat_index) + 1, 0) AS next_index FROM scene_beats WHERE scene_id = ?`,
+        [sceneId],
+      )
+    ).getRowObjectsJS() as Record<string, unknown>[];
+    startIndex = Number(rows[0]?.["next_index"] ?? 0);
+  } finally {
+    checkConn.closeSync();
+  }
+
+  const conn = await openWriteConn(instance);
+  try {
+    for (let i = 0; i < beats.length; i++) {
+      const beat = beats[i]!;
+      const embedding = embeddings[i]!;
+      const embeddingLiteral = `[${embedding.join(",")}]::FLOAT[768]`;
+      const beatId = crypto.randomUUID();
+      const created_at = new Date().toISOString();
+      const metadata = JSON.stringify(beat.metadata ?? {});
+
+      await conn.run(
+        `INSERT INTO scene_beats (id, scene_id, beat_index, kind, speaker, text, embedding, metadata, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ${embeddingLiteral}, ?, ?)`,
+        [beatId, sceneId, startIndex + i, beat.kind, beat.speaker ?? null, beat.text, metadata, created_at],
+      );
+    }
+  } finally {
+    conn.closeSync();
+  }
+}
+
+export async function getBeats(
+  campaignPath: string,
+  sceneId: string,
+): Promise<Beat[]> {
+  const instance = await getDb(campaignPath);
+  const conn = await instance.connect();
+  try {
+    const rows = (
+      await conn.runAndReadAll(
+        `SELECT id, scene_id, beat_index, kind, speaker, text, metadata, created_at
+         FROM scene_beats
+         WHERE scene_id = ?
+         ORDER BY beat_index`,
+        [sceneId],
+      )
+    ).getRowObjectsJS() as Record<string, unknown>[];
+    return rows.map(rowToBeat);
+  } finally {
+    conn.closeSync();
+  }
+}
+
+export async function searchBeats(
+  campaignPath: string,
+  query: string,
+  k?: number,
+  opts?: { kind?: string; scene_id?: string },
+): Promise<Beat[]> {
+  const limit = k ?? 5;
+
+  const [embedding, instance] = await Promise.all([
+    getEmbedding(query),
+    getDb(campaignPath),
+  ]);
+
+  const embeddingLiteral = `[${embedding.join(",")}]::FLOAT[768]`;
+
+  const conditions: string[] = [];
+  const params: unknown[] = [];
+
+  if (opts?.kind) {
+    conditions.push(`kind = ?`);
+    params.push(opts.kind);
+  }
+  if (opts?.scene_id) {
+    conditions.push(`scene_id = ?`);
+    params.push(opts.scene_id);
+  }
+  params.push(limit);
+
+  const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+
+  const conn = await instance.connect();
+  try {
+    const result = await conn.runAndReadAll(
+      `SELECT id, scene_id, beat_index, kind, speaker, text, metadata, created_at,
+              array_cosine_similarity(embedding, ${embeddingLiteral}) AS score
+       FROM scene_beats
+       ${whereClause}
+       ORDER BY score DESC
+       LIMIT ?`,
+      params,
+    );
+    const rows = result.getRowObjectsJS() as Record<string, unknown>[];
+    return rows.map(rowToBeat);
+  } finally {
+    conn.closeSync();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Export / Import
+// ---------------------------------------------------------------------------
 
 export interface SceneExport {
   id: string;
@@ -267,24 +494,63 @@ export interface SceneExport {
   timestamp: string;
   kind: string;
   complication_theme?: string;
+  beats?: BeatExport[];
 }
 
 export async function exportScenes(campaignPath: string): Promise<SceneExport[]> {
   const instance = await getDb(campaignPath);
   const conn = await instance.connect();
   try {
-    const rows = (
+    const sceneRows = (
       await conn.runAndReadAll(
         `SELECT id, text, timestamp, kind, complication_theme FROM scenes ORDER BY timestamp`,
       )
     ).getRowObjectsJS() as Record<string, unknown>[];
-    return rows.map((r) => ({
-      id: String(r["id"]),
-      text: String(r["text"]),
-      timestamp: String(r["timestamp"]),
-      kind: String(r["kind"]),
-      complication_theme: r["complication_theme"] != null ? String(r["complication_theme"]) : undefined,
-    }));
+
+    const beatRows = (
+      await conn.runAndReadAll(
+        `SELECT id, scene_id, beat_index, kind, speaker, text, metadata, created_at
+         FROM scene_beats
+         ORDER BY scene_id, beat_index`,
+      )
+    ).getRowObjectsJS() as Record<string, unknown>[];
+
+    // Group beats by scene_id
+    const beatsByScene = new Map<string, BeatExport[]>();
+    for (const row of beatRows) {
+      const sceneId = String(row["scene_id"]);
+      if (!beatsByScene.has(sceneId)) beatsByScene.set(sceneId, []);
+      let metadata: Record<string, unknown> = {};
+      try {
+        metadata = JSON.parse(String(row["metadata"] ?? "{}")) as Record<string, unknown>;
+      } catch {
+        // ignore
+      }
+      beatsByScene.get(sceneId)!.push({
+        id: String(row["id"]),
+        scene_id: sceneId,
+        beat_index: Number(row["beat_index"]),
+        kind: String(row["kind"]),
+        speaker: row["speaker"] != null ? String(row["speaker"]) : undefined,
+        text: String(row["text"]),
+        metadata,
+        created_at: String(row["created_at"]),
+      });
+    }
+
+    return sceneRows.map((r) => {
+      const id = String(r["id"]);
+      const beats = beatsByScene.get(id);
+      const entry: SceneExport = {
+        id,
+        text: String(r["text"]),
+        timestamp: String(r["timestamp"]),
+        kind: String(r["kind"]),
+        complication_theme: r["complication_theme"] != null ? String(r["complication_theme"]) : undefined,
+      };
+      if (beats && beats.length > 0) entry.beats = beats;
+      return entry;
+    });
   } finally {
     conn.closeSync();
   }
@@ -297,6 +563,7 @@ export async function importScene(
   timestamp: string,
   kind: string,
   complicationTheme?: string,
+  beats?: BeatExport[],
 ): Promise<boolean> {
   const instance = await getDb(campaignPath);
 
@@ -312,8 +579,13 @@ export async function importScene(
   }
   if (exists) return false;
 
-  const [embedding] = await Promise.all([getEmbedding(text)]);
-  const embeddingLiteral = `[${embedding.join(",")}]::FLOAT[768]`;
+  // Fetch scene + all beat embeddings in parallel
+  const allTexts = [text, ...(beats ?? []).map((b) => b.text)];
+  const allEmbeddings = await Promise.all(allTexts.map(getEmbedding));
+  const sceneEmbedding = allEmbeddings[0]!;
+  const beatEmbeddings = allEmbeddings.slice(1);
+
+  const embeddingLiteral = `[${sceneEmbedding.join(",")}]::FLOAT[768]`;
 
   const conn = await openWriteConn(instance);
   try {
@@ -321,6 +593,20 @@ export async function importScene(
       `INSERT INTO scenes (id, text, embedding, timestamp, kind, complication_theme) VALUES (?, ?, ${embeddingLiteral}, ?, ?, ?)`,
       [id, text, timestamp, kind, complicationTheme ?? null],
     );
+
+    if (beats && beats.length > 0) {
+      for (let i = 0; i < beats.length; i++) {
+        const beat = beats[i]!;
+        const beatEmbedding = beatEmbeddings[i]!;
+        const beatEmbeddingLiteral = `[${beatEmbedding.join(",")}]::FLOAT[768]`;
+        await conn.run(
+          `INSERT INTO scene_beats (id, scene_id, beat_index, kind, speaker, text, embedding, metadata, created_at)
+           VALUES (?, ?, ?, ?, ?, ?, ${beatEmbeddingLiteral}, ?, ?)`,
+          [beat.id, beat.scene_id, beat.beat_index, beat.kind, beat.speaker ?? null, beat.text, JSON.stringify(beat.metadata ?? {}), beat.created_at],
+        );
+      }
+    }
+
     return true;
   } finally {
     conn.closeSync();

--- a/plugins/ironsworn/scribe/src/tools/campaign.ts
+++ b/plugins/ironsworn/scribe/src/tools/campaign.ts
@@ -6,7 +6,7 @@ import { loadCharacter, saveCharacter } from "../state/character.js";
 import { loadThreads, saveThreads } from "../state/threads.js";
 import { listNpcs, writeNpcRaw } from "../state/npcs.js";
 import { exportLore, upsertLore, linkLore, checkpointLore, type LoreType } from "../rag/lore.js";
-import { exportScenes, importScene, checkpointScenes } from "../rag/scenes.js";
+import { exportScenes, importScene, checkpointScenes, type BeatExport } from "../rag/scenes.js";
 
 interface CampaignExport {
   version: 1;
@@ -184,6 +184,8 @@ export function register(server: McpServer, campaignPath: string): void {
               String(s["text"]),
               String(s["timestamp"]),
               String(s["kind"] ?? "scene"),
+              s["complication_theme"] != null ? String(s["complication_theme"]) : undefined,
+              Array.isArray(s["beats"]) ? (s["beats"] as BeatExport[]) : undefined,
             );
             if (inserted) counts.scenes++;
           }

--- a/plugins/ironsworn/scribe/src/tools/narrative.ts
+++ b/plugins/ironsworn/scribe/src/tools/narrative.ts
@@ -13,7 +13,7 @@ const BeatInputSchema = z.object({
   ),
   speaker: z.string().optional().describe("Speaker name for dialogue beats"),
   text: z.string().describe("Full text of the beat"),
-  metadata: z.record(z.unknown()).optional().describe(
+  metadata: z.record(z.string(), z.unknown()).optional().describe(
     "Structured data for move beats (e.g. {move: 'Face Danger', stat: 'edge', outcome: 'weak_hit'})"
   ),
 });

--- a/plugins/ironsworn/scribe/src/tools/narrative.ts
+++ b/plugins/ironsworn/scribe/src/tools/narrative.ts
@@ -1,11 +1,22 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { recordScene, getScene, updateScene, deleteScene } from "../rag/scenes.js";
+import { recordScene, getScene, updateScene, deleteScene, type BeatInput } from "../rag/scenes.js";
 import { openThread, closeThread } from "../state/threads.js";
 import { upsertNpc, getNpc } from "../state/npcs.js";
 import { getLore } from "../rag/lore.js";
 import { loadCharacter, saveCharacter, ProgressTrack } from "../state/character.js";
 import { recordMutation } from "../checkpoint.js";
+
+const BeatInputSchema = z.object({
+  kind: z.enum(["narration", "dialogue", "move", "choice", "oracle"]).describe(
+    "Type of beat: narration (descriptive prose), dialogue (NPC/player speech), move (mechanical resolution), choice (player decision point), oracle (oracle roll + interpretation)"
+  ),
+  speaker: z.string().optional().describe("Speaker name for dialogue beats"),
+  text: z.string().describe("Full text of the beat"),
+  metadata: z.record(z.unknown()).optional().describe(
+    "Structured data for move beats (e.g. {move: 'Face Danger', stat: 'edge', outcome: 'weak_hit'})"
+  ),
+});
 
 // ---------------------------------------------------------------------------
 // Warning helpers (exported for testing)
@@ -49,7 +60,7 @@ export async function buildSceneWarnings(
 export function register(server: McpServer, campaignPath: string): void {
   server.tool(
     "record_scene",
-    "Record a scene summary into the scene journal",
+    "Record a scene summary into the scene journal. Optionally include beats — ordered narrative units capturing the full texture of the scene.",
     {
       summary: z.string().describe("Scene summary text to record"),
       kind: z.string().optional().describe("Kind of scene (e.g. 'combat', 'exploration', 'social')"),
@@ -58,14 +69,17 @@ export function register(server: McpServer, campaignPath: string): void {
       complication_theme: z.string().optional().describe(
         "Freeform thematic category of the complication (e.g. 'weather', 'beasts', 'fungal-network', 'physical-hazard'). Set only when the scene involves a miss/complication."
       ),
+      beats: z.array(BeatInputSchema).optional().describe(
+        "Optional ordered narrative beats for the scene. When omitted, only the summary is stored (backward-compatible)."
+      ),
     },
-    async ({ summary, kind, npcs, lore_ids, complication_theme }) => {
+    async ({ summary, kind, npcs, lore_ids, complication_theme, beats }) => {
       try {
-        await recordScene(campaignPath, summary, kind, complication_theme);
+        const id = await recordScene(campaignPath, summary, kind, complication_theme, beats as BeatInput[] | undefined);
         recordMutation(campaignPath);
         const warnings = await buildSceneWarnings(campaignPath, npcs, lore_ids);
         return {
-          content: [{ type: "text", text: JSON.stringify({ ok: true, warnings }) }],
+          content: [{ type: "text", text: JSON.stringify({ ok: true, id, warnings }) }],
         };
       } catch (e) {
         return {

--- a/plugins/ironsworn/scribe/src/tools/read.ts
+++ b/plugins/ironsworn/scribe/src/tools/read.ts
@@ -4,7 +4,7 @@ import { loadCharacter } from "../state/character.js";
 import { listThreads } from "../state/threads.js";
 import { getNpc } from "../state/npcs.js";
 import { searchRules, lookupMove } from "../rag/query.js";
-import { searchScenes, getRecentComplications } from "../rag/scenes.js";
+import { searchScenes, getRecentComplications, getScene, searchBeats } from "../rag/scenes.js";
 import { lookupAsset } from "../rules/ironsworn/assets.js";
 
 function characterDigest(char: Awaited<ReturnType<typeof loadCharacter>>) {
@@ -206,6 +206,58 @@ export function register(server: McpServer, campaignPath: string): void {
         }
         return {
           content: [{ type: "text", text: JSON.stringify(asset) }],
+        };
+      } catch (e) {
+        return {
+          content: [{ type: "text", text: `Error: ${e instanceof Error ? e.message : String(e)}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.tool(
+    "get_scene",
+    "Get a scene by ID, optionally including its full beat-by-beat narrative",
+    {
+      id: z.string().describe("ID of the scene to retrieve"),
+      include_beats: z.boolean().optional().describe("Include full beat-by-beat narrative (default false)"),
+    },
+    async ({ id, include_beats }) => {
+      try {
+        const scene = await getScene(campaignPath, id, { include_beats });
+        if (scene === null) {
+          return {
+            content: [{ type: "text", text: `Scene not found: ${id}` }],
+            isError: true,
+          };
+        }
+        return {
+          content: [{ type: "text", text: JSON.stringify(scene) }],
+        };
+      } catch (e) {
+        return {
+          content: [{ type: "text", text: `Error: ${e instanceof Error ? e.message : String(e)}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.tool(
+    "search_beats",
+    "Search scene beats using semantic similarity. Finds specific moments of dialogue, narration, or move resolution across all scenes.",
+    {
+      query: z.string().describe("Search query"),
+      k: z.number().int().positive().optional().describe("Number of results to return (default 5)"),
+      kind: z.string().optional().describe("Filter by beat kind: narration, dialogue, move, choice, oracle"),
+      scene_id: z.string().optional().describe("Filter to beats from a specific scene"),
+    },
+    async ({ query, k, kind, scene_id }) => {
+      try {
+        const results = await searchBeats(campaignPath, query, k, { kind, scene_id });
+        return {
+          content: [{ type: "text", text: JSON.stringify(results) }],
         };
       } catch (e) {
         return {


### PR DESCRIPTION
## Summary

- Adds `scene_beats` table with HNSW index for per-beat semantic search
- `record_scene` gains optional `beats` array — backward-compatible when omitted
- `get_scene` gains `include_beats` flag (off by default)
- New `search_beats` MCP tool for cross-scene beat-level semantic search
- Export/import round-trips beats; existing exports without beats remain importable
- GM agent prompt updated to emit beats at scene close

## Test plan

- [x] Beats round-trip: record scene with beats, retrieve via `get_scene(id, {include_beats: true})`
- [x] `search_beats` returns most semantically similar beat
- [x] Summary-only backward compatibility: `record_scene` without beats works unchanged
- [x] Export/import with and without beats
- [x] `deleteScene` cascades to beats
- [x] Sequential beat indexing via `recordBeats`
- [x] TypeScript typecheck passes (`bun run tsc --noEmit`)
- [x] All 238 tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)