### PR TITLE
feat(scribe): auto-extract lore from scenes (closes #55)

### DIFF
--- a/plugins/ironsworn/.claude-plugin/plugin.json
+++ b/plugins/ironsworn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ironsworn",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "Solo Ironsworn GM companion — fiction-first, dice-driven, with a living lore graph",
   "author": {
     "name": "Karim Naguib"

--- a/plugins/ironsworn/commands/extract-session-lore.md
+++ b/plugins/ironsworn/commands/extract-session-lore.md
@@ -1,0 +1,15 @@
+---
+description: Extract lore entities and relations from all unprocessed scenes this session
+---
+
+Call the `extract_session_lore` MCP tool to batch-extract lore from all scenes recorded since the last extraction run.
+
+After the tool returns, report the results to the player in a brief, friendly summary:
+- How many scenes were processed vs skipped
+- How many entities were created and updated
+- How many relations were created
+- How many items were skipped (low confidence or unresolvable)
+
+If no scenes were processed (all already extracted), say so clearly.
+
+If the tool returns an error (e.g., missing ANTHROPIC_API_KEY), report the error directly.

--- a/plugins/ironsworn/scribe/src/rag/extraction.test.ts
+++ b/plugins/ironsworn/scribe/src/rag/extraction.test.ts
@@ -398,3 +398,27 @@ describe("extractUnprocessedScenes — batch skipping", () => {
     expect(batchReport.scenes_skipped).toBe(1);
   });
 });
+
+describe("extractLoreFromScene — beats fallback", () => {
+  it("uses scene summary text when no beats are present", async () => {
+    if (!(await ollamaAvailable())) return;
+
+    const { recordScene, exportScenes } = await import("./scenes.js");
+    // recordScene without beats — summary only
+    await recordScene(campaignDir, "The ironmaster forges a blade in silence.");
+    const scenes = await exportScenes(campaignDir);
+    const sceneId = scenes[scenes.length - 1]!.id;
+
+    let capturedSceneText = "";
+    const capturingExtractor: Extractor = async (sceneText, _existing) => {
+      capturedSceneText = sceneText;
+      return { entities: [], relations: [] };
+    };
+
+    await extractLoreFromScene(campaignDir, sceneId, {
+      extractor: capturingExtractor,
+    });
+
+    expect(capturedSceneText).toBe("The ironmaster forges a blade in silence.");
+  });
+});

--- a/plugins/ironsworn/scribe/src/rag/extraction.test.ts
+++ b/plugins/ironsworn/scribe/src/rag/extraction.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  extractLoreFromScene,
+  extractUnprocessedScenes,
+  _makeDefaultExtractor,
+  type Extractor,
+  type ExtractionResult,
+  type ExtractionReport,
+  type BatchReport,
+} from "./extraction.js";
+import { upsertLore, getLore } from "./lore.js";
+import { LORE_TYPES } from "./lore.js";
+
+let _ollamaReady: boolean | null = null;
+async function ollamaAvailable(): Promise<boolean> {
+  if (_ollamaReady !== null) return _ollamaReady;
+  try {
+    const baseUrl = process.env["OLLAMA_BASE_URL"] ?? "http://localhost:11434";
+    const res = await fetch(`${baseUrl}/api/embed`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model: "nomic-embed-text", input: "t" }),
+    });
+    _ollamaReady = res.ok;
+  } catch {
+    _ollamaReady = false;
+  }
+  return _ollamaReady;
+}
+
+let campaignDir: string;
+
+beforeEach(async () => {
+  campaignDir = await mkdtemp(join(tmpdir(), "scribe-extraction-test-"));
+});
+
+afterEach(async () => {
+  await rm(campaignDir, { recursive: true, force: true });
+});
+
+// Stub extractor — returns a fixed result, no LLM needed
+function makeStubExtractor(result: ExtractionResult): Extractor {
+  return async (_sceneText, _existingEntities) => result;
+}
+
+describe("_makeDefaultExtractor", () => {
+  it("is a function", () => {
+    expect(typeof _makeDefaultExtractor).toBe("function");
+  });
+});

--- a/plugins/ironsworn/scribe/src/rag/extraction.test.ts
+++ b/plugins/ironsworn/scribe/src/rag/extraction.test.ts
@@ -178,3 +178,65 @@ describe("extractLoreFromScene — dedup", () => {
     expect(lonaEntities.length).toBe(1);
   });
 });
+
+describe("extractLoreFromScene — idempotency", () => {
+  it("re-running extraction on the same scene produces no extra entities or relations", async () => {
+    if (!(await ollamaAvailable())) return;
+
+    const { recordScene, exportScenes } = await import("./scenes.js");
+    await recordScene(campaignDir, "Vera guards the gate of Stonehaven.");
+    const scenes = await exportScenes(campaignDir);
+    const sceneId = scenes[scenes.length - 1]!.id;
+
+    const stubResult: ExtractionResult = {
+      entities: [
+        {
+          canonical: "Vera",
+          type: "creature",
+          summary: "A guard at the gate of Stonehaven.",
+          aliases: [],
+          excerpt: "Vera guards the gate",
+          confidence: 0.9,
+        },
+        {
+          canonical: "Stonehaven",
+          type: "place",
+          summary: "A fortified settlement with a guarded gate.",
+          aliases: [],
+          excerpt: "gate of Stonehaven",
+          confidence: 0.95,
+        },
+      ],
+      relations: [
+        {
+          from: "Vera",
+          to: "Stonehaven",
+          relation: "guards",
+          excerpt: "Vera guards the gate of Stonehaven.",
+          confidence: 0.9,
+        },
+      ],
+    };
+
+    const report1 = await extractLoreFromScene(campaignDir, sceneId, {
+      extractor: makeStubExtractor(stubResult),
+    });
+    const report2 = await extractLoreFromScene(campaignDir, sceneId, {
+      extractor: makeStubExtractor(stubResult),
+    });
+
+    // First run: verify entities were created as expected
+    expect(report1.entities_created).toBe(2);
+
+    // Second run: Vera and Stonehaven are now existing entities → updated not created
+    expect(report2.entities_created).toBe(0);
+    expect(report2.entities_updated).toBe(2);
+    // relation is idempotent (linkLore uses ON CONFLICT)
+    expect(report2.relations_created).toBe(1);
+
+    const { exportLore } = await import("./lore.js");
+    const { entities } = await exportLore(campaignDir);
+    expect(entities.filter((e) => e.canonical === "Vera").length).toBe(1);
+    expect(entities.filter((e) => e.canonical === "Stonehaven").length).toBe(1);
+  });
+});

--- a/plugins/ironsworn/scribe/src/rag/extraction.test.ts
+++ b/plugins/ironsworn/scribe/src/rag/extraction.test.ts
@@ -323,3 +323,78 @@ describe("extractLoreFromScene — confidence threshold", () => {
     expect(report.skipped).toBe(1);
   });
 });
+
+describe("extractLoreFromScene — unresolvable relation endpoint", () => {
+  it("skips a relation when either endpoint entity does not exist in the graph", async () => {
+    if (!(await ollamaAvailable())) return;
+
+    const { recordScene, exportScenes } = await import("./scenes.js");
+    await recordScene(campaignDir, "The oracle serves the hidden god.");
+    const scenes = await exportScenes(campaignDir);
+    const sceneId = scenes[scenes.length - 1]!.id;
+
+    const stubResult: ExtractionResult = {
+      entities: [
+        {
+          canonical: "Oracle",
+          type: "creature",
+          summary: "A seer.",
+          aliases: [],
+          excerpt: "The oracle",
+          confidence: 0.9,
+        },
+        // "Hidden God" entity is NOT in the entities list so won't be in the graph
+      ],
+      relations: [
+        {
+          from: "Oracle",
+          to: "Hidden God", // not created → unresolvable
+          relation: "sworn_on",
+          excerpt: "The oracle serves the hidden god.",
+          confidence: 0.8,
+        },
+      ],
+    };
+
+    const report = await extractLoreFromScene(campaignDir, sceneId, {
+      extractor: makeStubExtractor(stubResult),
+    });
+
+    expect(report.relations_created).toBe(0);
+    expect(report.skipped).toBe(1);
+    expect(report.entities_created).toBe(1);
+  });
+});
+
+describe("extractUnprocessedScenes — batch skipping", () => {
+  it("skips already-logged scenes and processes only new ones", async () => {
+    if (!(await ollamaAvailable())) return;
+
+    const { recordScene } = await import("./scenes.js");
+
+    // Record two scenes
+    await recordScene(campaignDir, "Scene one: the wolf howls.");
+    await recordScene(campaignDir, "Scene two: the fire burns low.");
+
+    const { exportScenes } = await import("./scenes.js");
+    const scenes = await exportScenes(campaignDir);
+    expect(scenes.length).toBe(2);
+    const [scene1, scene2] = scenes as [typeof scenes[0], typeof scenes[0]];
+    // silence unused-variable warning from tsc; scene2 is implicitly the unprocessed one
+    void scene2;
+
+    const emptyResult: ExtractionResult = { entities: [], relations: [] };
+    const stubExtractor = makeStubExtractor(emptyResult);
+
+    // Extract scene1 first
+    await extractLoreFromScene(campaignDir, scene1.id, { extractor: stubExtractor });
+
+    // Now run batch — should skip scene1, process scene2 only
+    const batchReport = await extractUnprocessedScenes(campaignDir, {
+      extractor: stubExtractor,
+    });
+
+    expect(batchReport.scenes_processed).toBe(1);
+    expect(batchReport.scenes_skipped).toBe(1);
+  });
+});

--- a/plugins/ironsworn/scribe/src/rag/extraction.test.ts
+++ b/plugins/ironsworn/scribe/src/rag/extraction.test.ts
@@ -240,3 +240,86 @@ describe("extractLoreFromScene — idempotency", () => {
     expect(entities.filter((e) => e.canonical === "Stonehaven").length).toBe(1);
   });
 });
+
+describe("extractLoreFromScene — confidence threshold", () => {
+  it("low-confidence entity is upserted with needs_review=true", async () => {
+    if (!(await ollamaAvailable())) return;
+
+    const { recordScene, exportScenes } = await import("./scenes.js");
+    await recordScene(campaignDir, "A shadowy figure was seen near the ruins.");
+    const scenes = await exportScenes(campaignDir);
+    const sceneId = scenes[scenes.length - 1]!.id;
+
+    const stubResult: ExtractionResult = {
+      entities: [
+        {
+          canonical: "Shadowy Figure",
+          type: "creature",
+          summary: "An unidentified figure seen near ruins.",
+          aliases: [],
+          excerpt: "A shadowy figure was seen near the ruins.",
+          confidence: 0.4, // below default threshold of 0.6
+        },
+      ],
+      relations: [],
+    };
+
+    const report = await extractLoreFromScene(campaignDir, sceneId, {
+      extractor: makeStubExtractor(stubResult),
+    });
+
+    // Entity is still created, just flagged
+    expect(report.entities_created).toBe(1);
+    expect(report.skipped).toBe(0);
+
+    const entity = await getLore(campaignDir, "Shadowy Figure");
+    expect(entity).not.toBeNull();
+    expect(entity!.metadata["needs_review"]).toBe(true);
+  });
+
+  it("low-confidence relation is skipped entirely", async () => {
+    if (!(await ollamaAvailable())) return;
+
+    const { recordScene, exportScenes } = await import("./scenes.js");
+    await recordScene(campaignDir, "Perhaps the merchant knows the thane.");
+    const scenes = await exportScenes(campaignDir);
+    const sceneId = scenes[scenes.length - 1]!.id;
+
+    const stubResult: ExtractionResult = {
+      entities: [
+        {
+          canonical: "The Merchant",
+          type: "creature",
+          summary: "A traveling merchant.",
+          aliases: [],
+          excerpt: "the merchant",
+          confidence: 0.85,
+        },
+        {
+          canonical: "The Thane",
+          type: "creature",
+          summary: "A local leader.",
+          aliases: [],
+          excerpt: "the thane",
+          confidence: 0.85,
+        },
+      ],
+      relations: [
+        {
+          from: "The Merchant",
+          to: "The Thane",
+          relation: "allied_with",
+          excerpt: "Perhaps the merchant knows the thane.",
+          confidence: 0.3, // below threshold
+        },
+      ],
+    };
+
+    const report = await extractLoreFromScene(campaignDir, sceneId, {
+      extractor: makeStubExtractor(stubResult),
+    });
+
+    expect(report.relations_created).toBe(0);
+    expect(report.skipped).toBe(1);
+  });
+});

--- a/plugins/ironsworn/scribe/src/rag/extraction.test.ts
+++ b/plugins/ironsworn/scribe/src/rag/extraction.test.ts
@@ -130,3 +130,51 @@ describe("extractLoreFromScene — basic extraction", () => {
     expect(caldren!.type).toBe("place");
   });
 });
+
+describe("extractLoreFromScene — dedup", () => {
+  it("updates an existing entity when cosine similarity >= 0.92 instead of creating a duplicate", async () => {
+    if (!(await ollamaAvailable())) return;
+
+    // Pre-seed an entity for "Lona"
+    await upsertLore(campaignDir, {
+      canonical: "Lona",
+      type: "creature",
+      summary: "A healer in Caldren.",
+    });
+
+    const { recordScene } = await import("./scenes.js");
+    await recordScene(campaignDir, "Lona tends the sick.");
+    const { exportScenes } = await import("./scenes.js");
+    const scenes = await exportScenes(campaignDir);
+    const sceneId = scenes[scenes.length - 1]!.id;
+
+    const stubResult: ExtractionResult = {
+      entities: [
+        {
+          canonical: "Lona",
+          type: "creature",
+          summary: "Lona, the healer of Caldren, known for her skill.",
+          aliases: ["the healer Lona"],
+          excerpt: "Lona tends the sick.",
+          confidence: 0.9,
+        },
+      ],
+      relations: [],
+    };
+
+    const report = await extractLoreFromScene(campaignDir, sceneId, {
+      extractor: makeStubExtractor(stubResult),
+    });
+
+    expect(report.entities_created).toBe(0);
+    expect(report.entities_updated).toBe(1);
+
+    // Only one "lona" entity should exist
+    const { exportLore } = await import("./lore.js");
+    const { entities } = await exportLore(campaignDir);
+    const lonaEntities = entities.filter(
+      (e) => e.canonical.toLowerCase() === "lona",
+    );
+    expect(lonaEntities.length).toBe(1);
+  });
+});

--- a/plugins/ironsworn/scribe/src/rag/extraction.test.ts
+++ b/plugins/ironsworn/scribe/src/rag/extraction.test.ts
@@ -51,3 +51,82 @@ describe("_makeDefaultExtractor", () => {
     expect(typeof _makeDefaultExtractor).toBe("function");
   });
 });
+
+describe("extractLoreFromScene — basic extraction", () => {
+  it("creates entities and relations from a synthetic scene", async () => {
+    if (!(await ollamaAvailable())) return;
+
+    // We need a real scene in scenes.duckdb — import the scenes module directly
+    // to record a scene without going through the MCP tool layer.
+    const { recordScene } = await import("./scenes.js");
+    const sceneId = await recordScene(
+      campaignDir,
+      "Lona the healer tends to wounds in the village of Caldren. She serves the Thornwood faction.",
+    );
+
+    const stubResult: ExtractionResult = {
+      entities: [
+        {
+          canonical: "Lona",
+          type: "creature",
+          summary: "A healer who tends wounds in Caldren.",
+          aliases: ["the healer Lona"],
+          excerpt: "Lona the healer tends to wounds",
+          confidence: 0.9,
+        },
+        {
+          canonical: "Caldren",
+          type: "place",
+          summary: "A village where Lona practices healing.",
+          aliases: [],
+          excerpt: "the village of Caldren",
+          confidence: 0.95,
+        },
+        {
+          canonical: "Thornwood",
+          type: "faction",
+          summary: "A faction that Lona serves.",
+          aliases: [],
+          excerpt: "She serves the Thornwood faction.",
+          confidence: 0.85,
+        },
+      ],
+      relations: [
+        {
+          from: "Lona",
+          to: "Caldren",
+          relation: "located_in",
+          notes: "practices healing here",
+          excerpt: "Lona the healer tends to wounds in the village of Caldren",
+          confidence: 0.9,
+        },
+        {
+          from: "Lona",
+          to: "Thornwood",
+          relation: "member_of",
+          excerpt: "She serves the Thornwood faction.",
+          confidence: 0.85,
+        },
+      ],
+    };
+
+    const report = await extractLoreFromScene(campaignDir, sceneId, {
+      extractor: makeStubExtractor(stubResult),
+    });
+
+    expect(report.scene_id).toBe(sceneId);
+    expect(report.entities_created).toBe(3);
+    expect(report.entities_updated).toBe(0);
+    expect(report.relations_created).toBe(2);
+    expect(report.skipped).toBe(0);
+
+    // Verify entities are in the graph
+    const lona = await getLore(campaignDir, "Lona");
+    expect(lona).not.toBeNull();
+    expect(lona!.type).toBe("creature");
+
+    const caldren = await getLore(campaignDir, "Caldren");
+    expect(caldren).not.toBeNull();
+    expect(caldren!.type).toBe("place");
+  });
+});

--- a/plugins/ironsworn/scribe/src/rag/extraction.ts
+++ b/plugins/ironsworn/scribe/src/rag/extraction.ts
@@ -1,0 +1,361 @@
+import Anthropic from "@anthropic-ai/sdk";
+import { type AnthropicLike } from "./communities.js";
+import {
+  upsertLore,
+  searchLore,
+  linkLore,
+  getLore,
+  LORE_TYPES,
+  type LoreType,
+  type LoreSearchHit,
+} from "./lore.js";
+import { getLoreDb, openLoreWriteConn } from "./lore-db.js";
+import { getScene, exportScenes } from "./scenes.js";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface ExtractedEntity {
+  canonical: string;
+  type: LoreType;
+  summary: string;
+  aliases?: string[];
+  excerpt: string;
+  confidence: number;
+}
+
+export interface ExtractedRelation {
+  from: string;
+  to: string;
+  relation: string;
+  notes?: string;
+  excerpt: string;
+  confidence: number;
+}
+
+export interface ExtractionResult {
+  entities: ExtractedEntity[];
+  relations: ExtractedRelation[];
+}
+
+export interface ExtractionReport {
+  scene_id: string;
+  entities_created: number;
+  entities_updated: number;
+  relations_created: number;
+  skipped: number;
+}
+
+export interface BatchReport {
+  scenes_processed: number;
+  scenes_skipped: number;
+  entities_created: number;
+  entities_updated: number;
+  relations_created: number;
+  skipped_items: number;
+}
+
+export interface ExtractOptions {
+  confidenceThreshold?: number;
+  extractor?: Extractor;
+}
+
+export type Extractor = (
+  sceneText: string,
+  existingEntities: LoreSearchHit[],
+) => Promise<ExtractionResult>;
+
+// ---------------------------------------------------------------------------
+// Dedup threshold
+// ---------------------------------------------------------------------------
+
+const DEDUP_SIMILARITY_THRESHOLD = 0.92;
+
+// ---------------------------------------------------------------------------
+// Scene text builder (beats > summary fallback)
+// ---------------------------------------------------------------------------
+
+function buildSceneText(scene: Awaited<ReturnType<typeof getScene>>): string {
+  if (!scene) return "";
+  if (scene.beats && scene.beats.length > 0) {
+    return scene.beats
+      .map((b) => {
+        const speaker = b.speaker ? `${b.speaker}: ` : "";
+        return `[${b.beat_index}] (${b.kind}) ${speaker}${b.text}`;
+      })
+      .join("\n");
+  }
+  return scene.text;
+}
+
+// ---------------------------------------------------------------------------
+// Log helpers
+// ---------------------------------------------------------------------------
+
+async function writeExtractionLog(
+  campaignPath: string,
+  report: ExtractionReport,
+): Promise<void> {
+  const instance = await getLoreDb(campaignPath);
+  const conn = await openLoreWriteConn(instance);
+  try {
+    await conn.run(
+      `INSERT INTO lore_extraction_log
+         (scene_id, extracted_at, entities_created, entities_updated, relations_created, skipped)
+       VALUES (?, ?, ?, ?, ?, ?)
+       ON CONFLICT (scene_id) DO UPDATE SET
+         extracted_at      = EXCLUDED.extracted_at,
+         entities_created  = EXCLUDED.entities_created,
+         entities_updated  = EXCLUDED.entities_updated,
+         relations_created = EXCLUDED.relations_created,
+         skipped           = EXCLUDED.skipped`,
+      [
+        report.scene_id,
+        new Date().toISOString(),
+        report.entities_created,
+        report.entities_updated,
+        report.relations_created,
+        report.skipped,
+      ],
+    );
+  } finally {
+    conn.closeSync();
+  }
+}
+
+async function getLoggedSceneIds(campaignPath: string): Promise<Set<string>> {
+  const instance = await getLoreDb(campaignPath);
+  const conn = await instance.connect();
+  try {
+    const rows = (
+      await conn.runAndReadAll(`SELECT scene_id FROM lore_extraction_log`)
+    ).getRowObjectsJS() as Record<string, unknown>[];
+    return new Set(rows.map((r) => String(r["scene_id"])));
+  } finally {
+    conn.closeSync();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Core extraction
+// ---------------------------------------------------------------------------
+
+export async function extractLoreFromScene(
+  campaignPath: string,
+  sceneId: string,
+  opts?: ExtractOptions,
+): Promise<ExtractionReport> {
+  const threshold = opts?.confidenceThreshold ?? 0.6;
+  const extractor = opts?.extractor ?? defaultExtractor;
+
+  const scene = await getScene(campaignPath, sceneId, { include_beats: true });
+  if (scene === null) {
+    throw new Error(`Scene not found: ${sceneId}`);
+  }
+
+  const sceneText = buildSceneText(scene);
+  const existingEntities = await searchLore(campaignPath, sceneText, 10);
+  const result = await extractor(sceneText, existingEntities);
+
+  const report: ExtractionReport = {
+    scene_id: sceneId,
+    entities_created: 0,
+    entities_updated: 0,
+    relations_created: 0,
+    skipped: 0,
+  };
+
+  // Process entities
+  for (const entity of result.entities) {
+    if (!LORE_TYPES.includes(entity.type)) {
+      report.skipped++;
+      continue;
+    }
+
+    const hits = await searchLore(campaignPath, entity.canonical, 3);
+    const topHit = hits[0];
+    const isExisting = topHit !== undefined && topHit.score >= DEDUP_SIMILARITY_THRESHOLD;
+
+    const metadata: Record<string, unknown> = {};
+    if (entity.confidence < threshold) {
+      metadata["needs_review"] = true;
+    }
+
+    await upsertLore(campaignPath, {
+      ...(isExisting ? { id: topHit.id } : {}),
+      canonical: isExisting ? topHit.canonical : entity.canonical,
+      type: entity.type,
+      summary: entity.summary,
+      aliases: entity.aliases,
+      metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
+      provenance: {
+        source_kind: "extraction",
+        source_id: sceneId,
+        excerpt: entity.excerpt,
+        confidence: entity.confidence,
+      },
+    });
+
+    if (isExisting) {
+      report.entities_updated++;
+    } else {
+      report.entities_created++;
+    }
+  }
+
+  // Process relations
+  for (const rel of result.relations) {
+    if (rel.confidence < threshold) {
+      report.skipped++;
+      continue;
+    }
+
+    const fromEntity = await getLore(campaignPath, rel.from);
+    const toEntity = await getLore(campaignPath, rel.to);
+
+    if (fromEntity === null || toEntity === null) {
+      report.skipped++;
+      continue;
+    }
+
+    await linkLore(campaignPath, {
+      from: fromEntity.id,
+      to: toEntity.id,
+      relation: rel.relation,
+      notes: rel.notes,
+      provenance: {
+        source_kind: "extraction",
+        source_id: sceneId,
+        excerpt: rel.excerpt,
+        confidence: rel.confidence,
+      },
+    });
+
+    report.relations_created++;
+  }
+
+  await writeExtractionLog(campaignPath, report);
+  return report;
+}
+
+export async function extractUnprocessedScenes(
+  campaignPath: string,
+  opts?: ExtractOptions,
+): Promise<BatchReport> {
+  const [allScenes, loggedIds] = await Promise.all([
+    exportScenes(campaignPath),
+    getLoggedSceneIds(campaignPath),
+  ]);
+
+  const batch: BatchReport = {
+    scenes_processed: 0,
+    scenes_skipped: 0,
+    entities_created: 0,
+    entities_updated: 0,
+    relations_created: 0,
+    skipped_items: 0,
+  };
+
+  for (const scene of allScenes) {
+    if (loggedIds.has(scene.id)) {
+      batch.scenes_skipped++;
+      continue;
+    }
+    const report = await extractLoreFromScene(campaignPath, scene.id, opts);
+    batch.scenes_processed++;
+    batch.entities_created += report.entities_created;
+    batch.entities_updated += report.entities_updated;
+    batch.relations_created += report.relations_created;
+    batch.skipped_items += report.skipped;
+  }
+
+  return batch;
+}
+
+// ---------------------------------------------------------------------------
+// Default extractor (Anthropic Claude)
+// ---------------------------------------------------------------------------
+
+const DEFAULT_EXTRACTION_MODEL =
+  process.env["SCRIBE_SUMMARY_MODEL"] ?? "claude-haiku-4-5-20251001";
+
+const EXTRACTION_SYSTEM_PROMPT =
+  "You are extracting lore from a solo Ironsworn campaign scene. " +
+  "Return ONLY valid JSON matching the requested schema. No prose, no markdown fences.";
+
+export function _makeDefaultExtractor(client: AnthropicLike): Extractor {
+  return async (sceneText, existingEntities) => {
+    const existingContext =
+      existingEntities.length > 0
+        ? existingEntities
+            .map((e) => `${e.id}|${e.canonical}|${e.type}|${e.summary}`)
+            .join("\n")
+        : "(none)";
+
+    const userPrompt =
+      `Scene text:\n${sceneText}\n\n` +
+      `Existing lore entities for dedup (id|canonical|type|summary):\n${existingContext}\n\n` +
+      `Extract entities and relations newly revealed or changed in this scene.\n` +
+      `Entity types allowed: ${LORE_TYPES.join(", ")}.\n` +
+      `Preferred relation labels (use these or a close variant): ` +
+      `allied_with, enemy_of, member_of, leads, guards, located_in, created_by, corrupts, bound_to, sworn_on, seeks, opposes.\n` +
+      `For each item, provide the exact excerpt supporting it and a confidence 0.0–1.0.\n` +
+      `Confidence reflects how clearly the scene establishes this fact.\n\n` +
+      `Return ONLY this JSON object:\n` +
+      `{\n` +
+      `  "entities": [\n` +
+      `    { "canonical": string, "type": string, "summary": string, "aliases": string[], "excerpt": string, "confidence": number }\n` +
+      `  ],\n` +
+      `  "relations": [\n` +
+      `    { "from": string, "to": string, "relation": string, "notes": string, "excerpt": string, "confidence": number }\n` +
+      `  ]\n` +
+      `}`;
+
+    const response = await client.messages.create({
+      model: DEFAULT_EXTRACTION_MODEL,
+      max_tokens: 2048,
+      system: EXTRACTION_SYSTEM_PROMPT,
+      messages: [{ role: "user", content: userPrompt }],
+    });
+
+    const text = response.content
+      .flatMap((b) =>
+        b.type === "text" && typeof b.text === "string" ? [b.text] : [],
+      )
+      .join("")
+      .trim();
+
+    if (text.length === 0) {
+      throw new Error("Empty extraction response from Anthropic");
+    }
+
+    const parsed = JSON.parse(text) as ExtractionResult;
+    // Coerce types to valid LoreType, drop unknown types
+    parsed.entities = parsed.entities.filter((e) =>
+      LORE_TYPES.includes(e.type),
+    );
+    return parsed;
+  };
+}
+
+let _anthropicClient: Anthropic | null = null;
+function getAnthropic(): Anthropic {
+  if (_anthropicClient !== null) return _anthropicClient;
+  const apiKey = process.env["ANTHROPIC_API_KEY"];
+  if (!apiKey || apiKey.length === 0) {
+    throw new Error(
+      "ANTHROPIC_API_KEY is required for lore extraction. " +
+        "Set it in the env, or pass a custom `extractor` to extractLoreFromScene.",
+    );
+  }
+  _anthropicClient = new Anthropic({ apiKey });
+  return _anthropicClient;
+}
+
+function defaultExtractor(
+  sceneText: string,
+  existingEntities: LoreSearchHit[],
+): Promise<ExtractionResult> {
+  return _makeDefaultExtractor(getAnthropic())(sceneText, existingEntities);
+}

--- a/plugins/ironsworn/scribe/src/rag/lore-db.ts
+++ b/plugins/ironsworn/scribe/src/rag/lore-db.ts
@@ -118,6 +118,17 @@ async function initDb(campaignPath: string): Promise<DuckDBInstance> {
       CREATE INDEX IF NOT EXISTS lore_communities_level_idx
       ON lore_communities (level)
     `);
+
+    await conn.run(`
+      CREATE TABLE IF NOT EXISTS lore_extraction_log (
+        scene_id          TEXT PRIMARY KEY,
+        extracted_at      TEXT NOT NULL,
+        entities_created  INTEGER NOT NULL DEFAULT 0,
+        entities_updated  INTEGER NOT NULL DEFAULT 0,
+        relations_created INTEGER NOT NULL DEFAULT 0,
+        skipped           INTEGER NOT NULL DEFAULT 0
+      )
+    `);
   } finally {
     conn.closeSync();
   }

--- a/plugins/ironsworn/scribe/src/tools/lore.ts
+++ b/plugins/ironsworn/scribe/src/tools/lore.ts
@@ -14,6 +14,10 @@ import {
   listCommunities,
   getCommunity,
 } from "../rag/communities.js";
+import {
+  extractLoreFromScene,
+  extractUnprocessedScenes,
+} from "../rag/extraction.js";
 import { recordMutation } from "../checkpoint.js";
 
 export function register(server: McpServer, campaignPath: string): void {
@@ -209,6 +213,64 @@ export function register(server: McpServer, campaignPath: string): void {
       try {
         const community = await getCommunity(campaignPath, id);
         return { content: [{ type: "text", text: JSON.stringify(community) }] };
+      } catch (e) {
+        return {
+          content: [{ type: "text", text: `Error: ${e instanceof Error ? e.message : String(e)}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.tool(
+    "extract_lore_from_scene",
+    "Extract lore entities and relations from a recorded scene using Claude. " +
+      "Deduplicates against the existing graph. Upserts with provenance source_kind='extraction'. " +
+      "Requires ANTHROPIC_API_KEY.",
+    {
+      scene_id: z.string().describe("UUID of the scene to extract from"),
+      confidence_threshold: z
+        .coerce.number()
+        .min(0)
+        .max(1)
+        .optional()
+        .describe("Minimum confidence to accept an entity or relation (default 0.6)"),
+    },
+    async ({ scene_id, confidence_threshold }) => {
+      try {
+        const report = await extractLoreFromScene(campaignPath, scene_id, {
+          confidenceThreshold: confidence_threshold,
+        });
+        recordMutation(campaignPath);
+        return { content: [{ type: "text", text: JSON.stringify(report) }] };
+      } catch (e) {
+        return {
+          content: [{ type: "text", text: `Error: ${e instanceof Error ? e.message : String(e)}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.tool(
+    "extract_session_lore",
+    "Batch-extract lore from all scenes not yet processed. Skips scenes already in the extraction log. " +
+      "Processes scenes in recording order. Requires ANTHROPIC_API_KEY.",
+    {
+      confidence_threshold: z
+        .coerce.number()
+        .min(0)
+        .max(1)
+        .optional()
+        .describe("Minimum confidence to accept an entity or relation (default 0.6)"),
+    },
+    async ({ confidence_threshold }) => {
+      try {
+        const report = await extractUnprocessedScenes(campaignPath, {
+          confidenceThreshold: confidence_threshold,
+        });
+        recordMutation(campaignPath);
+        return { content: [{ type: "text", text: JSON.stringify(report) }] };
       } catch (e) {
         return {
           content: [{ type: "text", text: `Error: ${e instanceof Error ? e.message : String(e)}` }],


### PR DESCRIPTION
## Summary

Closes #55 — automatic lore extraction from recorded scenes via a single structured Claude call per scene.

- New `rag/extraction.ts` module with injectable `Extractor` (mirrors `communities.ts` pattern for testability)
- Dedups against the existing graph via `searchLore` at cosine ≥ 0.92 before upserting; all upserts carry `provenance: { source_kind: 'extraction', source_id, excerpt, confidence }`
- Low-confidence entities (< threshold, default 0.6) flagged with `metadata.needs_review = true`; low-confidence relations skipped entirely
- New `lore_extraction_log` DuckDB table tracks processed scenes; batch tool skips already-extracted scenes (idempotent)
- Two MCP tools: `extract_lore_from_scene` (per-scene) and `extract_session_lore` (batch)
- `/extract-session-lore` slash command wraps the batch tool for end-of-session use
- Plugin version bumped 0.9.1 → 0.10.0

## Test plan

- [x] 9 test cases in `extraction.test.ts`, guarded by `ollamaAvailable()` so they skip cleanly when Ollama is unreachable:
  - basic extraction creates entities + relations
  - dedup: existing entity updated, not duplicated
  - idempotency: re-running produces no extra entities/relations
  - low-confidence entity flagged `needs_review`
  - low-confidence relation skipped
  - unresolvable relation endpoint skipped
  - batch skips already-logged scenes
  - summary fallback when scene has no beats
  - injectable Extractor pattern exposed
- [x] Full suite: 300 passing, 0 failing
- [x] `bun run tsc --noEmit` clean
- [ ] Manual smoke: record a scene with beats → `/extract-session-lore` → confirm entities land in `lore.duckdb` with `source_kind='extraction'` provenance

🤖 Generated with [Claude Code](https://claude.com/claude-code)
