### PR TITLE
feat(skill): add ironsworn-oracle mode-of-play skill (#97)

### DIFF
--- a/plugins/ironsworn/.claude-plugin/plugin.json
+++ b/plugins/ironsworn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ironsworn",
-  "version": "0.14.0",
+  "version": "0.13.0",
   "description": "Solo Ironsworn GM companion — fiction-first, dice-driven, with a living lore graph",
   "author": {
     "name": "Karim Naguib"

--- a/plugins/ironsworn/.claude-plugin/plugin.json
+++ b/plugins/ironsworn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ironsworn",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Solo Ironsworn GM companion — fiction-first, dice-driven, with a living lore graph",
   "author": {
     "name": "Karim Naguib"

--- a/plugins/ironsworn/skills/ironsworn-oracle/SKILL.md
+++ b/plugins/ironsworn/skills/ironsworn-oracle/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: ironsworn-oracle
+description: >
+  Governs all Fate moves and oracle-driven inspiration: Ask the Oracle (yes/no
+  questions, descriptor prompts, random events) and Pay the Price (consequence
+  selection on a miss). Centralizes how to set odds, when to ask versus when to
+  decide, how to interpret "action+theme" and other prompt rolls, when "no" is
+  more interesting than "yes," and how to choose a Pay the Price consequence
+  from the palette. ALWAYS invoke this skill whenever the GM is about to call
+  `roll_yes_no` or `roll_oracle`, when the player says things like "ask the
+  oracle", "is there", "do they", "what does", "what happens", "pay the price",
+  "what's here", "roll for it", or any time a miss outcome reads "Pay the
+  Price." Other mechanics skills (combat, social, suffer, progress-tracks)
+  defer here for oracle and consequence interpretation. Never improvise odds
+  or fabricate oracle results from memory.
+---
+
+# Ironsworn Oracle & Pay the Price
+
+The oracle is the engine of surprise. Anything you don't already know, the dice can tell you. This skill is the single source of truth for the two Fate moves — **Ask the Oracle** and **Pay the Price** — and for how every other skill should reach for `roll_yes_no` and `roll_oracle`.
+
+---
+
+## Tools This Skill Governs
+
+| Tool | When |
+|---|---|
+| `roll_yes_no` | Any binary question to the world: "is there...", "do they...", "does it..." |
+| `roll_oracle` | Any named oracle table (Action, Theme, Pay the Price, Region, Settlement Trouble, etc.) |
+| `search_lore_global` | **Before interpreting** any oracle result — Fiction Grounding Protocol (#103) |
+| `search_lore` | Entity/name resolution before naming a place, NPC, or faction the oracle suggests |
+| `get_recent_complications` | **Before** Pay the Price narration (Complication Diversity Protocol — owned by GM agent) |
+| `record_scene` | After Pay the Price, tag with `complication_theme` |
+
+---
+
+## When to Invoke This Skill
+
+- A miss outcome whose effect reads "Pay the Price"
+- A player asks a yes/no question about the world ("Is there a path down?")
+- Fiction needs detail you don't have (NPC motive, what's around the bend, what the storm brings)
+- A move outcome says "Envision what you find (Ask the Oracle if unsure)"
+- Any other skill is about to call `roll_yes_no` or `roll_oracle`
+
+If you already know the answer from established lore, **don't roll** — narrate. Oracles are for genuine uncertainty.
+
+---
+
+## Ask the Oracle
+
+**RAW trigger:** When you seek to resolve questions, discover details in the world, determine how other characters respond, or trigger encounters or events.
+
+Two flavors. Pick by what you need.
+
+### Yes/No — `roll_yes_no`
+
+Use for any binary world-question. Set odds honestly, **before** the roll, based on the established fiction.
+
+| Likelihood | "Yes" range (d100) | When to pick it |
+|---|---|---|
+| `almost_certain` | 11–100 | Strongly supported by fiction; narrating "no" would be perverse |
+| `likely` | 26–100 | The fiction tilts this way |
+| `50_50` | 51–100 | Genuinely uncertain — the most common choice |
+| `unlikely` | 1–25 | The fiction tilts against it |
+| `small_chance` | 1–10 | Would be a real surprise; narrating "yes" would feel like a gift |
+
+**A "no" is often more interesting than a "yes."** A yes resolves; a no forces invention. If both answers feel boring, your question is wrong — ask a sharper one.
+
+**Twist (matched digits, e.g. 33, 77, 00):** the result is true *but* with an unexpected wrinkle. Narrate the answer, then introduce the twist. A "yes, with a twist" is not the same as a "no" — the underlying fact stands.
+
+### Prompt rolls — `roll_oracle`
+
+For open-ended uncertainty, roll on a named table. The most flexible pair is **Action + Theme**: roll both, treat as an evocative prompt, **then ground the interpretation in lore**. Other useful tables: `Pay the Price`, `Region`, `Location`, `Settlement Trouble`, `Settlement Name`, `Character Role`, `Character Goal`, `Character Descriptor`, `Major Plot Twist`, `Mystic Backlash`.
+
+Full interpretation patterns, worked examples, and the "when to ask vs. decide" decision flow → `references/oracle-prompts.md`.
+
+### Fiction Notes — Ask the Oracle
+
+The oracle never tells you *what happens* — it tells you *what is true*. Your job is to make that truth land inside the established world. Before narrating any oracle interpretation, call `search_lore_global` (and `search_lore` if a name/place is implicated) to anchor the result. Treat odd or contradictory rolls as gifts: the world is stranger than your plan. Never re-roll for a "better" answer.
+
+---
+
+## Pay the Price
+
+**RAW trigger:** When you suffer the outcome of a move (almost always a miss).
+
+Pay the Price is a *menu*, not a mandate. You may **choose** a consequence that fits the fiction, **or** `roll_oracle` "Pay the Price" when you're stuck or want surprise.
+
+### The Discipline (preference order)
+
+1. **Flat mechanical cost (default).** −1 supply, −1 momentum, harm, lost progress, broken gear. Has teeth without spawning plot.
+2. **Escalate an existing thread.** Worsen, resurface, or complicate something already open. The world has unfinished business — use it before inventing.
+3. **Introduce a new narrative hook (rarely).** Budget: 0–1 per session.
+
+Full discipline, palette interpretation, and worked examples → `references/pay-the-price.md`.
+
+### Complication Diversity Protocol (cross-link)
+
+Before narrating ANY Pay the Price outcome:
+
+1. `get_recent_complications` (k=5)
+2. Pick a *different* thematic category than what dominates recent history
+3. After narrating, `record_scene` with `complication_theme` set
+
+The full protocol and complication palette live in the GM agent system prompt (`agents/ironsworn-gm.md`). **Do not duplicate** — this skill defers to that source.
+
+### Fiction Notes — Pay the Price
+
+The price is paid by the *fiction*, not the spreadsheet. A −1 supply is "your wineskin froze and split." A new danger isn't a stat block — it's a smell, a sound, a presence at the edge of the firelight. Whatever you choose, it should feel inevitable in retrospect: of course this happened. The campaign earns its weight from accumulating small costs, not from compounding crises.
+
+---
+
+## Common Mistakes
+
+- **Don't roll when you know.** Oracles are for genuine uncertainty.
+- **Don't bias the odds.** Set likelihood from the fiction, not from what you want.
+- **Don't skip Fiction Grounding.** `search_lore_global` before you interpret — every time.
+- **Don't ignore twists.** Matched digits on `roll_yes_no` are a feature; narrate them.
+- **Don't always invent on Pay the Price.** Default to flat mechanical cost. New hooks are rare.
+- **Don't skip `get_recent_complications`** before a Pay the Price narration, or `record_scene` with `complication_theme` after.
+- **Don't re-roll oracles you don't like.** The oracle has spoken.

--- a/plugins/ironsworn/skills/ironsworn-oracle/references/oracle-prompts.md
+++ b/plugins/ironsworn/skills/ironsworn-oracle/references/oracle-prompts.md
@@ -1,0 +1,107 @@
+# Oracle Prompt Interpretation
+
+Patterns for interpreting `roll_oracle` results. The main `ironsworn-oracle` SKILL.md links here.
+
+---
+
+## Decision Flow — Ask vs. Decide
+
+Before any oracle call, run this filter:
+
+1. **Does established lore answer it?** Call `search_lore` / `search_lore_global` (in parallel). If yes → narrate the lore. Don't roll.
+2. **Does the fiction strongly imply an answer?** Set `almost_certain` or `small_chance` and roll yes/no — the dice can still surprise you with a twist.
+3. **Is the question genuinely binary?** Use `roll_yes_no` with the right likelihood.
+4. **Is the question open-ended?** Use `roll_oracle` on a named table — Action+Theme for abstract uncertainty, specific tables (Region, Settlement Trouble, etc.) for typed answers.
+5. **Is the question vague?** Sharpen it first. "What's in the woods?" → "Is anyone watching from the treeline?" + a likelihood.
+
+**The sharpness test:** if both yes and no would feel boring, the question is wrong. Re-frame before rolling.
+
+---
+
+## Setting Likelihood
+
+Likelihood is set by the fiction, **not** by what you want. Calibrate against this anchor:
+
+- `almost_certain` — narrating "no" would contradict established fiction or feel dishonest.
+- `likely` — the established fiction tilts this way; "no" would be a real surprise.
+- `50_50` — genuine uncertainty. **The most common pick.** When in doubt, this.
+- `unlikely` — the fiction tilts against it; "yes" would be a real surprise.
+- `small_chance` — narrating "yes" would feel like a gift to the player.
+
+**Never** pick a likelihood to *engineer* an outcome. If you want a specific result, just narrate it — that's a GM choice, not an oracle.
+
+---
+
+## Twist Interpretation (matched digits on yes/no)
+
+A roll of 11, 22, 33, 44, 55, 66, 77, 88, 99, or 00 is a twist. The yes/no answer **stands** — but introduce a wrinkle the player didn't ask about.
+
+Interpretation moves:
+
+- **"Yes, but..."** — the answer is yes, but with an unwelcome condition or cost.
+- **"No, but..."** — the answer is no, but with an unexpected opening or partial alternative.
+- **"...and there's something else."** — the answer is true, but you also discovered something tangential and important.
+
+The twist should *complicate the situation*, not nullify the answer. If the player asked "is the bridge intact?" and the roll is twist-yes, the bridge is intact — but something else is wrong (a body on it, a watcher beneath, a missing plank that wasn't missing yesterday).
+
+---
+
+## Action + Theme — The Universal Prompt
+
+Roll both `Action` and `Theme`. You get two abstract words. The interpretation isn't literal — it's evocative.
+
+**Process:**
+
+1. `roll_oracle` "Action" → e.g. *"Betray"*
+2. `roll_oracle` "Theme" → e.g. *"Shelter"*
+3. **Ground:** call `search_lore_global` with the current scene's framing question (e.g. *"what's the shape of the conflict at Holtfen?"*). Get a 2–4 sentence cluster summary.
+4. **Synthesize:** read the action/theme pair through the lore lens. *"Betray + Shelter"* in a campaign about oath-debt and harbored exiles → the safehouse host is about to turn the player in for an old debt. *"Betray + Shelter"* in a campaign about waking-darkness corruption → the cellar they hid in *is* the threat; the walls move when nobody looks.
+5. **Narrate** the interpretation — don't quote the words. The oracle's language is a private prompt, not the player-facing fiction.
+
+**Worked examples in references/examples.md** (if present) — otherwise treat the above pattern as the canonical form.
+
+---
+
+## Specific Table Cheat Sheet
+
+| Table | Use when |
+|---|---|
+| `Action` + `Theme` | Open-ended "what happens?", "what's their angle?", "what's the twist?" |
+| `Region` | Need a coarse location framing (Hinterlands, Deep Wilds, Tempest Hills, etc.) |
+| `Location` | Specific scene-level locale within a region |
+| `Settlement Trouble` | What's wrong in the village before the player arrives? |
+| `Settlement Name` | Need a holt/town name on the fly (cross-check `search_lore` for collisions) |
+| `Character Role` | Who is this person, structurally? (Warrior, Outcast, Scholar, etc.) |
+| `Character Goal` | What do they want? |
+| `Character Descriptor` | Single trait — "stoic," "vengeful," "frail" |
+| `Major Plot Twist` | When the campaign feels stable — invite chaos |
+| `Mystic Backlash` | When a ritual or supernatural action goes sideways |
+| `Pay the Price` | Last resort for miss consequences (see references/pay-the-price.md) |
+| `Endure Harm` / `Endure Stress` | Mortal harm / Desolation table — handled by `ironsworn-suffer`; cross-link |
+
+After every roll on a specific table, call `search_lore_global` so the result lands in the campaign's themes rather than generic fantasy.
+
+---
+
+## When the Oracle Surprises You
+
+Sometimes the oracle says something that contradicts your plan or seems impossible. **Never re-roll.** The oracle has spoken. Your options:
+
+1. **Re-interpret.** What you read as impossible is probably just unexpected. A "Helpful + Death" pair in a tense interrogation isn't nonsense — the prisoner offers help in exchange for an oath, knowing it will get them killed.
+2. **Take the gift.** The oracle just made the world more interesting than you would have. Run with it.
+3. **Narrow the question.** If the answer truly cannot be resolved, ask a follow-up yes/no to clarify shape — but don't re-roll the same table for a "better" answer.
+
+The dice know things you don't.
+
+---
+
+## Fiction Grounding (mandatory)
+
+Before any narration that uses an oracle result:
+
+```
+search_lore_global  ←  thematic frame
+search_lore         ←  if a name/place/NPC is implicated
+```
+
+Run them in parallel in the same turn. The oracle gives the *raw shape*; lore gives the *campaign-specific texture*. Without lore grounding, every oracle interpretation drifts toward generic fantasy. With it, the oracle becomes the engine that keeps surfacing the campaign's central tensions in new forms — the dark-elves' oath-tracking, the holtfolk's debt-economy, the corruption that makes beasts move wrong. The oracle is *of this world*, not above it.

--- a/plugins/ironsworn/skills/ironsworn-oracle/references/pay-the-price.md
+++ b/plugins/ironsworn/skills/ironsworn-oracle/references/pay-the-price.md
@@ -1,0 +1,144 @@
+# Pay the Price — Discipline & Palette
+
+Full procedures and worked examples. The main `ironsworn-oracle` SKILL.md links here.
+
+---
+
+## The Discipline (preference order)
+
+Run this list **top-down**. Stop at the first option that genuinely serves the fiction.
+
+### 1. Flat mechanical cost (default)
+
+A miss should hurt. Most misses end here. No new plot, no escalation — just a cost paid.
+
+| Cost | Example |
+|---|---|
+| −1 supply | wineskin froze and split; arrow shafts shattered against frozen ground |
+| −1 momentum | wasted effort; lost the thread of an argument; tactical setback |
+| Lose progress | ground covered must be re-covered; trust eroded; the foe shrugs off the wound |
+| Minor harm (suffer 1) | twisted ankle; shallow cut; deep cold |
+| Equipment degraded | bowstring slackened; blade chipped; lantern out of oil |
+| Time lost | a waypoint of bad weather; a wasted day waiting out a storm |
+
+Flat costs are **invisible** to the meta-narrative. They accumulate weight without crowding the world with new threads.
+
+### 2. Escalate an existing thread
+
+Before inventing anything new, scan open threads. The world has unfinished business.
+
+**Scan first:** `list_threads` (open status) or `search_scenes` for recent recurring entities. Pick something the current beat can plausibly worsen.
+
+Examples:
+- A forgotten debt comes due (an open thread named "The Bargain at Holtfen" surfaces here).
+- An old enemy reappears (the wounded raider from three sessions ago, healed and angrier).
+- An ally's loyalty cracks (the bonded NPC's hidden grudge surfaces under stress).
+- A condition the character has been ignoring sharpens (the wound that wouldn't heal, the dream that recurs).
+
+Escalation is **richer than invention** because it deepens what already exists. The campaign feels alive because old beats keep coming back.
+
+### 3. Introduce a new narrative hook (rarely)
+
+**Budget: 0–1 new threads per session.** Exceed only when the campaign is genuinely thin (early sessions, or after a major arc resolution).
+
+Before inventing, ask:
+
+1. Did I scan open threads? Was there really *nothing* I could escalate?
+2. Would a flat cost be more honest to this fiction?
+3. Will I be ready to advance this hook next session, or is it just noise?
+
+If the answer to any is "no" or "yes (flat cost is better)," fall back. New hooks are commitments — they obligate future play.
+
+---
+
+## When to Choose vs. When to Roll
+
+You may **choose** a Pay the Price consequence directly, or `roll_oracle` "Pay the Price" for the random table. Default to choosing — the fiction usually points clearly at one cost.
+
+**Roll the Pay the Price table when:**
+
+- You're stuck — nothing in the fiction clearly suggests a cost.
+- You want to surprise yourself — the cost might be sharper than what you'd invent.
+- Recent complications have all been your own picks and you want to break out of a rut.
+
+**Choose directly when:**
+
+- The fiction obviously points at one cost (combat miss → harm; journey miss → supply or weather).
+- You're escalating an existing thread (the table can't know about your thread).
+- You've already decided on flat mechanical cost.
+
+When you do roll, treat the result as a *prompt*, not a literal command — the table speaks in abstractions ("It is harmful," "It causes a delay") that you translate into concrete fiction.
+
+---
+
+## Pay the Price Table — Interpretation
+
+The d100 table (in `roll_oracle` "Pay the Price") gives outcomes like:
+
+- *"A new danger or foe is revealed"*
+- *"It is harmful"*
+- *"The current situation worsens"*
+- *"It wastes resources"*
+- *"A friend, companion, or ally is put in harm's way"*
+
+Each is a **category**, not a script. Translate through the campaign's themes:
+
+1. Roll → category.
+2. Call `search_lore_global` for thematic context.
+3. Call `get_recent_complications` for diversity check.
+4. Pick a fresh angle within the category — and within an under-used theme from the palette.
+5. Narrate.
+
+Example: roll 60–68 *"It is harmful."* Recent complications have been weather-heavy; the GM agent's palette suggests rotating to interpersonal/social or supernatural. Lore search surfaces the bonded NPC and an unresolved tension. The "harm" lands as: the bonded ally, exhausted from the journey, lashes out — a wounding word that sticks. Mechanical cost: suffer 1 stress. Narrative cost: a thread to revisit, not a new one created from scratch.
+
+---
+
+## Complication Diversity Protocol (cross-link)
+
+The protocol and palette live in `agents/ironsworn-gm.md`. **Do not duplicate** the palette here.
+
+Required steps before narration:
+
+1. `get_recent_complications` (k=5) — note repeated `complication_theme` values.
+2. Pick a category from the palette that has *not* dominated recent history.
+3. Narrate.
+4. `record_scene` with `complication_theme` set to the category you used.
+
+The palette is open — it grows from world truths. Use the truths your campaign established, not a generic list.
+
+---
+
+## Worked Examples
+
+**Example 1 — Resupply miss in deep wilds.**
+- Recent complications: weather, weather, beast.
+- Lore: campaign emphasizes oath-debt and corrupted wildlife.
+- Choice: flat cost — −1 supply (already implicit in the move's miss).
+- Narration: "The snares are sprung but empty. Something larger walked through and took your catch — tracks deep, wrong-shaped. You don't follow."
+- `record_scene` with `complication_theme: "supernatural-corruption"` (a category drawn from world truths, not on the default palette).
+
+**Example 2 — Compel miss against a holtfolk elder.**
+- Open threads: "Debt to the Mire-Holtfolk" (3 sessions old).
+- Choice: escalate the existing thread.
+- Narration: "The elder doesn't refuse you. She walks to a strongbox, sets a tally-stick on the table — your name, your debt — and waits. The price of her help is the price you've been avoiding."
+- Mechanical cost: none directly; but the thread now demands resolution.
+- `record_scene` with `complication_theme: "debt-economy"`.
+
+**Example 3 — Combat miss, wounded raider.**
+- Recent complications: social, debt, social.
+- Lore: corrupted-beast theme is under-used.
+- Choice: flat cost + light fictional escalation.
+- Narration: "Their blade slips past your guard — a shallow cut, but the wound burns wrong, like cold and rot at once."
+- Mechanical: suffer 1 harm + open question of whether the foe is corrupted (next scene's discovery).
+- `record_scene` with `complication_theme: "supernatural-corruption"`.
+
+---
+
+## Common Mistakes
+
+- **Inventing a new thread when an old one fits.** Always scan threads first.
+- **Stacking misses with major plot.** Misses should hurt and move on, not pile up cosmic stakes.
+- **Forgetting the diversity check.** `get_recent_complications` is mandatory before narration.
+- **Forgetting to tag the scene.** `record_scene` with `complication_theme` is what makes the protocol work.
+- **Treating the Pay the Price table as a script.** It's a prompt — the campaign supplies the texture.
+- **Choosing a consequence the player would clearly prefer.** Pay the Price should cost something the player cares about, not the cheapest item on the menu.

--- a/plugins/ironsworn/skills/ironsworn-oracle/references/pay-the-price.md
+++ b/plugins/ironsworn/skills/ironsworn-oracle/references/pay-the-price.md
@@ -49,6 +49,8 @@ Before inventing, ask:
 
 If the answer to any is "no" or "yes (flat cost is better)," fall back. New hooks are commitments — they obligate future play.
 
+**Making the new hook durable.** When invention *is* warranted — typically when the oracle (or the fiction) surfaces an implicit promise the player owes someone ("they ask something of you in return," a debt, a half-spoken oath) — make the obligation persistent so it doesn't evaporate in memory. Open a thread: `open_thread` with kind `debt` (favor owed) or `vow` (rises to an Iron Vow). The canonical pattern, including how the social moves (Compel weak, Forge a Bond weak, Test Your Bond weak) instantiate it, lives in `ironsworn-social/references/moves.md` — defer there rather than restating it here.
+
 ---
 
 ## When to Choose vs. When to Roll

--- a/plugins/ironsworn/skills/ironsworn-oracle/references/pay-the-price.md
+++ b/plugins/ironsworn/skills/ironsworn-oracle/references/pay-the-price.md
@@ -23,6 +23,8 @@ A miss should hurt. Most misses end here. No new plot, no escalation — just a 
 
 Flat costs are **invisible** to the meta-narrative. They accumulate weight without crowding the world with new threads.
 
+**Applying the cost.** Pay the Price picks *what* — `ironsworn-suffer` picks *how*. When the chosen cost is harm, stress, a supply drain, or a debility, defer to `ironsworn-suffer` for the matching tool call (`suffer_harm`, `suffer_stress`, `consume_supply`, `inflict_debility`). Don't apply those mutations from this skill. Note that Face Death / Face Desolation are triggered from the **Endure Harm** / **Endure Stress** oracle tables (the 1–10 result), not directly from Pay the Price — both are owned by `ironsworn-suffer`.
+
 ### 2. Escalate an existing thread
 
 Before inventing anything new, scan open threads. The world has unfinished business.


### PR DESCRIPTION
## Summary

- Adds `plugins/ironsworn/skills/ironsworn-oracle/` — the mode-of-play skill that owns the two Fate moves (**Ask the Oracle**, **Pay the Price**) and centralizes how every other mechanics skill calls `roll_yes_no` and `roll_oracle`.
- `SKILL.md` (~900 words) covers: when to ask vs. decide, `roll_yes_no` likelihood semantics + matched-digit twist rule, `roll_oracle` Action+Theme prompt pattern, Pay the Price discipline (flat mechanical cost → escalate open thread → invent rarely; 0–1 new threads/session).
- `references/oracle-prompts.md` — full likelihood guidance, decision flow, twist interpretation, Action+Theme worked pattern, named-table cheat sheet, Fiction Grounding Protocol (#103) checklist.
- `references/pay-the-price.md` — full discipline procedure, table interpretation, Complication Diversity Protocol cross-link, three worked examples spanning flat-cost / thread-escalation / new-hook patterns.
- Cross-links the Complication Diversity Protocol (lives in `agents/ironsworn-gm.md`) rather than duplicating; cites Fiction Grounding Protocol (#103) as mandatory before any oracle interpretation.
- Bumps `plugins/ironsworn/.claude-plugin/plugin.json` to **0.14.0** (Stop hook requires).

Closes #97.

## Test plan

- [ ] Skill auto-loads — `description` includes literal player phrases (`"ask the oracle"`, `"is there"`, `"do they"`, `"pay the price"`, `"what happens"`, `"roll for it"`).
- [ ] In a play session: GM invokes skill on a yes/no question with non-default likelihood — confirm the answer respects the d100 threshold table and matched-digit twist is narrated when it lands.
- [ ] On a miss with "Pay the Price" outcome — GM consults this skill, calls `get_recent_complications`, picks a fresh theme, narrates a flat mechanical cost first, then `record_scene` with `complication_theme` set.
- [ ] On open-ended uncertainty — GM rolls Action+Theme, calls `search_lore_global` first, narrates without quoting the abstract words.
- [ ] Combat / social / suffer skills (peer PRs) cross-link to this skill rather than inlining oracle/PtP mechanics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)