### PR TITLE
fix(narrative): auto-stub unregistered NPCs/lore in record_scene (closes #72)

### DIFF
--- a/plugins/ironsworn/.claude-plugin/plugin.json
+++ b/plugins/ironsworn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ironsworn",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Solo Ironsworn GM companion — fiction-first, dice-driven, with a living lore graph",
   "author": {
     "name": "Karim Naguib"

--- a/plugins/ironsworn/scribe/src/tools/narrative.test.ts
+++ b/plugins/ironsworn/scribe/src/tools/narrative.test.ts
@@ -3,8 +3,8 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { buildSceneWarnings } from "./narrative.js";
-import { upsertNpc } from "../state/npcs.js";
-import { upsertLore } from "../rag/lore.js";
+import { upsertNpc, getNpc } from "../state/npcs.js";
+import { upsertLore, getLore } from "../rag/lore.js";
 
 let _ollamaReady: boolean | null = null;
 async function ollamaAvailable(): Promise<boolean> {
@@ -35,38 +35,72 @@ afterEach(async () => {
 
 describe("buildSceneWarnings", () => {
   it("returns generic reminder when no params provided", async () => {
-    const warnings = await buildSceneWarnings(campaignDir, undefined, undefined);
-    expect(warnings).toHaveLength(1);
-    expect(warnings[0]).toContain("Reminder:");
-    expect(warnings[0]).toContain("upsert_npc");
-    expect(warnings[0]).toContain("upsert_lore");
+    const result = await buildSceneWarnings(campaignDir, undefined, undefined);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain("Reminder:");
+    expect(result.warnings[0]).toContain("upsert_npc");
+    expect(result.warnings[0]).toContain("upsert_lore");
+    expect(result.stubbed.npcs).toHaveLength(0);
+    expect(result.stubbed.lore).toHaveLength(0);
   });
 
   it("returns no warnings when all NPCs are found", async () => {
     await upsertNpc(campaignDir, "Kira", "A fierce warrior.", "Trustworthy");
-    const warnings = await buildSceneWarnings(campaignDir, ["Kira"], undefined);
-    expect(warnings).toHaveLength(0);
+    const result = await buildSceneWarnings(campaignDir, ["Kira"], undefined);
+    expect(result.warnings).toHaveLength(0);
+    expect(result.stubbed.npcs).toHaveLength(0);
   });
 
-  it("returns warning for missing NPC", async () => {
-    const warnings = await buildSceneWarnings(campaignDir, ["Unknown NPC"], undefined);
-    expect(warnings).toHaveLength(1);
-    expect(warnings[0]).toContain("Unknown NPC");
-    expect(warnings[0]).toContain("upsert_npc");
+  it("auto-stubs missing NPC and returns stubbed list instead of warning", async () => {
+    const result = await buildSceneWarnings(campaignDir, ["Saelin"], undefined);
+    expect(result.warnings).toHaveLength(0);
+    expect(result.stubbed.npcs).toEqual(["Saelin"]);
+    // Verify the stub was actually created
+    const npc = await getNpc(campaignDir, "Saelin");
+    expect(npc).not.toBeNull();
   });
 
-  it("returns warnings only for missing NPCs when some are recorded", async () => {
+  it("stubs only missing NPCs; already-registered NPCs pass through silently", async () => {
     await upsertNpc(campaignDir, "Kira", "A fierce warrior.", "Trustworthy");
-    const warnings = await buildSceneWarnings(campaignDir, ["Kira", "Ghost"], undefined);
-    expect(warnings).toHaveLength(1);
-    expect(warnings[0]).toContain("Ghost");
+    const result = await buildSceneWarnings(campaignDir, ["Kira", "Ghost"], undefined);
+    expect(result.warnings).toHaveLength(0);
+    expect(result.stubbed.npcs).toEqual(["Ghost"]);
+    // Kira's record is untouched (still has description)
+    const kira = await getNpc(campaignDir, "Kira");
+    expect(kira).toContain("A fierce warrior.");
+    // Ghost stub was created
+    const ghost = await getNpc(campaignDir, "Ghost");
+    expect(ghost).not.toBeNull();
   });
 
-  it("returns warning for missing lore entity (no Ollama needed for empty DB)", async () => {
-    const warnings = await buildSceneWarnings(campaignDir, undefined, ["lost-vale"]);
-    expect(warnings).toHaveLength(1);
-    expect(warnings[0]).toContain("lost-vale");
-    expect(warnings[0]).toContain("upsert_lore");
+  it("stubs multiple missing NPCs in one call", async () => {
+    const result = await buildSceneWarnings(campaignDir, ["Saelin", "Mara", "Thord"], undefined);
+    expect(result.warnings).toHaveLength(0);
+    expect(result.stubbed.npcs).toEqual(["Saelin", "Mara", "Thord"]);
+    for (const name of ["Saelin", "Mara", "Thord"]) {
+      const npc = await getNpc(campaignDir, name);
+      expect(npc).not.toBeNull();
+    }
+  });
+
+  it("auto-stubs missing lore entity when Ollama is available", async () => {
+    if (!(await ollamaAvailable())) return;
+    const result = await buildSceneWarnings(campaignDir, undefined, ["lost-vale"]);
+    expect(result.warnings).toHaveLength(0);
+    expect(result.stubbed.lore).toEqual(["lost-vale"]);
+    // Verify stub exists in the lore db
+    const entity = await getLore(campaignDir, "lost-vale");
+    expect(entity).not.toBeNull();
+    expect(entity!.canonical).toBe("lost-vale");
+  });
+
+  it("falls back to warning for missing lore when Ollama is unavailable", async () => {
+    if (await ollamaAvailable()) return; // skip if Ollama is running
+    const result = await buildSceneWarnings(campaignDir, undefined, ["lost-vale"]);
+    expect(result.stubbed.lore).toHaveLength(0);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain("lost-vale");
+    expect(result.warnings[0]).toContain("upsert_lore");
   });
 
   it("returns no warnings for present lore entity", async () => {
@@ -76,19 +110,32 @@ describe("buildSceneWarnings", () => {
       type: "place",
       summary: "A hidden valley shrouded in mist.",
     });
-    const warnings = await buildSceneWarnings(campaignDir, undefined, ["lost-vale"]);
-    expect(warnings).toHaveLength(0);
+    const result = await buildSceneWarnings(campaignDir, undefined, ["lost-vale"]);
+    expect(result.warnings).toHaveLength(0);
+    expect(result.stubbed.lore).toHaveLength(0);
   });
 
-  it("returns warnings for both missing NPC and missing lore", async () => {
-    const warnings = await buildSceneWarnings(campaignDir, ["Ghost"], ["unknown-place"]);
-    expect(warnings).toHaveLength(2);
-    expect(warnings.some((w) => w.includes("Ghost"))).toBe(true);
-    expect(warnings.some((w) => w.includes("unknown-place"))).toBe(true);
+  it("stubs both missing NPC and missing lore when Ollama is available", async () => {
+    if (!(await ollamaAvailable())) return;
+    const result = await buildSceneWarnings(campaignDir, ["Ghost"], ["unknown-place"]);
+    expect(result.warnings).toHaveLength(0);
+    expect(result.stubbed.npcs).toEqual(["Ghost"]);
+    expect(result.stubbed.lore).toEqual(["unknown-place"]);
   });
 
-  it("empty arrays produce no warnings (no generic reminder)", async () => {
-    const warnings = await buildSceneWarnings(campaignDir, [], []);
-    expect(warnings).toHaveLength(0);
+  it("falls back to warning for missing lore but stubs NPC when Ollama is unavailable", async () => {
+    if (await ollamaAvailable()) return; // skip if Ollama is running
+    const result = await buildSceneWarnings(campaignDir, ["Ghost"], ["unknown-place"]);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain("unknown-place");
+    expect(result.stubbed.npcs).toEqual(["Ghost"]);
+    expect(result.stubbed.lore).toHaveLength(0);
+  });
+
+  it("empty arrays produce no warnings and no stubs", async () => {
+    const result = await buildSceneWarnings(campaignDir, [], []);
+    expect(result.warnings).toHaveLength(0);
+    expect(result.stubbed.npcs).toHaveLength(0);
+    expect(result.stubbed.lore).toHaveLength(0);
   });
 });

--- a/plugins/ironsworn/scribe/src/tools/narrative.ts
+++ b/plugins/ironsworn/scribe/src/tools/narrative.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { recordScene, getScene, updateScene, deleteScene, type BeatInput } from "../rag/scenes.js";
 import { openThread, closeThread } from "../state/threads.js";
 import { upsertNpc, getNpc } from "../state/npcs.js";
-import { getLore } from "../rag/lore.js";
+import { getLore, upsertLore } from "../rag/lore.js";
 import { loadCharacter, saveCharacter, ProgressTrack } from "../state/character.js";
 import { recordMutation } from "../checkpoint.js";
 
@@ -22,25 +22,33 @@ const BeatInputSchema = z.object({
 // Warning helpers (exported for testing)
 // ---------------------------------------------------------------------------
 
+export interface SceneReferenceResult {
+  warnings: string[];
+  stubbed: { npcs: string[]; lore: string[] };
+}
+
 export async function buildSceneWarnings(
   campaignPath: string,
   npcs: string[] | undefined,
   loreIds: string[] | undefined,
-): Promise<string[]> {
+): Promise<SceneReferenceResult> {
   const warnings: string[] = [];
+  const stubbed: { npcs: string[]; lore: string[] } = { npcs: [], lore: [] };
 
   if (npcs === undefined && loreIds === undefined) {
     warnings.push(
       "Reminder: Have you recorded all NPCs and lore entities introduced in this scene? Call upsert_npc and upsert_lore if needed.",
     );
-    return warnings;
+    return { warnings, stubbed };
   }
 
   if (npcs !== undefined) {
     for (const name of npcs) {
       const found = await getNpc(campaignPath, name);
       if (found === null) {
-        warnings.push(`NPC not recorded: "${name}". Call upsert_npc to record this NPC.`);
+        // Auto-stub: create a minimal NPC record so the scene reference is linked
+        await upsertNpc(campaignPath, name);
+        stubbed.npcs.push(name);
       }
     }
   }
@@ -49,12 +57,24 @@ export async function buildSceneWarnings(
     for (const id of loreIds) {
       const found = await getLore(campaignPath, id);
       if (found === null) {
-        warnings.push(`Lore entity not recorded: "${id}". Call upsert_lore to record this entity.`);
+        // Auto-stub: attempt to create a minimal lore entry (requires Ollama for embedding)
+        try {
+          await upsertLore(campaignPath, {
+            id,
+            canonical: id,
+            type: "concept",
+            summary: id,
+          });
+          stubbed.lore.push(id);
+        } catch {
+          // Ollama unavailable or other embedding failure — fall back to warning
+          warnings.push(`Lore entity not recorded: "${id}". Call upsert_lore to record this entity.`);
+        }
       }
     }
   }
 
-  return warnings;
+  return { warnings, stubbed };
 }
 
 export function register(server: McpServer, campaignPath: string): void {
@@ -77,9 +97,9 @@ export function register(server: McpServer, campaignPath: string): void {
       try {
         const id = await recordScene(campaignPath, summary, kind, complication_theme, beats as BeatInput[] | undefined);
         recordMutation(campaignPath);
-        const warnings = await buildSceneWarnings(campaignPath, npcs, lore_ids);
+        const { warnings, stubbed } = await buildSceneWarnings(campaignPath, npcs, lore_ids);
         return {
-          content: [{ type: "text", text: JSON.stringify({ ok: true, id, warnings }) }],
+          content: [{ type: "text", text: JSON.stringify({ ok: true, id, warnings, stubbed }) }],
         };
       } catch (e) {
         return {
@@ -111,9 +131,9 @@ export function register(server: McpServer, campaignPath: string): void {
         }
         await updateScene(campaignPath, id, { summary, kind });
         recordMutation(campaignPath);
-        const warnings = await buildSceneWarnings(campaignPath, npcs, lore_ids);
+        const { warnings, stubbed } = await buildSceneWarnings(campaignPath, npcs, lore_ids);
         return {
-          content: [{ type: "text", text: JSON.stringify({ ok: true, id, warnings }) }],
+          content: [{ type: "text", text: JSON.stringify({ ok: true, id, warnings, stubbed }) }],
         };
       } catch (e) {
         return {


### PR DESCRIPTION
## Summary

- `record_scene` now auto-creates stub NPC records for any NPC name not yet registered, instead of emitting a warning per unknown NPC.
- Same for lore IDs: when Ollama is available, a minimal stub lore entity (`type: concept`, summary = the ID) is created automatically. When Ollama is unavailable, falls back to the previous warning.
- The response now includes `stubbed: { npcs: string[], lore: string[] }` alongside `warnings`, so the GM agent can see which stubs were created and enrich them later.
- `update_scene` gets the same treatment.
- Plugin version bumped 0.7.0 → 0.7.1.

## How auto-stub works

`buildSceneWarnings` was refactored from returning `string[]` to returning `{ warnings: string[], stubbed: { npcs: string[], lore: string[] } }`.

For each unknown NPC name it calls `upsertNpc(campaignPath, name)` with no description or impression. For each unknown lore ID it calls `upsertLore` with the ID as both id and canonical, type `concept`. If the Ollama embedding call fails, the lore stub falls back to a warning instead.

## Test plan

- [x] `auto-stubs missing NPC and returns stubbed list instead of warning`
- [x] `stubs only missing NPCs; already-registered NPCs pass through silently`
- [x] `stubs multiple missing NPCs in one call`
- [x] Ollama-conditional lore stub tests
- [x] All 241 existing tests pass
- [x] `bun run tsc --noEmit` clean

Generated with Claude Code