### PR TITLE
feat(scribe): add record_beat tool for real-time beat capture (closes #80)

### DIFF
--- a/plugins/ironsworn/.claude-plugin/plugin.json
+++ b/plugins/ironsworn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ironsworn",
-  "version": "0.8.2",
+  "version": "0.9.0",
   "description": "Solo Ironsworn GM companion — fiction-first, dice-driven, with a living lore graph",
   "author": {
     "name": "Karim Naguib"

--- a/plugins/ironsworn/scribe/src/rag/scenes.test.ts
+++ b/plugins/ironsworn/scribe/src/rag/scenes.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { recordScene, searchScenes, getRecentComplications, getScene, updateScene, deleteScene, recordBeats, getBeats, searchBeats, exportScenes, importScene } from "./scenes.js";
+import { recordScene, searchScenes, getRecentComplications, getScene, updateScene, deleteScene, recordBeats, recordBeat, getBeats, searchBeats, exportScenes, importScene } from "./scenes.js";
 
 let _ollamaReady: boolean | null = null;
 async function ollamaAvailable(): Promise<boolean> {
@@ -236,6 +236,74 @@ describe("scene beats — round-trip", () => {
 
     const beats = await getBeats(campaignDir, id);
     expect(beats).toHaveLength(0);
+  });
+});
+
+describe("recordBeat", () => {
+  it("appends a single beat and returns its 0-based index", async () => {
+    if (!(await ollamaAvailable())) return;
+    const sceneId = await recordScene(campaignDir, "A tense standoff.", "combat");
+
+    const idx = await recordBeat(campaignDir, sceneId, { kind: "narration", text: "Silence falls over the clearing." });
+    expect(idx).toBe(0);
+
+    const beats = await getBeats(campaignDir, sceneId);
+    expect(beats).toHaveLength(1);
+    expect(beats[0]!.text).toContain("Silence falls");
+    expect(beats[0]!.beat_index).toBe(0);
+  });
+
+  it("returns sequential indices when multiple beats are appended one by one", async () => {
+    if (!(await ollamaAvailable())) return;
+    const sceneId = await recordScene(campaignDir, "A dialogue scene.", "social");
+
+    const idx0 = await recordBeat(campaignDir, sceneId, { kind: "narration", text: "The fire crackles." });
+    const idx1 = await recordBeat(campaignDir, sceneId, { kind: "dialogue", speaker: "Kira", text: "You came back." });
+    const idx2 = await recordBeat(campaignDir, sceneId, { kind: "move", text: "Compel the guard.", metadata: { move: "Compel", stat: "heart", outcome: "strong_hit" } });
+
+    expect(idx0).toBe(0);
+    expect(idx1).toBe(1);
+    expect(idx2).toBe(2);
+
+    const beats = await getBeats(campaignDir, sceneId);
+    expect(beats).toHaveLength(3);
+  });
+
+  it("beat is persisted — subsequent getScene includes it when include_beats is true", async () => {
+    if (!(await ollamaAvailable())) return;
+    const sceneId = await recordScene(campaignDir, "A brief scene.", "exploration");
+
+    await recordBeat(campaignDir, sceneId, { kind: "oracle", text: "The oracle speaks: iron and ash." });
+
+    const scene = await getScene(campaignDir, sceneId, { include_beats: true });
+    expect(scene).not.toBeNull();
+    expect(scene!.beats).toHaveLength(1);
+    expect(scene!.beats![0]!.text).toContain("iron and ash");
+    expect(scene!.beats![0]!.kind).toBe("oracle");
+  });
+
+  it("appending to a scene that already has beats continues the index sequence", async () => {
+    if (!(await ollamaAvailable())) return;
+    const sceneId = await recordScene(campaignDir, "A multi-part scene.", "social", undefined, [
+      { kind: "narration", text: "The hall falls silent." },
+      { kind: "dialogue", speaker: "Elder", text: "Speak your vow." },
+    ]);
+
+    const idx = await recordBeat(campaignDir, sceneId, { kind: "choice", text: "You swear on iron." });
+    expect(idx).toBe(2);
+
+    const beats = await getBeats(campaignDir, sceneId);
+    expect(beats).toHaveLength(3);
+    expect(beats[2]!.kind).toBe("choice");
+  });
+
+  it("throws when scene_id does not exist", async () => {
+    if (!(await ollamaAvailable())) return;
+    // Initialize the DB by recording a scene
+    await recordScene(campaignDir, "Placeholder to init DB.");
+    await expect(
+      recordBeat(campaignDir, "non-existent-scene-id", { kind: "narration", text: "This should fail." }),
+    ).rejects.toThrow("Scene not found");
   });
 });
 

--- a/plugins/ironsworn/scribe/src/rag/scenes.ts
+++ b/plugins/ironsworn/scribe/src/rag/scenes.ts
@@ -423,6 +423,62 @@ export async function recordBeats(
   }
 }
 
+/**
+ * Append a single beat to an existing scene and return its 0-based index.
+ * Throws if the scene does not exist.
+ */
+export async function recordBeat(
+  campaignPath: string,
+  sceneId: string,
+  beat: BeatInput,
+): Promise<number> {
+  const instance = await getDb(campaignPath);
+
+  // Verify the scene exists
+  const checkConn = await instance.connect();
+  let beatIndex: number;
+  try {
+    const sceneRows = (
+      await checkConn.runAndReadAll(
+        `SELECT id FROM scenes WHERE id = ?`,
+        [sceneId],
+      )
+    ).getRowObjectsJS() as Record<string, unknown>[];
+    if (sceneRows.length === 0) {
+      throw new Error(`Scene not found: ${sceneId}`);
+    }
+
+    const rows = (
+      await checkConn.runAndReadAll(
+        `SELECT COALESCE(MAX(beat_index) + 1, 0) AS next_index FROM scene_beats WHERE scene_id = ?`,
+        [sceneId],
+      )
+    ).getRowObjectsJS() as Record<string, unknown>[];
+    beatIndex = Number(rows[0]?.["next_index"] ?? 0);
+  } finally {
+    checkConn.closeSync();
+  }
+
+  const embedding = await getEmbedding(beat.text);
+  const embeddingLiteral = `[${embedding.join(",")}]::FLOAT[768]`;
+  const beatId = crypto.randomUUID();
+  const created_at = new Date().toISOString();
+  const metadata = JSON.stringify(beat.metadata ?? {});
+
+  const conn = await openWriteConn(instance);
+  try {
+    await conn.run(
+      `INSERT INTO scene_beats (id, scene_id, beat_index, kind, speaker, text, embedding, metadata, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ${embeddingLiteral}, ?, ?)`,
+      [beatId, sceneId, beatIndex, beat.kind, beat.speaker ?? null, beat.text, metadata, created_at],
+    );
+  } finally {
+    conn.closeSync();
+  }
+
+  return beatIndex;
+}
+
 export async function getBeats(
   campaignPath: string,
   sceneId: string,

--- a/plugins/ironsworn/scribe/src/tools/narrative.test.ts
+++ b/plugins/ironsworn/scribe/src/tools/narrative.test.ts
@@ -2,9 +2,13 @@ import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { buildSceneWarnings } from "./narrative.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { buildSceneWarnings, register } from "./narrative.js";
 import { upsertNpc, getNpc } from "../state/npcs.js";
 import { upsertLore, getLore } from "../rag/lore.js";
+import { recordScene, getScene } from "../rag/scenes.js";
 
 let _ollamaReady: boolean | null = null;
 async function ollamaAvailable(): Promise<boolean> {
@@ -137,5 +141,80 @@ describe("buildSceneWarnings", () => {
     expect(result.warnings).toHaveLength(0);
     expect(result.stubbed.npcs).toHaveLength(0);
     expect(result.stubbed.lore).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// record_beat tool
+// ---------------------------------------------------------------------------
+
+describe("record_beat tool", () => {
+  let server: McpServer;
+  let client: Client;
+
+  beforeEach(async () => {
+    server = new McpServer({ name: "test", version: "0.0.1" });
+    register(server, campaignDir);
+    client = new Client({ name: "test-client", version: "0.0.1" });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+  });
+
+  it("happy path: appends a beat and returns correct beat_index", async () => {
+    if (!(await ollamaAvailable())) return;
+    const sceneId = await recordScene(campaignDir, "An ambush at the forest edge.", "combat");
+
+    const result = await client.callTool({
+      name: "record_beat",
+      arguments: { scene_id: sceneId, kind: "narration", text: "Arrows fly from the shadows." },
+    });
+    expect(result.isError).not.toBe(true);
+    const parsed = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+    expect(parsed.beat_index).toBe(0);
+  });
+
+  it("sequential calls return incrementing indices", async () => {
+    if (!(await ollamaAvailable())) return;
+    const sceneId = await recordScene(campaignDir, "A social encounter.", "social");
+
+    const r1 = await client.callTool({ name: "record_beat", arguments: { scene_id: sceneId, kind: "narration", text: "The fire crackles." } });
+    const r2 = await client.callTool({ name: "record_beat", arguments: { scene_id: sceneId, kind: "dialogue", speaker: "Kira", text: "You came back." } });
+
+    expect(r1.isError).not.toBe(true);
+    expect(r2.isError).not.toBe(true);
+    const p1 = JSON.parse((r1.content as Array<{ type: string; text: string }>)[0].text);
+    const p2 = JSON.parse((r2.content as Array<{ type: string; text: string }>)[0].text);
+    expect(p1.beat_index).toBe(0);
+    expect(p2.beat_index).toBe(1);
+  });
+
+  it("beat is persisted — subsequent getScene shows the beat", async () => {
+    if (!(await ollamaAvailable())) return;
+    const sceneId = await recordScene(campaignDir, "A brief exploration.", "exploration");
+
+    await client.callTool({
+      name: "record_beat",
+      arguments: { scene_id: sceneId, kind: "oracle", text: "The oracle whispers: fire and shadow." },
+    });
+
+    const scene = await getScene(campaignDir, sceneId, { include_beats: true });
+    expect(scene).not.toBeNull();
+    expect(scene!.beats).toHaveLength(1);
+    expect(scene!.beats![0]!.text).toContain("fire and shadow");
+  });
+
+  it("invalid scene_id returns an error", async () => {
+    if (!(await ollamaAvailable())) return;
+    // Initialize the DB
+    await recordScene(campaignDir, "Placeholder to init DB.");
+
+    const result = await client.callTool({
+      name: "record_beat",
+      arguments: { scene_id: "non-existent-id", kind: "narration", text: "Should fail." },
+    });
+    expect(result.isError).toBe(true);
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text).toContain("non-existent-id");
   });
 });

--- a/plugins/ironsworn/scribe/src/tools/narrative.ts
+++ b/plugins/ironsworn/scribe/src/tools/narrative.ts
@@ -1,6 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { recordScene, getScene, updateScene, deleteScene, type BeatInput } from "../rag/scenes.js";
+import { recordScene, getScene, updateScene, deleteScene, recordBeat, recordBeats, type BeatInput } from "../rag/scenes.js";
 import { openThread, closeThread } from "../state/threads.js";
 import { upsertNpc, getNpc } from "../state/npcs.js";
 import { getLore, upsertLore } from "../rag/lore.js";
@@ -112,15 +112,18 @@ export function register(server: McpServer, campaignPath: string): void {
 
   server.tool(
     "update_scene",
-    "Update an existing scene record. Only provided fields are changed.",
+    "Update an existing scene record. Only provided fields are changed. Use append_beats to add new beats without replacing existing ones.",
     {
       id: z.string().describe("ID of the scene to update"),
       summary: z.string().optional().describe("New summary text (replaces existing)"),
       kind: z.string().optional().describe("New kind of scene"),
       npcs: z.array(z.string()).optional().describe("NPC names to verify are recorded"),
       lore_ids: z.array(z.string()).optional().describe("Lore entity IDs to verify are recorded"),
+      append_beats: z.array(BeatInputSchema).optional().describe(
+        "New beats to append to the scene's existing beats array (does not replace existing beats)"
+      ),
     },
-    async ({ id, summary, kind, npcs, lore_ids }) => {
+    async ({ id, summary, kind, npcs, lore_ids, append_beats }) => {
       try {
         const existing = await getScene(campaignPath, id);
         if (existing === null) {
@@ -130,10 +133,43 @@ export function register(server: McpServer, campaignPath: string): void {
           };
         }
         await updateScene(campaignPath, id, { summary, kind });
+        if (append_beats && append_beats.length > 0) {
+          await recordBeats(campaignPath, id, append_beats as BeatInput[]);
+        }
         recordMutation(campaignPath);
         const { warnings, stubbed } = await buildSceneWarnings(campaignPath, npcs, lore_ids);
         return {
           content: [{ type: "text", text: JSON.stringify({ ok: true, id, warnings, stubbed }) }],
+        };
+      } catch (e) {
+        return {
+          content: [{ type: "text", text: `Error: ${e instanceof Error ? e.message : String(e)}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.tool(
+    "record_beat",
+    "Append a single beat to an existing scene in real time, as events happen during play. Returns the 0-based index of the appended beat.",
+    {
+      scene_id: z.string().describe("ID of the scene to append the beat to"),
+      kind: z.enum(["dialogue", "narration", "move", "choice", "oracle"]).describe(
+        "Type of beat: dialogue (NPC/player speech), narration (descriptive prose), move (mechanical resolution), choice (player decision point), oracle (oracle roll + interpretation)"
+      ),
+      text: z.string().describe("Full text of the beat"),
+      speaker: z.string().optional().describe("Speaker name for dialogue beats"),
+      metadata: z.record(z.string(), z.unknown()).optional().describe(
+        "Structured data for move beats (e.g. {move: 'Face Danger', stat: 'edge', outcome: 'weak_hit'})"
+      ),
+    },
+    async ({ scene_id, kind, text, speaker, metadata }) => {
+      try {
+        const beatIndex = await recordBeat(campaignPath, scene_id, { kind, text, speaker, metadata });
+        recordMutation(campaignPath);
+        return {
+          content: [{ type: "text", text: JSON.stringify({ beat_index: beatIndex }) }],
         };
       } catch (e) {
         return {


### PR DESCRIPTION
## Summary
Adds a `record_beat` MCP tool that appends a single beat to an existing scene's beats array in real time, as events happen during play. Also adds `append_beats` support to the existing `update_scene` tool for batch-appending multiple beats at once. The underlying `recordBeat()` function in `rag/scenes.ts` validates the scene exists before inserting, returning the 0-based index of the newly appended beat.

## Changes
- `rag/scenes.ts`: Add `recordBeat(campaignPath, sceneId, beat)` — single-beat append with scene existence check, returns beat index
- `tools/narrative.ts`: Import `recordBeat` and `recordBeats`; add `record_beat` tool; add `append_beats` optional parameter to `update_scene`
- `rag/scenes.test.ts`: Five new tests for `recordBeat` covering happy path, sequential index assignment, persistence, appending to pre-existing beats, and invalid scene_id error
- `tools/narrative.test.ts`: Four new MCP client/server integration tests for the `record_beat` tool (happy path, sequential indices, persistence, invalid scene_id)
- `plugins/ironsworn/.claude-plugin/plugin.json`: Bump version 0.8.2 → 0.9.0 (minor — new tool)

## Testing
- `bun test` passes 291 tests across 22 files (0 failures)
- `bun tsc --noEmit` passes with 0 errors
- Ollama-dependent tests are automatically skipped when Ollama is not running

Closes #80