### PR TITLE
fix(tracks): add close_track tool and filter ready tracks with closed threads (closes #81)

### DIFF
--- a/plugins/ironsworn/.claude-plugin/plugin.json
+++ b/plugins/ironsworn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ironsworn",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Solo Ironsworn GM companion — fiction-first, dice-driven, with a living lore graph",
   "author": {
     "name": "Karim Naguib"

--- a/plugins/ironsworn/scribe/src/state/character.ts
+++ b/plugins/ironsworn/scribe/src/state/character.ts
@@ -346,6 +346,21 @@ export async function spendExperience(
   });
 }
 
+export async function closeTrack(
+  campaignPath: string,
+  trackName: string,
+): Promise<MutationResult> {
+  return mutate(campaignPath, "closeTrack", (char) => {
+    const track = char.progressTracks.find(
+      (t) => t.name.toLowerCase() === trackName.toLowerCase(),
+    );
+    if (!track) {
+      throw new Error(`Progress track not found: "${trackName}"`);
+    }
+    track.completed = true;
+  });
+}
+
 export async function upgradeAsset(
   campaignPath: string,
   assetName: string,

--- a/plugins/ironsworn/scribe/src/tools/mutations.test.ts
+++ b/plugins/ironsworn/scribe/src/tools/mutations.test.ts
@@ -25,6 +25,7 @@ const CHARACTER_WITH_TRACKS = {
     { name: "Remove Caldren from Holtfen", rank: "dangerous", kind: "vow", ticks: 0, completed: false },
     { name: "Explore the Caverns", rank: "troublesome", kind: "journey", ticks: 20, completed: false },
     { name: "Almost Full", rank: "formidable", kind: "vow", ticks: 36, completed: false },
+    { name: "Combat Ended", rank: "formidable", kind: "combat", ticks: 40, completed: false },
   ],
   companions: [],
   bonds: 0,
@@ -140,5 +141,68 @@ describe("tick_progress", () => {
       arguments: { track_name: "Nonexistent Track", marks: 1 },
     });
     expect(result.isError).toBe(true);
+  });
+});
+
+describe("close_track", () => {
+  it("marks a non-vow track as completed without awarding XP", async () => {
+    const result = await client.callTool({
+      name: "close_track",
+      arguments: { track_name: "Combat Ended" },
+    });
+    expect(result.isError).not.toBe(true);
+    const parsed = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.track.completed).toBe(true);
+    expect(parsed.xpAwarded).toBe(0);
+  });
+
+  it("does not change XP when closing a non-vow track", async () => {
+    const before = await client.callTool({ name: "get_character_digest", arguments: {} });
+    // close_track doesn't exist yet in read tools, so check via close_track result
+    const result = await client.callTool({
+      name: "close_track",
+      arguments: { track_name: "Explore the Caverns" },
+    });
+    expect(result.isError).not.toBe(true);
+    const parsed = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.xpAwarded).toBe(0);
+    expect(parsed.track.completed).toBe(true);
+    expect(parsed.track.name).toBe("Explore the Caverns");
+  });
+
+  it("also works for vow tracks (closes without awarding XP, unlike fulfill_progress)", async () => {
+    const result = await client.callTool({
+      name: "close_track",
+      arguments: { track_name: "Remove Caldren from Holtfen" },
+    });
+    expect(result.isError).not.toBe(true);
+    const parsed = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.track.completed).toBe(true);
+    expect(parsed.xpAwarded).toBe(0);
+  });
+
+  it("returns error for unknown track name", async () => {
+    const result = await client.callTool({
+      name: "close_track",
+      arguments: { track_name: "Nonexistent Track" },
+    });
+    expect(result.isError).toBe(true);
+  });
+
+  it("is idempotent — closing an already-completed track succeeds", async () => {
+    // First close
+    await client.callTool({ name: "close_track", arguments: { track_name: "Combat Ended" } });
+    // Second close — should still succeed
+    const result = await client.callTool({
+      name: "close_track",
+      arguments: { track_name: "Combat Ended" },
+    });
+    expect(result.isError).not.toBe(true);
+    const parsed = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.track.completed).toBe(true);
   });
 });

--- a/plugins/ironsworn/scribe/src/tools/mutations.ts
+++ b/plugins/ironsworn/scribe/src/tools/mutations.ts
@@ -20,6 +20,7 @@ import {
   companionRestoreHealth,
   upsertCompanion,
   upgradeAsset,
+  closeTrack,
   Character,
 } from "../state/character.js";
 import { burnMomentum } from "../rules/ironsworn/momentum.js";
@@ -406,6 +407,40 @@ export function register(server: McpServer, campaignPath: string): void {
         recordMutation(campaignPath);
         return {
           content: [{ type: "text", text: JSON.stringify({ ok: true, track: character.progressTracks[idx], xpGained, experience: character.experience }) }],
+        };
+      } catch (e) {
+        return {
+          content: [{ type: "text", text: `Error: ${e instanceof Error ? e.message : String(e)}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.tool(
+    "close_track",
+    [
+      "Dismiss/close a progress track without awarding XP.",
+      "Use this for non-vow tracks (combat, journey, bond, other) that have resolved fictionally",
+      "but were never formally completed via fulfill_progress — e.g. a battle that ended narratively,",
+      "a journey that was abandoned, or any track sitting at 40/40 after the fiction has moved on.",
+      "Also works for vow tracks when you want to abandon a vow without XP.",
+      "",
+      "The track is marked completed=true (same flag as fulfill_progress) but no XP is awarded.",
+      "After closing, the track will no longer appear in session_briefing's 'ready' or 'open' buckets.",
+    ].join("\n"),
+    {
+      track_name: z.string().describe("Name of the progress track to close/dismiss (case-insensitive)"),
+    },
+    async ({ track_name }) => {
+      try {
+        const result = await closeTrack(campaignPath, track_name);
+        recordMutation(campaignPath);
+        const track = result.after.progressTracks.find(
+          (t) => t.name.toLowerCase() === track_name.toLowerCase(),
+        );
+        return {
+          content: [{ type: "text", text: JSON.stringify({ ok: true, track, xpAwarded: 0 }) }],
         };
       } catch (e) {
         return {

--- a/plugins/ironsworn/scribe/src/tools/read.test.ts
+++ b/plugins/ironsworn/scribe/src/tools/read.test.ts
@@ -247,6 +247,50 @@ describe("session_briefing — recent_scenes", () => {
   });
 });
 
+describe("session_briefing — ready bucket excludes tracks with closed threads", () => {
+  it("a ready track whose thread title matches and is closed is NOT in ready", async () => {
+    // "Combat Resolved" track (ticks=40, completed=false) — open matching thread
+    await openThread(campaignDir, "Combat Resolved", "other", "Ongoing combat");
+    await closeThread(campaignDir, "Combat Resolved", "Enemy defeated");
+
+    const result = await client.callTool({ name: "session_briefing", arguments: {} });
+    const briefing = parseToolText<{
+      tracks: { ready: Array<{ name: string }> };
+    }>(result);
+
+    // "Combat Resolved" track should NOT appear in ready since its thread is closed
+    const readyNames = briefing.tracks.ready.map((t) => t.name);
+    expect(readyNames).not.toContain("Combat Resolved");
+    // "Journey Done" should still be ready (no closed thread)
+    expect(readyNames).toContain("Journey Done");
+  });
+
+  it("a ready track whose thread is still open remains in ready", async () => {
+    // Open a thread matching a ready track — but don't close it
+    await openThread(campaignDir, "Combat Resolved", "other", "Ongoing combat");
+
+    const result = await client.callTool({ name: "session_briefing", arguments: {} });
+    const briefing = parseToolText<{
+      tracks: { ready: Array<{ name: string }> };
+    }>(result);
+
+    const readyNames = briefing.tracks.ready.map((t) => t.name);
+    expect(readyNames).toContain("Combat Resolved");
+    expect(readyNames).toContain("Journey Done");
+  });
+
+  it("a ready track with no matching thread stays in ready", async () => {
+    const result = await client.callTool({ name: "session_briefing", arguments: {} });
+    const briefing = parseToolText<{
+      tracks: { ready: Array<{ name: string }> };
+    }>(result);
+
+    const readyNames = briefing.tracks.ready.map((t) => t.name);
+    expect(readyNames).toContain("Combat Resolved");
+    expect(readyNames).toContain("Journey Done");
+  });
+});
+
 describe("session_briefing — overall shape", () => {
   it("returns all four top-level keys", async () => {
     const result = await client.callTool({ name: "session_briefing", arguments: {} });

--- a/plugins/ironsworn/scribe/src/tools/read.ts
+++ b/plugins/ironsworn/scribe/src/tools/read.ts
@@ -333,13 +333,23 @@ export function register(server: McpServer, campaignPath: string): void {
         // --- Track bucketing ---
         // open     = ticks < 40 AND completed == false
         // ready    = ticks == 40 AND completed == false (full — completion roll pending)
+        //            BUT exclude tracks whose matching thread (by name) is closed —
+        //            those have resolved fictionally and should not surface as pending.
         // completed = completed == true
+        const closedThreadTitles = new Set(
+          allThreads
+            .filter((t) => t.status === "closed")
+            .map((t) => t.title.toLowerCase()),
+        );
         const tracks = {
           open: character.progressTracks.filter(
             (t) => !t.completed && t.ticks < 40,
           ),
           ready: character.progressTracks.filter(
-            (t) => !t.completed && t.ticks >= 40,
+            (t) =>
+              !t.completed &&
+              t.ticks >= 40 &&
+              !closedThreadTitles.has(t.name.toLowerCase()),
           ),
           completed: character.progressTracks.filter((t) => t.completed),
         };


### PR DESCRIPTION
## Summary

- Adds a `close_track` MCP tool that marks any progress track as completed/dismissed without awarding XP — for combat/journey tracks resolved in fiction
- Updates `session_briefing` to suppress "ready" tracks when the associated thread (same name, case-insensitive) is closed
- 5 new unit tests for `close_track`, 3 new tests for the session_briefing filter

## Test plan
- [ ] `close_track` marks a track completed with `xpAwarded: 0`
- [ ] `close_track` works on vow tracks (for abandonment)
- [ ] `close_track` throws on unknown track name
- [ ] `close_track` is idempotent
- [ ] `session_briefing` hides a ready track whose thread is closed
- [ ] `session_briefing` keeps a ready track whose thread is open
- [ ] `session_briefing` keeps a ready track with no associated thread

🤖 Generated with [Claude Code](https://claude.com/claude-code)