### PR TITLE
fix(tick_progress): return applied delta and warn on clamp (fixes #71)

### DIFF
--- a/plugins/ironsworn/.claude-plugin/plugin.json
+++ b/plugins/ironsworn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ironsworn",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Solo Ironsworn GM companion — fiction-first, dice-driven, with a living lore graph",
   "author": {
     "name": "Karim Naguib"

--- a/plugins/ironsworn/scribe/src/tools/mutations.test.ts
+++ b/plugins/ironsworn/scribe/src/tools/mutations.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { register } from "./mutations.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+
+let campaignDir: string;
+let client: Client;
+let server: McpServer;
+
+const CHARACTER_WITH_TRACKS = {
+  name: "Kara",
+  stats: { edge: 2, heart: 3, iron: 1, shadow: 2, wits: 3 },
+  momentum: 2,
+  momentumReset: 2,
+  health: 4,
+  spirit: 3,
+  supply: 3,
+  debilities: {},
+  assets: [],
+  progressTracks: [
+    { name: "Remove Caldren from Holtfen", rank: "dangerous", kind: "vow", ticks: 0, completed: false },
+    { name: "Explore the Caverns", rank: "troublesome", kind: "journey", ticks: 20, completed: false },
+    { name: "Almost Full", rank: "formidable", kind: "vow", ticks: 36, completed: false },
+  ],
+  companions: [],
+  bonds: 0,
+  experience: 0,
+  customState: {},
+};
+
+beforeEach(async () => {
+  campaignDir = await mkdtemp(join(tmpdir(), "scribe-mutations-test-"));
+  await writeFile(join(campaignDir, "character.json"), JSON.stringify(CHARACTER_WITH_TRACKS));
+
+  server = new McpServer({ name: "test", version: "0.0.1" });
+  register(server, campaignDir);
+
+  client = new Client({ name: "test-client", version: "0.0.1" });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+});
+
+afterEach(async () => {
+  await rm(campaignDir, { recursive: true, force: true });
+});
+
+describe("tick_progress", () => {
+  it("returns applied.prior_ticks matching the track ticks before the tick", async () => {
+    const result = await client.callTool({
+      name: "tick_progress",
+      arguments: { track_name: "Remove Caldren from Holtfen", marks: 1 },
+    });
+    expect(result.isError).not.toBe(true);
+    const parsed = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+    expect(parsed.applied.prior_ticks).toBe(0);
+  });
+
+  it("returns applied.ticks_added as actual ticks added (not clamped)", async () => {
+    // dangerous rank: 1 mark = 8 ticks; starting at 0 → ticks_added = 8
+    const result = await client.callTool({
+      name: "tick_progress",
+      arguments: { track_name: "Remove Caldren from Holtfen", marks: 2 },
+    });
+    expect(result.isError).not.toBe(true);
+    const parsed = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+    expect(parsed.applied.ticks_added).toBe(16); // 2 marks * 8 ticks/mark
+    expect(parsed.applied.prior_ticks).toBe(0);
+    expect(parsed.applied.requested_marks).toBe(2);
+    expect(parsed.applied.clamped).toBe(false);
+  });
+
+  it("returns applied.clamped=false when no clamping occurs", async () => {
+    const result = await client.callTool({
+      name: "tick_progress",
+      arguments: { track_name: "Remove Caldren from Holtfen", marks: 1 },
+    });
+    expect(result.isError).not.toBe(true);
+    const parsed = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+    expect(parsed.applied.clamped).toBe(false);
+    expect(parsed.warnings).toBeUndefined();
+  });
+
+  it("returns applied.clamped=true and a warning when marks exceed max ticks", async () => {
+    // dangerous rank: 16 marks * 8 ticks = 128 ticks, clamped to 40
+    const result = await client.callTool({
+      name: "tick_progress",
+      arguments: { track_name: "Remove Caldren from Holtfen", marks: 16 },
+    });
+    expect(result.isError).not.toBe(true);
+    const parsed = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.track.ticks).toBe(40);
+    expect(parsed.applied.prior_ticks).toBe(0);
+    expect(parsed.applied.requested_marks).toBe(16);
+    expect(parsed.applied.ticks_added).toBe(40); // actual delta after clamping
+    expect(parsed.applied.clamped).toBe(true);
+    expect(parsed.warnings).toBeDefined();
+    expect(parsed.warnings).toHaveLength(1);
+    expect(parsed.warnings[0]).toContain("16");
+    expect(parsed.warnings[0]).toContain("clamped");
+  });
+
+  it("returns applied.ticks_added as actual delta when clamping occurs at partial fill", async () => {
+    // Almost Full track: formidable (4 ticks/mark), ticks=36, room=4
+    // 4 marks requested = 4*4=16 ticks, but only 4 ticks fit → ticks_added=4
+    const result = await client.callTool({
+      name: "tick_progress",
+      arguments: { track_name: "Almost Full", marks: 4 },
+    });
+    expect(result.isError).not.toBe(true);
+    const parsed = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+    expect(parsed.track.ticks).toBe(40);
+    expect(parsed.applied.prior_ticks).toBe(36);
+    expect(parsed.applied.ticks_added).toBe(4); // only 4 ticks fit
+    expect(parsed.applied.clamped).toBe(true);
+    expect(parsed.warnings).toHaveLength(1);
+  });
+
+  it("defaults to 1 mark when marks not specified", async () => {
+    // dangerous: 1 mark = 8 ticks
+    const result = await client.callTool({
+      name: "tick_progress",
+      arguments: { track_name: "Remove Caldren from Holtfen" },
+    });
+    expect(result.isError).not.toBe(true);
+    const parsed = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+    expect(parsed.applied.requested_marks).toBe(1);
+    expect(parsed.applied.ticks_added).toBe(8);
+    expect(parsed.applied.clamped).toBe(false);
+  });
+
+  it("returns error for unknown track name", async () => {
+    const result = await client.callTool({
+      name: "tick_progress",
+      arguments: { track_name: "Nonexistent Track", marks: 1 },
+    });
+    expect(result.isError).toBe(true);
+  });
+});

--- a/plugins/ironsworn/scribe/src/tools/mutations.ts
+++ b/plugins/ironsworn/scribe/src/tools/mutations.ts
@@ -23,7 +23,7 @@ import {
   Character,
 } from "../state/character.js";
 import { burnMomentum } from "../rules/ironsworn/momentum.js";
-import { tickProgress, vowXp } from "../rules/ironsworn/progress.js";
+import { tickProgress, vowXp, TICKS_PER_MARK } from "../rules/ironsworn/progress.js";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { recordMutation } from "../checkpoint.js";
@@ -255,10 +255,28 @@ export function register(server: McpServer, campaignPath: string): void {
 
   server.tool(
     "tick_progress",
-    "Tick a named progress track by the given number of marks",
+    [
+      "Tick a named progress track by the given number of marks.",
+      "",
+      "IMPORTANT — unit clarification:",
+      "  `marks` is the number of *progress marks* (boxes), NOT raw ticks.",
+      "  Each mark equals a rank-dependent number of ticks:",
+      "    troublesome=12, dangerous=8, formidable=4, extreme=2, epic=1.",
+      "  Example: marks=2 on a dangerous track adds 2*8=16 ticks.",
+      "",
+      "The response always includes an `applied` object with:",
+      "  - prior_ticks: ticks before this call",
+      "  - requested_marks: the marks value that was passed (or 1 if default)",
+      "  - ticks_added: actual ticks added after clamping",
+      "  - clamped: true if the result was clamped at the 40-tick maximum",
+      "",
+      "When clamping occurs, a `warnings` array is also returned.",
+    ].join("\n"),
     {
       track_name: z.string().describe("Name of the progress track to tick (case-insensitive)"),
-      marks: z.coerce.number().int().positive().optional().describe("Number of marks to tick (default 1)"),
+      marks: z.coerce.number().int().positive().optional().describe(
+        "Number of progress marks (boxes) to tick, not raw ticks (default 1). Each mark adds rank-dependent ticks: troublesome=12, dangerous=8, formidable=4, extreme=2, epic=1.",
+      ),
     },
     async ({ track_name, marks }) => {
       try {
@@ -272,8 +290,14 @@ export function register(server: McpServer, campaignPath: string): void {
             isError: true,
           };
         }
+        const requestedMarks = marks ?? 1;
+        const track = character.progressTracks[idx]!;
+        const priorTicks = track.ticks;
+        const ticksRequested = requestedMarks * TICKS_PER_MARK[track.rank];
         const before = structuredClone(character);
-        const updatedTrack = tickProgress(character.progressTracks[idx]!, marks ?? 1);
+        const updatedTrack = tickProgress(track, requestedMarks);
+        const ticksAdded = updatedTrack.ticks - priorTicks;
+        const clamped = ticksAdded < ticksRequested;
         character.progressTracks[idx] = updatedTrack;
         await saveCharacter(campaignPath, character);
         await appendJournal(campaignPath, {
@@ -283,8 +307,19 @@ export function register(server: McpServer, campaignPath: string): void {
           after: character,
         });
         recordMutation(campaignPath);
+        const applied = {
+          requested_marks: requestedMarks,
+          ticks_added: ticksAdded,
+          prior_ticks: priorTicks,
+          clamped,
+        };
+        const warnings: string[] = clamped
+          ? [`Requested ${requestedMarks} marks (${ticksRequested} ticks) would exceed max; clamped at 40`]
+          : [];
+        const payload: Record<string, unknown> = { ok: true, track: updatedTrack, applied };
+        if (warnings.length > 0) payload.warnings = warnings;
         return {
-          content: [{ type: "text", text: JSON.stringify({ ok: true, track: updatedTrack }) }],
+          content: [{ type: "text", text: JSON.stringify(payload) }],
         };
       } catch (e) {
         return {


### PR DESCRIPTION
## Summary

- **Root cause**: `tick_progress` applied marks, clamped ticks to the 40-tick max, but returned only `{ ok, track }` — giving the caller no information about prior state, actual delta applied, or whether clamping occurred.
- **What `marks` means**: `marks` is progress *boxes* (not raw ticks). Each mark converts to rank-dependent ticks: troublesome=12, dangerous=8, formidable=4, extreme=2, epic=1. This was already the implementation but was never documented in the tool description.
- **Fix**: The response now always includes an `applied` object: `{ prior_ticks, requested_marks, ticks_added, clamped }`. When clamping occurs, a `warnings` array is also returned matching the pattern used by `record_scene`.
- **TDD**: Wrote 7 failing tests first (covering the `marks: 16` scenario from the issue, partial-fill clamping, no-clamp case, and default-marks path), then implemented. All 245 tests pass; typecheck is clean.
- **Version bump**: `plugin.json` bumped from 0.7.0 → 0.7.1 (patch fix).

## Test plan

- [x] `bun test` — 245/245 pass
- [x] `bun run tsc --noEmit` — exit 0
- [x] New test: `marks: 16` on dangerous track at 0 ticks returns `applied.clamped=true`, `ticks_added=40`, and a warning message
- [x] New test: partial fill (room for only 4 ticks) returns correct `ticks_added` delta
- [x] New test: normal tick returns `applied.clamped=false` and no `warnings` key
- [x] New test: default marks (1) populates `applied.requested_marks=1`

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)