### PR TITLE
fix(mutations): rename 'n' parameter to 'amount' across all stat tools (closes #82)

### DIFF
--- a/plugins/ironsworn/.claude-plugin/plugin.json
+++ b/plugins/ironsworn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ironsworn",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Solo Ironsworn GM companion — fiction-first, dice-driven, with a living lore graph",
   "author": {
     "name": "Karim Naguib"

--- a/plugins/ironsworn/scribe/src/tools/mutations.test.ts
+++ b/plugins/ironsworn/scribe/src/tools/mutations.test.ts
@@ -49,6 +49,141 @@ afterEach(async () => {
   await rm(campaignDir, { recursive: true, force: true });
 });
 
+describe("amount parameter naming", () => {
+  it("restore_spirit accepts 'amount' parameter", async () => {
+    const result = await client.callTool({
+      name: "restore_spirit",
+      arguments: { amount: 2 },
+    });
+    expect(result.isError).not.toBe(true);
+    const parsed = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.state.spirit).toBe(5); // 3 + 2 = 5
+  });
+
+  it("restore_supply accepts 'amount' parameter", async () => {
+    const result = await client.callTool({
+      name: "restore_supply",
+      arguments: { amount: 2 },
+    });
+    expect(result.isError).not.toBe(true);
+    const parsed = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.state.supply).toBe(5); // 3 + 2 = 5
+  });
+
+  it("restore_health accepts 'amount' parameter", async () => {
+    const result = await client.callTool({
+      name: "restore_health",
+      arguments: { amount: 1 },
+    });
+    expect(result.isError).not.toBe(true);
+    const parsed = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.state.health).toBe(5); // 4 + 1 = 5
+  });
+
+  it("suffer_harm accepts 'amount' parameter", async () => {
+    const result = await client.callTool({
+      name: "suffer_harm",
+      arguments: { amount: 2 },
+    });
+    expect(result.isError).not.toBe(true);
+    const parsed = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.state.health).toBe(2); // 4 - 2 = 2
+  });
+
+  it("suffer_stress accepts 'amount' parameter", async () => {
+    const result = await client.callTool({
+      name: "suffer_stress",
+      arguments: { amount: 1 },
+    });
+    expect(result.isError).not.toBe(true);
+    const parsed = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.state.spirit).toBe(2); // 3 - 1 = 2
+  });
+
+  it("consume_supply accepts 'amount' parameter", async () => {
+    const result = await client.callTool({
+      name: "consume_supply",
+      arguments: { amount: 1 },
+    });
+    expect(result.isError).not.toBe(true);
+    const parsed = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.state.supply).toBe(2); // 3 - 1 = 2
+  });
+
+  it("take_momentum accepts 'amount' parameter", async () => {
+    const result = await client.callTool({
+      name: "take_momentum",
+      arguments: { amount: 3 },
+    });
+    expect(result.isError).not.toBe(true);
+    const parsed = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.state.momentum).toBe(5); // 2 + 3 = 5
+  });
+
+  it("gain_experience accepts 'amount' parameter", async () => {
+    const result = await client.callTool({
+      name: "gain_experience",
+      arguments: { amount: 2 },
+    });
+    expect(result.isError).not.toBe(true);
+    const parsed = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.experience).toBe(2);
+  });
+
+  it("spend_experience accepts 'amount' parameter", async () => {
+    // first gain some XP
+    await client.callTool({ name: "gain_experience", arguments: { amount: 5 } });
+    const result = await client.callTool({
+      name: "spend_experience",
+      arguments: { amount: 3 },
+    });
+    expect(result.isError).not.toBe(true);
+    const parsed = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.experience).toBe(2);
+  });
+
+  it("companion_suffer_harm accepts 'amount' parameter", async () => {
+    // first add a companion
+    await client.callTool({
+      name: "upsert_companion",
+      arguments: { companion_name: "Wolf", health: 4 },
+    });
+    const result = await client.callTool({
+      name: "companion_suffer_harm",
+      arguments: { companion_name: "Wolf", amount: 2 },
+    });
+    expect(result.isError).not.toBe(true);
+    const parsed = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.companion.health).toBe(2);
+  });
+
+  it("companion_restore_health accepts 'amount' parameter", async () => {
+    // first add a companion with low health
+    await client.callTool({
+      name: "upsert_companion",
+      arguments: { companion_name: "Wolf", health: 2 },
+    });
+    const result = await client.callTool({
+      name: "companion_restore_health",
+      arguments: { companion_name: "Wolf", amount: 2 },
+    });
+    expect(result.isError).not.toBe(true);
+    const parsed = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.companion.health).toBe(4);
+  });
+});
+
 describe("tick_progress", () => {
   it("returns applied.prior_ticks matching the track ticks before the tick", async () => {
     const result = await client.callTool({

--- a/plugins/ironsworn/scribe/src/tools/mutations.ts
+++ b/plugins/ironsworn/scribe/src/tools/mutations.ts
@@ -48,10 +48,10 @@ export function register(server: McpServer, campaignPath: string): void {
   server.tool(
     "take_momentum",
     "Add or remove momentum from the character",
-    { n: z.coerce.number().int().describe("Amount to add (positive) or remove (negative)") },
-    async ({ n }) => {
+    { amount: z.coerce.number().int().describe("Amount to add (positive) or remove (negative)") },
+    async ({ amount }) => {
       try {
-        const result = await takeMomentum(campaignPath, n);
+        const result = await takeMomentum(campaignPath, amount);
         recordMutation(campaignPath);
         return {
           content: [{ type: "text", text: JSON.stringify({ ok: true, state: characterDigest(result.after) }) }],
@@ -95,11 +95,11 @@ export function register(server: McpServer, campaignPath: string): void {
 
   server.tool(
     "suffer_harm",
-    "Reduce character health by n points",
-    { n: z.coerce.number().int().positive().describe("Amount of harm to suffer") },
-    async ({ n }) => {
+    "Reduce character health by the given amount",
+    { amount: z.coerce.number().int().positive().describe("Amount of harm to suffer") },
+    async ({ amount }) => {
       try {
-        const result = await sufferHarm(campaignPath, n);
+        const result = await sufferHarm(campaignPath, amount);
         recordMutation(campaignPath);
         return {
           content: [{ type: "text", text: JSON.stringify({ ok: true, state: characterDigest(result.after) }) }],
@@ -115,11 +115,11 @@ export function register(server: McpServer, campaignPath: string): void {
 
   server.tool(
     "suffer_stress",
-    "Reduce character spirit by n points",
-    { n: z.coerce.number().int().positive().describe("Amount of stress to suffer") },
-    async ({ n }) => {
+    "Reduce character spirit by the given amount",
+    { amount: z.coerce.number().int().positive().describe("Amount of stress to suffer") },
+    async ({ amount }) => {
       try {
-        const result = await sufferStress(campaignPath, n);
+        const result = await sufferStress(campaignPath, amount);
         recordMutation(campaignPath);
         return {
           content: [{ type: "text", text: JSON.stringify({ ok: true, state: characterDigest(result.after) }) }],
@@ -135,11 +135,11 @@ export function register(server: McpServer, campaignPath: string): void {
 
   server.tool(
     "consume_supply",
-    "Reduce character supply by n points",
-    { n: z.coerce.number().int().positive().describe("Amount of supply to consume") },
-    async ({ n }) => {
+    "Reduce character supply by the given amount",
+    { amount: z.coerce.number().int().positive().describe("Amount of supply to consume") },
+    async ({ amount }) => {
       try {
-        const result = await consumeSupply(campaignPath, n);
+        const result = await consumeSupply(campaignPath, amount);
         recordMutation(campaignPath);
         return {
           content: [{ type: "text", text: JSON.stringify({ ok: true, state: characterDigest(result.after) }) }],
@@ -155,11 +155,11 @@ export function register(server: McpServer, campaignPath: string): void {
 
   server.tool(
     "restore_health",
-    "Restore character health by n points (clamped to max 5)",
-    { n: z.coerce.number().int().positive().describe("Amount of health to restore") },
-    async ({ n }) => {
+    "Restore character health by the given amount (clamped to max 5)",
+    { amount: z.coerce.number().int().positive().describe("Amount of health to restore") },
+    async ({ amount }) => {
       try {
-        const result = await restoreHealth(campaignPath, n);
+        const result = await restoreHealth(campaignPath, amount);
         recordMutation(campaignPath);
         return {
           content: [{ type: "text", text: JSON.stringify({ ok: true, state: characterDigest(result.after) }) }],
@@ -175,11 +175,11 @@ export function register(server: McpServer, campaignPath: string): void {
 
   server.tool(
     "restore_spirit",
-    "Restore character spirit by n points (clamped to max 5)",
-    { n: z.coerce.number().int().positive().describe("Amount of spirit to restore") },
-    async ({ n }) => {
+    "Restore character spirit by the given amount (clamped to max 5)",
+    { amount: z.coerce.number().int().positive().describe("Amount of spirit to restore") },
+    async ({ amount }) => {
       try {
-        const result = await restoreSpirit(campaignPath, n);
+        const result = await restoreSpirit(campaignPath, amount);
         recordMutation(campaignPath);
         return {
           content: [{ type: "text", text: JSON.stringify({ ok: true, state: characterDigest(result.after) }) }],
@@ -195,11 +195,11 @@ export function register(server: McpServer, campaignPath: string): void {
 
   server.tool(
     "restore_supply",
-    "Restore character supply by n points (clamped to max 5)",
-    { n: z.coerce.number().int().positive().describe("Amount of supply to restore") },
-    async ({ n }) => {
+    "Restore character supply by the given amount (clamped to max 5)",
+    { amount: z.coerce.number().int().positive().describe("Amount of supply to restore") },
+    async ({ amount }) => {
       try {
-        const result = await restoreSupply(campaignPath, n);
+        const result = await restoreSupply(campaignPath, amount);
         recordMutation(campaignPath);
         return {
           content: [{ type: "text", text: JSON.stringify({ ok: true, state: characterDigest(result.after) }) }],
@@ -482,14 +482,14 @@ export function register(server: McpServer, campaignPath: string): void {
   );
   server.tool(
     "companion_suffer_harm",
-    "Reduce a companion's health by n points",
+    "Reduce a companion's health by the given amount",
     {
       companion_name: z.string().describe("Name of the companion (case-insensitive)"),
-      n: z.coerce.number().int().positive().describe("Amount of harm to suffer"),
+      amount: z.coerce.number().int().positive().describe("Amount of harm to suffer"),
     },
-    async ({ companion_name, n }) => {
+    async ({ companion_name, amount }) => {
       try {
-        const result = await companionSufferHarm(campaignPath, companion_name, n);
+        const result = await companionSufferHarm(campaignPath, companion_name, amount);
         recordMutation(campaignPath);
         const companion = result.after.companions.find(
           (c) => c.name.toLowerCase() === companion_name.toLowerCase(),
@@ -508,14 +508,14 @@ export function register(server: McpServer, campaignPath: string): void {
 
   server.tool(
     "companion_restore_health",
-    "Restore a companion's health by n points",
+    "Restore a companion's health by the given amount",
     {
       companion_name: z.string().describe("Name of the companion (case-insensitive)"),
-      n: z.coerce.number().int().positive().describe("Amount of health to restore"),
+      amount: z.coerce.number().int().positive().describe("Amount of health to restore"),
     },
-    async ({ companion_name, n }) => {
+    async ({ companion_name, amount }) => {
       try {
-        const result = await companionRestoreHealth(campaignPath, companion_name, n);
+        const result = await companionRestoreHealth(campaignPath, companion_name, amount);
         recordMutation(campaignPath);
         const companion = result.after.companions.find(
           (c) => c.name.toLowerCase() === companion_name.toLowerCase(),
@@ -561,10 +561,10 @@ export function register(server: McpServer, campaignPath: string): void {
   server.tool(
     "gain_experience",
     "Add experience points to the character",
-    { n: z.coerce.number().int().positive().describe("Amount of experience to gain") },
-    async ({ n }) => {
+    { amount: z.coerce.number().int().positive().describe("Amount of experience to gain") },
+    async ({ amount }) => {
       try {
-        const result = await gainExperience(campaignPath, n);
+        const result = await gainExperience(campaignPath, amount);
         recordMutation(campaignPath);
         return {
           content: [{ type: "text", text: JSON.stringify({ ok: true, experience: result.after.experience }) }],
@@ -581,10 +581,10 @@ export function register(server: McpServer, campaignPath: string): void {
   server.tool(
     "spend_experience",
     "Spend experience points from the character",
-    { n: z.coerce.number().int().positive().describe("Amount of experience to spend") },
-    async ({ n }) => {
+    { amount: z.coerce.number().int().positive().describe("Amount of experience to spend") },
+    async ({ amount }) => {
       try {
-        const result = await spendExperience(campaignPath, n);
+        const result = await spendExperience(campaignPath, amount);
         recordMutation(campaignPath);
         return {
           content: [{ type: "text", text: JSON.stringify({ ok: true, experience: result.after.experience }) }],


### PR DESCRIPTION
## Summary

Renamed the `n` parameter to `amount` in all 11 numeric stat-mutation tools so GMs can call them naturally:

- `take_momentum`, `suffer_harm`, `suffer_stress`, `consume_supply`
- `restore_health`, `restore_spirit`, `restore_supply`
- `companion_suffer_harm`, `companion_restore_health`
- `gain_experience`, `spend_experience`

Tool descriptions updated from "by n points" → "by the given amount". 11 new tests added (one per tool).

## Test plan
- [ ] Each tool accepts `amount` parameter without error
- [ ] All 11 new `amount parameter naming` tests pass
- [ ] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)