### PR TITLE
fix(search_beats): add total_beats diagnostic to distinguish no-match from no-data (closes #83)

### DIFF
--- a/plugins/ironsworn/.claude-plugin/plugin.json
+++ b/plugins/ironsworn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ironsworn",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Solo Ironsworn GM companion — fiction-first, dice-driven, with a living lore graph",
   "author": {
     "name": "Karim Naguib"

--- a/plugins/ironsworn/scribe/src/rag/scenes.test.ts
+++ b/plugins/ironsworn/scribe/src/rag/scenes.test.ts
@@ -250,9 +250,10 @@ describe("searchBeats", () => {
 
     expect(id).toBeTruthy();
 
-    const results = await searchBeats(campaignDir, "birds in the sky", 3);
-    expect(results.length).toBeGreaterThan(0);
-    expect(results[0]!.text).toContain("Ravens");
+    const result = await searchBeats(campaignDir, "birds in the sky", 3);
+    expect(result.beats.length).toBeGreaterThan(0);
+    expect(result.beats[0]!.text).toContain("Ravens");
+    expect(result.total_beats).toBe(3);
   });
 
   it("filters by kind", async () => {
@@ -262,8 +263,10 @@ describe("searchBeats", () => {
       { kind: "dialogue", speaker: "NPC", text: "Welcome to Thornhaven." },
     ]);
 
-    const dialogueOnly = await searchBeats(campaignDir, "greeting welcome", 5, { kind: "dialogue" });
-    expect(dialogueOnly.every((b) => b.kind === "dialogue")).toBe(true);
+    const result = await searchBeats(campaignDir, "greeting welcome", 5, { kind: "dialogue" });
+    expect(result.beats.every((b) => b.kind === "dialogue")).toBe(true);
+    // total_beats counts ALL beats matching the kind filter, regardless of search results
+    expect(result.total_beats).toBe(1);
   });
 
   it("filters by scene_id", async () => {
@@ -275,15 +278,29 @@ describe("searchBeats", () => {
       { kind: "narration", text: "A quiet morning." },
     ]);
 
-    const results = await searchBeats(campaignDir, "snow blood", 5, { scene_id: id1 });
-    expect(results.every((b) => b.scene_id === id1)).toBe(true);
+    const result = await searchBeats(campaignDir, "snow blood", 5, { scene_id: id1 });
+    expect(result.beats.every((b) => b.scene_id === id1)).toBe(true);
+    expect(result.total_beats).toBe(1);
   });
 
-  it("returns empty array when no beats recorded", async () => {
+  it("returns empty beats array and total_beats=0 when no beats recorded", async () => {
     if (!(await ollamaAvailable())) return;
     await recordScene(campaignDir, "A summary-only scene.");
-    const results = await searchBeats(campaignDir, "anything", 5);
-    expect(results).toEqual([]);
+    const result = await searchBeats(campaignDir, "anything", 5);
+    expect(result.beats).toEqual([]);
+    expect(result.total_beats).toBe(0);
+  });
+
+  it("distinguishes no-match from no-data: total_beats > 0 when beats exist but none match top-k", async () => {
+    if (!(await ollamaAvailable())) return;
+    const sceneId = await recordScene(campaignDir, "A combat scene.", "combat", undefined, [
+      { kind: "move", text: "You strike with iron resolve." },
+      { kind: "narration", text: "The enemy falls." },
+    ]);
+    // Use scene_id filter to scope total_beats to this specific scene.
+    // Regardless of which beats are returned, total_beats must reflect the full count.
+    const result = await searchBeats(campaignDir, "completely unrelated romantic picnic", 1, { scene_id: sceneId });
+    expect(result.total_beats).toBe(2);
   });
 });
 

--- a/plugins/ironsworn/scribe/src/rag/scenes.ts
+++ b/plugins/ironsworn/scribe/src/rag/scenes.ts
@@ -43,6 +43,15 @@ export interface Beat {
   score?: number;
 }
 
+export interface BeatSearchResult {
+  beats: Beat[];
+  /** Total number of beats in scope (applying any kind/scene_id filters but ignoring
+   *  the search query and k limit).  Callers can use this to distinguish "no results
+   *  because nothing matched the query" (total_beats > 0) from "no results because
+   *  this scene has no beats recorded at all" (total_beats === 0). */
+  total_beats: number;
+}
+
 export interface BeatExport {
   id: string;
   scene_id: string;
@@ -441,7 +450,7 @@ export async function searchBeats(
   query: string,
   k?: number,
   opts?: { kind?: string; scene_id?: string },
-): Promise<Beat[]> {
+): Promise<BeatSearchResult> {
   const limit = k ?? 5;
 
   const [embedding, instance] = await Promise.all([
@@ -452,22 +461,31 @@ export async function searchBeats(
   const embeddingLiteral = `[${embedding.join(",")}]::FLOAT[768]`;
 
   const conditions: string[] = [];
-  const params: DuckDBValue[] = [];
+  const filterParams: DuckDBValue[] = [];
 
   if (opts?.kind) {
     conditions.push(`kind = ?`);
-    params.push(opts.kind);
+    filterParams.push(opts.kind);
   }
   if (opts?.scene_id) {
     conditions.push(`scene_id = ?`);
-    params.push(opts.scene_id);
+    filterParams.push(opts.scene_id);
   }
-  params.push(limit);
 
   const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
 
   const conn = await instance.connect();
   try {
+    // Count total beats in scope (same filters, no query/limit applied)
+    const countResult = await conn.runAndReadAll(
+      `SELECT COUNT(*) AS cnt FROM scene_beats ${whereClause}`,
+      filterParams,
+    );
+    const countRows = countResult.getRowObjectsJS() as Record<string, unknown>[];
+    const total_beats = Number(countRows[0]?.["cnt"] ?? 0);
+
+    // Semantic search with limit
+    const searchParams: DuckDBValue[] = [...filterParams, limit];
     const result = await conn.runAndReadAll(
       `SELECT id, scene_id, beat_index, kind, speaker, text, metadata, created_at,
               array_cosine_similarity(embedding, ${embeddingLiteral}) AS score
@@ -475,10 +493,10 @@ export async function searchBeats(
        ${whereClause}
        ORDER BY score DESC
        LIMIT ?`,
-      params,
+      searchParams,
     );
     const rows = result.getRowObjectsJS() as Record<string, unknown>[];
-    return rows.map(rowToBeat);
+    return { beats: rows.map(rowToBeat), total_beats };
   } finally {
     conn.closeSync();
   }

--- a/plugins/ironsworn/scribe/src/tools/read.ts
+++ b/plugins/ironsworn/scribe/src/tools/read.ts
@@ -246,7 +246,11 @@ export function register(server: McpServer, campaignPath: string): void {
 
   server.tool(
     "search_beats",
-    "Search scene beats using semantic similarity. Finds specific moments of dialogue, narration, or move resolution across all scenes.",
+    [
+      "Search scene beats using semantic similarity. Finds specific moments of dialogue, narration, or move resolution across all scenes.",
+      "The response includes `beats` (matched results) and `total_beats` (count of all beats in scope before the query/limit is applied).",
+      "Use `total_beats` to distinguish 'no match' (total_beats > 0, beats empty) from 'no data' (total_beats === 0, scene has no beats recorded).",
+    ].join(" "),
     {
       query: z.string().describe("Search query"),
       k: z.number().int().positive().optional().describe("Number of results to return (default 5)"),
@@ -255,9 +259,9 @@ export function register(server: McpServer, campaignPath: string): void {
     },
     async ({ query, k, kind, scene_id }) => {
       try {
-        const results = await searchBeats(campaignPath, query, k, { kind, scene_id });
+        const result = await searchBeats(campaignPath, query, k, { kind, scene_id });
         return {
-          content: [{ type: "text", text: JSON.stringify(results) }],
+          content: [{ type: "text", text: JSON.stringify(result) }],
         };
       } catch (e) {
         return {


### PR DESCRIPTION
## Summary

`search_beats` now returns `{ beats, total_beats }` instead of a bare array:
- `total_beats` is the count of all beats in the scene regardless of the search query
- `total_beats: 0` means the scene has no beats recorded (summary-only scene)
- `total_beats > 0` with empty `beats` means the query didn't match

MCP tool description updated to document the new field. Tests updated and two new diagnostic tests added.

## Test plan
- [ ] Returns `total_beats: 0` when scene has no beats recorded
- [ ] Returns `total_beats > 0` with empty `beats` when query doesn't match existing beats
- [ ] Existing beat search tests still pass with correct `total_beats` counts
- [ ] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)