### PR TITLE
feat(skill): add ironsworn-social mode-of-play skill (#96)

### DIFF
--- a/plugins/ironsworn/.claude-plugin/plugin.json
+++ b/plugins/ironsworn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ironsworn",
-  "version": "0.14.0",
+  "version": "0.13.0",
   "description": "Solo Ironsworn GM companion — fiction-first, dice-driven, with a living lore graph",
   "author": {
     "name": "Karim Naguib"

--- a/plugins/ironsworn/.claude-plugin/plugin.json
+++ b/plugins/ironsworn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ironsworn",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Solo Ironsworn GM companion — fiction-first, dice-driven, with a living lore graph",
   "author": {
     "name": "Karim Naguib"

--- a/plugins/ironsworn/skills/ironsworn-social/SKILL.md
+++ b/plugins/ironsworn/skills/ironsworn-social/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: ironsworn-social
+description: >
+  Governs Ironsworn social mode of play: Compel, Sojourn, Forge a Bond, Test
+  Your Bond, Aid Your Ally, and Write Your Epilogue. ALWAYS invoke this skill
+  when the player says things like "I sojourn", "I want to forge a bond",
+  "let's test our bond", "I compel them", "I try to persuade", "I aid my ally",
+  "I want to write your epilogue", or "I retire", or whenever the GM is about
+  to resolve a relationship move, increment bonds, or run a recovery scene in
+  a community. Owns the NPC-mutation and thread-management sequences that
+  follow social outcomes (promises, debts, retirement). Defers NPC voice and
+  reactions to ironsworn-npc-voice; defers vow advancement to
+  ironsworn-progress-tracks.
+---
+
+# Ironsworn Social Mode of Play
+
+Social moves resolve persuasion, recovery in community, and the relationships that anchor the character to the Ironlands. This skill is the single source of truth for **how** these moves resolve, what tool calls follow each outcome, and where social play hands off to other skills.
+
+---
+
+## Tools This Skill Governs
+
+| Tool | When |
+|---|---|
+| `resolve_move` | Compel, Sojourn, Forge a Bond, Test Your Bond, Aid Your Ally, Write Your Epilogue (action rolls) |
+| `roll_progress` | Write Your Epilogue (progress roll on bonds) |
+| `override` (path=`bonds`) | Increment / clear `bonds` after Forge a Bond or Test Your Bond outcomes |
+| `get_character_digest` | Read current `bonds` value before mutating |
+| `upsert_npc` | Record a new NPC, or update impression after a beat |
+| `open_thread` (kind=`debt`) | Compel weak hit, Forge a Bond weak hit (they ask for something) |
+| `open_thread` (kind=`vow`) | If the price/promise rises to an Iron Vow |
+| `close_thread` | Promise fulfilled, or bond cleared |
+| `restore_health` / `restore_spirit` / `restore_supply` / `take_momentum` / `clear_debility` | Sojourn recovery actions |
+| `search_lore_global`, `get_npc`, `get_community` | Fiction Grounding Protocol — read BEFORE inventing |
+| `roll_oracle` | "Envision what they want" / "Envision it" prompts |
+
+---
+
+## When to Invoke This Skill
+
+- One of the six moves above is being triggered.
+- The player says "I sojourn", "forge a bond", "test our bond", "compel", "aid my ally", "write your epilogue", or "I retire".
+- About to call `override(path="bonds", ...)` — bonds only move on social outcomes.
+- A Sojourn recovery menu is needed.
+- An NPC has just made a demand or asked a favor (Compel weak, Forge a Bond weak, Test Your Bond weak).
+
+For NPC voice and reactions, defer to `ironsworn-npc-voice`. For vow milestones triggered by a social beat, defer to `ironsworn-progress-tracks`.
+
+---
+
+## Fiction Grounding Protocol (#103)
+
+Before narrating any non-trivial social beat, call `search_lore_global` (and `get_npc` / `get_community` when the entity is named). Pull what is already established — disposition, debts, prior bonds, community truths — and let those facts shape the scene. **Never invent a new fact about a known NPC or community without checking first.** If a fact is missing, `roll_oracle` and then `upsert_npc` / `upsert_lore` so it is durable.
+
+---
+
+## The Six Moves
+
+### Compel
+**Trigger:** persuade someone to do something. **Stat:** heart (charm/barter), iron (threaten/incite), or shadow (lie/swindle).
+
+- Strong → they comply or share. `take_momentum amount=1`. Chain into Gather Information at +1 if the player wants.
+- Weak → they comply, but want something back. `roll_oracle` for the demand, then `open_thread` (kind=`debt`). `take_momentum amount=1`.
+- Miss → refusal or costly demand. **Pay the Price** (defer to `ironsworn-suffer`).
+
+**Fiction Notes.** Compel is leverage, not always charm. The chosen stat is the lens — narrate to match: iron threatens, heart appeals, shadow deceives. A weak-hit debt is a *thread*, not an off-hand promise — track it.
+
+### Sojourn
+**Trigger:** spend time in a community seeking assistance. **Stat:** heart.
+
+- Strong → choose **two** menu items.
+- Weak → choose **one**.
+- Miss → no recovery, **Pay the Price**.
+
+After choosing, the player may **focus** one chosen *Recover* action: re-roll +heart (+1 if bonded to the community), strong=+2 to that action, weak=+1, miss=lose all benefits *for that focused action only*. Full menu and tool sequence in `references/sojourn.md`.
+
+**Sojourn vs Make Camp.** Sojourn requires a community and uses heart. Make Camp is wilderness recovery on a journey and uses supply (see `ironsworn-progress-tracks`). If the character is in a settlement asking for help, it's Sojourn; if resting in the wild between waypoints, it's Make Camp.
+
+**Fiction Notes.** Sojourn is *a scene of welcome or grudging tolerance*, not a vending machine. Who greets the Ironsworn? What is the price of hospitality? Even a strong hit can carry social weight — debts, news, oaths.
+
+### Forge a Bond
+**Trigger:** significant time, shared hardship, or sacrifice for a person or community. **Stat:** heart.
+
+- Strong → bond made. Read `bonds` via `get_character_digest`, then `override(path="bonds", value=N+1)`. Choose: `+1 spirit` or `+2 momentum`.
+- Weak → they ask for one more proof. `roll_oracle`, then either play it out OR `open_thread` (kind=`vow`) and Swear an Iron Vow. Mark the bond on success; **Pay the Price** on refusal/failure.
+- Miss → rejected. **Pay the Price.**
+
+**Fiction Notes.** Bonds are slow. The fiction must show *time, hardship, or sacrifice* — narrate the weight. After a strong hit, also `upsert_npc` (or `upsert_lore` for a community) recording the bond. `bonds` is a plain integer, not a progress track.
+
+### Test Your Bond
+**Trigger:** a bond is tested by conflict, betrayal, or circumstance. **Stat:** heart.
+
+- Strong → bond strengthened. Choose: `+1 spirit` or `+2 momentum`. **No bond increment** — already counted at forging.
+- Weak → bond is fragile. `roll_oracle`, prove loyalty (or Swear). Refuse/fail → **clear the bond** (`override(path="bonds", value=N-1)`) and **Pay the Price**.
+- Miss → **clear the bond** and **Pay the Price**.
+
+**Fiction Notes.** Testing surfaces what was always there — whatever the NPC asks for must echo the bond's origin, not a random favor. A cleared bond is a wound; reflect it in fiction and `upsert_npc` impression.
+
+### Aid Your Ally
+**Trigger:** Secure an Advantage in direct support of an ally. Resolve **as Secure an Advantage** with the bonus handed to the ally's next move. No separate outcome table.
+
+**Fiction Notes.** Aid is a fiction frame on an existing move. Decide the supporting action (cover, feint, scout, reassure), pick the stat that matches, and resolve as Secure an Advantage — the result modifies the ally's next roll, not yours.
+
+### Write Your Epilogue
+**Trigger:** the character retires from the life of the Ironsworn. This is a **progress roll on bonds**, not an action roll: use `roll_progress` (treat each filled bond, up to 10, as a filled progress box).
+
+- Strong → things come to pass as hoped.
+- Weak → an unexpected turn — narrate the new life (`roll_oracle` if unsure).
+- Miss → fears realized.
+
+After resolution, the campaign closes for that character. **Fiction Notes.** Epilogue is the *cost-benefit ledger of bonds* paying out — few bonds risks isolation, many cashes them in for the life earned. Run it as montage, not scene.
+
+---
+
+## Common Mistakes
+
+- **Forge a Bond strong hit increments the integer `bonds` field**, not a progress track. Read with `get_character_digest`, write with `override(path="bonds", value=N+1)`.
+- **Test Your Bond strong hit does NOT increment** — the bond was forged already.
+- **A weak-hit promise is a thread.** `open_thread` (debt or vow). Don't trust memory.
+- **Don't conflate Sojourn with Make Camp** — community heart vs wilderness supply.
+- **Aid Your Ally is not a separate roll table** — it's Secure an Advantage with the bonus given to the ally.
+- **Write Your Epilogue uses `roll_progress` on bonds**, not `resolve_move`. It ends the campaign for that character.
+- **Ground in lore first** — `search_lore_global` / `get_npc` before inventing motives, debts, or community history.
+
+---
+
+## References
+
+- `references/sojourn.md` — full Sojourn outcome tables, recovery menus, focused option, Sojourn-vs-Make-Camp decision tree, tool sequence.
+- `references/moves.md` — full outcome text for Compel, Forge a Bond, Test Your Bond, Aid Your Ally, Write Your Epilogue.
+- `references/scenarios.md` — worked examples per move.

--- a/plugins/ironsworn/skills/ironsworn-social/references/moves.md
+++ b/plugins/ironsworn/skills/ironsworn-social/references/moves.md
@@ -1,0 +1,173 @@
+# Social Moves — Full Outcome Reference
+
+Outcome text below is from `data/moves.yaml`. Tool sequences and clarifications are added.
+
+---
+
+## Compel
+
+**Trigger.** When you attempt to persuade someone to do something.
+
+**Stats.** heart, iron, or shadow. Hint: *Charm, pacify, barter, or convince* (heart); *Threaten or incite* (iron); *Lie or swindle* (shadow).
+
+**Outcomes.**
+
+| Result | Text |
+|---|---|
+| Strong hit | They'll do what you want or share what they know. Take +1 momentum. If you use this exchange to Gather Information, make that move now and add +1. |
+| Weak hit | They'll do what you want or share what they know... but they ask something of you in return. Envision what they want (Ask the Oracle if unsure). Take +1 momentum. If you use this exchange to Gather Information, make that move now and add +1. |
+| Miss | They refuse or make a demand which costs you greatly. Pay the Price. |
+
+**Tool sequence (strong hit).**
+1. `resolve_move move="Compel" stat=<heart|iron|shadow>`.
+2. `take_momentum amount=1`.
+3. (Optional) `resolve_move move="Gather Information" stat="wits" adds=1`.
+
+**Tool sequence (weak hit).**
+1. `resolve_move move="Compel" stat=<…>`.
+2. `roll_oracle` for what they want (e.g., `roll_oracle "action"` + `roll_oracle "theme"`).
+3. `open_thread title="<obligation summary>" kind="debt" notes="<NPC asked for X in exchange for Y>"`.
+4. `take_momentum amount=1`.
+5. (Optional Gather Information chain.)
+
+**Tool sequence (miss).**
+1. `resolve_move move="Compel" stat=<…>`.
+2. Pay the Price — defer to `ironsworn-suffer` for the consequence selection.
+
+**Stat choice.** The stat *is* the approach:
+- **heart** — sincere appeal, charm, fellowship.
+- **iron** — threat, intimidation, force of will.
+- **shadow** — lie, manipulation, false promise.
+
+A miss on shadow can ruin a relationship; a miss on iron can start a fight. Pay the Price should reflect the lens.
+
+---
+
+## Forge a Bond
+
+**Trigger.** When you spend significant time with a person or community, stand together to face hardships, or make sacrifices for their cause.
+
+**Stat.** heart.
+
+**Outcomes.**
+
+| Result | Text |
+|---|---|
+| Strong hit | Make note of the bond, mark a tick on your bond progress track, and choose one: +1 spirit OR +2 momentum. |
+| Weak hit | They ask something more of you first. Envision what it is (Ask the Oracle if unsure), do it (or Swear an Iron Vow), and mark the bond. If you refuse or fail, Pay the Price. |
+| Miss | They reject you. Pay the Price. |
+
+**Important.** "Mark a tick on your bond progress track" — in this campaign system `bonds` is a plain integer (max 10), not a 40-tick progress track. Each Forge a Bond strong hit increments it by 1. See `ironsworn-progress-tracks` § Bonds.
+
+**Tool sequence (strong hit).**
+1. `resolve_move move="Forge a Bond" stat="heart"`.
+2. `get_character_digest` — read current `bonds` value (call it `N`).
+3. `override path="bonds" value=<N+1>`.
+4. Player chooses: `restore_spirit amount=1` OR `take_momentum amount=2`.
+5. `upsert_npc name="<n>" impression="bonded — <fiction note>"` (or `upsert_lore` for a community/faction).
+
+**Tool sequence (weak hit).**
+1. `resolve_move move="Forge a Bond" stat="heart"`.
+2. `roll_oracle` to find what they ask for.
+3. Play it out (resolve as moves) OR — if it's a quest — `open_thread title="<vow>" kind="vow" rank=<…>` and `resolve_move move="Swear an Iron Vow" stat="heart" adds=1`.
+4. On success, mark the bond as in the strong-hit sequence.
+5. On refusal/failure, Pay the Price.
+
+**Tool sequence (miss).**
+1. `resolve_move move="Forge a Bond" stat="heart"`.
+2. Pay the Price.
+3. `upsert_npc impression="rejected the bond — <reason>"` to record the refusal.
+
+---
+
+## Test Your Bond
+
+**Trigger.** When your bond is tested through conflict, betrayal, or circumstance.
+
+**Stat.** heart.
+
+**Outcomes.**
+
+| Result | Text |
+|---|---|
+| Strong hit | This test has strengthened your bond. Choose one: +1 spirit OR +2 momentum. |
+| Weak hit | Your bond is fragile and you must prove your loyalty. Envision what they ask of you (Ask the Oracle if unsure), and do it (or Swear an Iron Vow). If you refuse or fail, clear the bond and Pay the Price. |
+| Miss | Clear the bond and Pay the Price. |
+
+**Important.** Strong hit does **not** increment `bonds` — the bond was already counted at forging. Weak/miss "clear the bond" means decrement `bonds` by 1.
+
+**Tool sequence (strong hit).**
+1. `resolve_move move="Test Your Bond" stat="heart"`.
+2. Player chooses: `restore_spirit amount=1` OR `take_momentum amount=2`.
+3. `upsert_npc impression="bond strengthened — <fiction>"` (optional).
+
+**Tool sequence (weak hit, succeed).**
+1. `resolve_move`.
+2. `roll_oracle` to find what they ask.
+3. Play it out, or open a vow thread.
+4. On success, the bond holds — no mechanical change.
+
+**Tool sequence (weak hit fail / miss).**
+1. `resolve_move`.
+2. `get_character_digest` — read `bonds` (call it `N`).
+3. `override path="bonds" value=<max(0, N-1)>`.
+4. Pay the Price.
+5. `upsert_npc impression="bond broken — <reason>"`.
+
+---
+
+## Aid Your Ally
+
+**Trigger.** When you Secure an Advantage in direct support of an ally.
+
+**Resolution.** This is **Secure an Advantage** narrated as supporting an ally. The bonus modifies the ally's next move, not your own. There is no separate outcome table — the data file lists empty outcomes intentionally.
+
+**Tool sequence.**
+1. Decide the supporting action and stat (cover, feint, scout, reassure → iron / shadow / wits / heart respectively).
+2. `resolve_move move="Secure an Advantage" stat=<…>` — narrate as Aid Your Ally.
+3. On hit, the ally's next action move adds the bonus from Secure an Advantage to their roll. (This is a fiction-tracked benefit; no tool call captures the +adds — just remember to apply it on the ally's next `resolve_move`.)
+4. On miss, **Pay the Price** — and consider whether the ally's situation worsens.
+
+In solo play, "ally" is typically a companion asset or NPC. In coop or guided play with another PC, the bonus goes to that PC's next move.
+
+---
+
+## Write Your Epilogue
+
+**Trigger.** When you retire from your life as Ironsworn.
+
+**Roll type.** **Progress roll** on `bonds`, not an action roll.
+
+**Outcomes.**
+
+| Result | Text |
+|---|---|
+| Strong hit | Things come to pass as you had hoped. |
+| Weak hit | Your life takes an unexpected turn, but not necessarily for the worse. You find yourself spending your days with someone or in a place you did not foresee. Envision it (Ask the Oracle if unsure). |
+| Miss | Your fears are realized. |
+
+**Mapping bonds to a progress score.** A progress roll counts *fully filled boxes* (0 to 10). Treat the integer `bonds` value directly as the progress score: 0–10 filled boxes. There is no rank — this is a special move where bonds *are* the track.
+
+**Tool sequence.**
+1. `get_character_digest` to confirm `bonds` value.
+2. `roll_progress` — but no track is registered for bonds. **Workaround:** roll the challenge dice manually with `roll_dice spec="2d10"` and compare the bonds value (capped at 10) against each die.
+   - `bonds > both dice` → strong hit
+   - `bonds > one die` → weak hit
+   - `bonds ≤ both` → miss
+3. Narrate the epilogue based on the band. Use `roll_oracle` for the "envision" prompts on weak/miss.
+4. `record_scene` summarizing the retirement.
+5. The campaign closes for this character. No XP. No further moves.
+
+If the campaign uses a custom bonds-as-track configuration (some games convert bonds into a 10-box track), `roll_progress` may work natively — check campaign config first.
+
+---
+
+## Cross-Skill Hand-Offs
+
+| Situation | Skill |
+|---|---|
+| NPC voice, mannerism, dialect, reaction | `ironsworn-npc-voice` |
+| Vow advancement triggered by social outcome | `ironsworn-progress-tracks` (call `reach_milestone`) |
+| Pay the Price selection | `ironsworn-suffer` |
+| Make Camp (wilderness recovery) | `ironsworn-progress-tracks` |
+| Oracle prompts and "envision what they want" | `ironsworn-oracle` (or direct `roll_oracle`) |

--- a/plugins/ironsworn/skills/ironsworn-social/references/scenarios.md
+++ b/plugins/ironsworn/skills/ironsworn-social/references/scenarios.md
@@ -1,0 +1,159 @@
+# Worked Scenarios
+
+Realistic walk-throughs showing tool sequences and fiction grounding for each move.
+
+---
+
+## Scenario 1: Compel — heart approach, weak hit
+
+**Setup.** The Ironsworn has been turned away at the gates of a logging hamlet. They want the gatekeeper to let them in.
+
+**Ground.**
+```
+search_lore_global query="logging hamlet gatekeeper"
+get_community name="Westwood"     # if known
+```
+Returns: Westwood is suspicious of outsiders after a raider attack last winter. The gatekeeper, Hild, lost a brother in that raid.
+
+**Roll.**
+```
+resolve_move move="Compel" stat="heart"
+```
+Result: weak hit. Action 5+heart 2+adds 0 = 7; challenge dice 6, 9.
+
+**Fiction grounding informs the demand.** Hild lost a brother. She doesn't want a coin or a story; she wants the Ironsworn to **swear they will hunt the raiders if they come back**.
+
+```
+roll_oracle table="action+theme"   # confirmation, e.g. "Defend / Family"
+open_thread title="Hild's promise: hunt the raiders" kind="debt" \
+    notes="If raiders return, Ironsworn must defend Westwood"
+take_momentum amount=1
+```
+
+The Ironsworn passes the gate. The thread is now durable — if raiders return next session, the GM has the obligation tracked.
+
+---
+
+## Scenario 2: Sojourn — strong hit with focus
+
+**Setup.** Ironsworn arrives at the bonded community of Stonewall after a hard journey. Wounded, low spirit, low supply.
+
+**Ground.** `get_community name="Stonewall"` — Stonewall is a fortified mining town, the Ironsworn forged a bond two sessions ago for defending it from drogs.
+
+**Roll.**
+```
+resolve_move move="Sojourn" stat="heart"
+```
+Strong hit. Two picks.
+
+**Player chooses.** Mend (clear wounded, +1 health) and Plan (+2 momentum).
+
+```
+clear_debility name="wounded"
+restore_health amount=1
+take_momentum amount=2
+```
+
+**Focus.** Player focuses on Plan. Bonded to Stonewall → +1 to the focused roll.
+```
+resolve_move move="Sojourn" stat="heart" focused=true adds=1
+```
+Strong hit on the focus. +2 more momentum on Plan.
+```
+take_momentum amount=2
+```
+Net momentum gain: +4. Net health: +1, wounded cleared. Other recovery (spirit, supply) was not picked.
+
+```
+record_scene title="Welcomed at Stonewall" \
+    summary="Stonewall received the Ironsworn warmly, mended wounds, and shared news of orcish movement. Bond reaffirmed."
+```
+
+---
+
+## Scenario 3: Forge a Bond — strong hit
+
+**Setup.** After three sessions traveling and fighting alongside Olaric, a wandering scribe, the Ironsworn formally Forges a Bond.
+
+**Ground.** `get_npc name="Olaric"` — Olaric is a scribe seeking lost histories of the old kingdom; bonded to no one yet.
+
+**Roll.**
+```
+resolve_move move="Forge a Bond" stat="heart"
+```
+Strong hit.
+
+```
+get_character_digest    # returns bonds: 2
+override path="bonds" value=3
+take_momentum amount=2  # player's choice over +1 spirit
+upsert_npc name="Olaric" impression="bonded — fellow seekers of the old histories"
+```
+
+The bond is now persistent — appears in `bonds` count, in Olaric's NPC entry, and influences Sojourn focused-roll bonuses if Olaric represents a community (he doesn't, but the principle holds for community-level bonds).
+
+---
+
+## Scenario 4: Test Your Bond — weak hit, refuse, clear bond
+
+**Setup.** The Ironsworn is bonded to the Wardens, a militia. The Wardens demand the Ironsworn lead a punitive raid on a neighboring village suspected of harboring a thief. The Ironsworn believes the village is innocent.
+
+**Roll.**
+```
+resolve_move move="Test Your Bond" stat="heart"
+```
+Weak hit.
+
+`roll_oracle` confirms: the Wardens want the Ironsworn to lead the raid personally — proof of loyalty.
+
+The player **refuses** on principle.
+
+```
+get_character_digest    # bonds: 4
+override path="bonds" value=3
+upsert_npc name="The Wardens" impression="bond broken — refused to raid Greenhill village"
+```
+
+Pay the Price (defer to `ironsworn-suffer`). The Wardens are now hostile or distant.
+
+---
+
+## Scenario 5: Aid Your Ally — companion in trouble
+
+**Setup.** Companion Hound is being pulled down by a swamp creature. Player wants to Aid Your Ally.
+
+**Choice.** The Ironsworn fires a warning bolt to give Hound an opening — wits-based feint.
+
+```
+resolve_move move="Secure an Advantage" stat="wits"
+```
+Strong hit, +2 to next roll.
+
+The bonus is given to **Hound's next action**. On Hound's roll (resolve as a companion move or as a contested check), apply +2 adds.
+
+No tool call captures the +adds for "next move on someone else" — track it in conversation and apply at the next `resolve_move` for Hound.
+
+---
+
+## Scenario 6: Write Your Epilogue — campaign close
+
+**Setup.** After 30+ sessions, the Ironsworn (Eira) has fulfilled her background vow and decides to retire. `bonds = 7`.
+
+**Ground.** `search_lore_global query="Eira"` — pulls bonds: Stonewall, Olaric, the Wardens (broken), her brother Aelric, the village of Greenhill, Captain Vrek, and Sister Mira. (7 net after one broken.)
+
+**Roll.**
+```
+roll_dice spec="2d10"     # challenge dice: e.g. 4 and 9
+```
+Compare 7 (bonds) vs 4 and 9: 7 > 4 (yes), 7 > 9 (no). **Weak hit.**
+
+**Outcome.** "Your life takes an unexpected turn, but not necessarily for the worse." `roll_oracle` for the new life.
+
+The oracle returns: "Quiet teaching." Eira does not return to Stonewall, nor to Olaric. She becomes a teacher in Greenhill — the very village she once defended from the Wardens. A life she had not foreseen, but earned by her bonds.
+
+```
+record_scene title="Epilogue: Eira" \
+    summary="Eira retires to Greenhill. She becomes a village teacher, surrounded by children who will never know what she carried."
+```
+
+The campaign closes for Eira.

--- a/plugins/ironsworn/skills/ironsworn-social/references/sojourn.md
+++ b/plugins/ironsworn/skills/ironsworn-social/references/sojourn.md
@@ -1,0 +1,115 @@
+# Sojourn — Full Reference
+
+**Trigger.** When you spend time in a community seeking assistance.
+
+**Stat.** heart (only).
+
+**Roll.** action roll via `resolve_move` with `move="Sojourn"`, `stat="heart"`.
+
+---
+
+## Initial Outcome
+
+| Result | Effect |
+|---|---|
+| Strong hit | You and your allies may each choose **two** from the menu below. |
+| Weak hit | You and your allies may each choose **one** from the menu below. |
+| Miss | The community offers nothing. **Pay the Price.** |
+
+---
+
+## Recovery Menu
+
+Three categories. Each chosen item is one menu pick.
+
+### Clear a Condition
+
+| Option | Effect | Tool |
+|---|---|---|
+| Mend | Clear `wounded` debility, +1 health | `clear_debility name="wounded"` then `restore_health amount=1` |
+| Hearten | Clear `shaken` debility, +1 spirit | `clear_debility name="shaken"` then `restore_spirit amount=1` |
+| Equip | Clear `unprepared` debility, +1 supply | `clear_debility name="unprepared"` then `restore_supply amount=1` |
+
+### Recover
+
+| Option | Effect | Tool |
+|---|---|---|
+| Recuperate | +2 health for self and any companions | `restore_health amount=2`; for each companion: `companion_restore_health companion_name=<n> amount=2` |
+| Consort | +2 spirit | `restore_spirit amount=2` |
+| Provision | +2 supply | `restore_supply amount=2` |
+| Plan | +2 momentum | `take_momentum amount=2` |
+
+### Provide Aid
+
+| Option | Effect | Tool |
+|---|---|---|
+| Take a quest | Envision community's need (or `roll_oracle`). If you choose to help, **Swear an Iron Vow with +1**. | `open_thread` (kind=`vow`, rank=…), then `resolve_move` "Swear an Iron Vow" with adds=1 |
+
+---
+
+## Focused Option (after the initial roll)
+
+After picking menu items, the player may **focus** on **one** chosen *Recover* action. Re-roll Sojourn with `focused=true`:
+
+```
+resolve_move move="Sojourn" stat="heart" focused=true
+   adds=<+1 if bonded to this community, else 0>
+```
+
+| Focused result | Bonus to that one action |
+|---|---|
+| Strong hit | +2 more |
+| Weak hit | +1 more |
+| Miss | Lose ALL benefits for *that focused action only* (other menu picks remain) |
+
+So a strong-hit Sojourn with a strong-hit focus on Plan = +2 momentum + +2 momentum = +4 momentum on the focused pick (the other menu pick is unaffected).
+
+The +1 if bonded to the community: read `bonds`-related lore via `get_community` or `search_lore_global`. The bond bonus applies once, on the focused re-roll only.
+
+---
+
+## Sojourn vs Make Camp — Decision Tree
+
+```
+Is the character in a settlement / community asking for help?
+├── Yes → SOJOURN (heart). This skill.
+└── No → Are they on a journey, resting in the wilds?
+        ├── Yes → MAKE CAMP (supply). Defer to ironsworn-progress-tracks.
+        └── No → Neither move; narrate a quiet beat or invoke another move.
+```
+
+Key differences:
+
+| | Sojourn | Make Camp |
+|---|---|---|
+| Stat | heart | wits (supply gate) |
+| Cost | -1 supply for the visit if relevant fiction; otherwise none | -1 supply automatic |
+| Setting | community / settlement / camp of allies | wilderness, on a journey track |
+| Recovery menu | health, spirit, supply, momentum, debilities, quests | health, spirit, momentum, prepare for next Undertake |
+| Bond bonus | +1 to focused re-roll if bonded to community | +1 to first Undertake roll if bonded community is the start |
+| Skill | `ironsworn-social` | `ironsworn-progress-tracks` |
+
+If the player is unclear about which mode they are in, ask: "Are you in a settlement, or out on the trail?"
+
+---
+
+## Tool Sequence (full Sojourn beat)
+
+1. **Ground.** `search_lore_global query="<community name>"` and/or `get_community name="<n>"`. Pull tone, NPCs, prior debts.
+2. **Resolve.** `resolve_move move="Sojourn" stat="heart"`.
+3. **Apply.** Based on the band, present the menu (1 or 2 picks). For each pick, call the matching tool.
+4. **Offer focus.** If at least one Recover action was picked, ask if the player wants to focus on one. If yes, `resolve_move move="Sojourn" stat="heart" focused=true adds=<bond bonus>`.
+5. **Apply focused bonus or loss.** Strong/weak adds to the focused action; miss removes its benefits.
+6. **Persist fiction.** `upsert_npc` for any new NPCs met; `record_scene` summarizing the visit; `open_thread` for any quest taken or debt incurred.
+
+---
+
+## Fiction Notes (extended)
+
+A Sojourn scene is a *social transaction*, not a vending machine. The recovery menu represents what the community is willing or able to give. Even a strong hit can carry social weight:
+
+- A community at war may give Mend and Equip but with the unspoken expectation the Ironsworn will fight for them.
+- A community that distrusts the Ironsworn may grudgingly Provision but refuse Take a quest — narrate the cold welcome.
+- A bonded community may offer warmth that exceeds the menu's mechanical benefit; the +1 to focused roll is the mechanical reflection of that.
+
+Always ask: who runs this place? Who greets the Ironsworn at the gate? Who watches them eat? What price — explicit or implicit — comes with hospitality?


### PR DESCRIPTION
## Summary

- New `ironsworn-social` skill governs the social mode of play: Compel, Sojourn, Forge a Bond, Test Your Bond, Aid Your Ally, Write Your Epilogue.
- Per-move tool sequences explicitly chain `resolve_move` / `override(path="bonds", ...)` / `open_thread` / `upsert_npc` / `restore_*`, including the `get_character_digest`-then-`override` pattern for bond increment after a Forge a Bond strong hit.
- Cross-links: NPC voice → `ironsworn-npc-voice`; vow advancement → `ironsworn-progress-tracks`; oracle prompts and Pay-the-Price discipline → `ironsworn-oracle`; suffering and the Pay-the-Price palette → `ironsworn-suffer`.
- Fiction Grounding Protocol (#103) cited at the top: `search_lore_global` / `get_npc` / `get_community` before any non-trivial social beat.
- References: full Sojourn outcome tables and recovery menu, focused-roll mechanics, Sojourn-vs-Make-Camp decision tree, full outcome text per move, six worked scenarios.
- Plugin bumped to **0.14.0** (collides with combat/oracle PRs — team-lead will sequence).

Closes #96.

## Test plan

- [ ] Frontmatter `description` triggers correctly on player phrases: "I sojourn", "forge a bond", "test our bond", "I compel", "I aid my ally", "write your epilogue".
- [ ] Forge a Bond strong-hit walkthrough: skill prompts `get_character_digest`, then `override(path="bonds", value=N+1)`, then the +1 spirit / +2 momentum choice.
- [ ] Test Your Bond miss walkthrough: skill clears the bond via `override(path="bonds", value=N-1)` and hands off to `ironsworn-suffer`.
- [ ] Compel weak hit walkthrough: skill calls `roll_oracle`, then `open_thread` (kind=`debt`), then `take_momentum amount=1`.
- [ ] Sojourn strong hit + focused Plan: two menu picks plus focused re-roll with bond +1, momentum totals correctly.
- [ ] Write Your Epilogue: skill recognizes the manual `roll_dice spec="2d10"` workaround (no `bonds` progress track exists).
- [ ] Stop hook: version bump verified (0.13.0 → 0.14.0 in `plugins/ironsworn/.claude-plugin/plugin.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)