### PR TITLE
feat(skill): add ironsworn-combat mode-of-play skill (#95)

### DIFF
--- a/plugins/ironsworn/.claude-plugin/plugin.json
+++ b/plugins/ironsworn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ironsworn",
-  "version": "0.13.0",
+  "version": "0.15.0",
   "description": "Solo Ironsworn GM companion — fiction-first, dice-driven, with a living lore graph",
   "author": {
     "name": "Karim Naguib"

--- a/plugins/ironsworn/.claude-plugin/plugin.json
+++ b/plugins/ironsworn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ironsworn",
-  "version": "0.15.0",
+  "version": "0.13.0",
   "description": "Solo Ironsworn GM companion — fiction-first, dice-driven, with a living lore graph",
   "author": {
     "name": "Karim Naguib"

--- a/plugins/ironsworn/skills/ironsworn-combat/SKILL.md
+++ b/plugins/ironsworn/skills/ironsworn-combat/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: ironsworn-combat
+description: >
+  Governs combat as a mode of play in Ironsworn: Enter the Fray, Strike,
+  Clash, Battle, Turn the Tide, End the Fight, and the decisive-action
+  resolution loop. ALWAYS invoke this skill the moment combat begins or the
+  player says things like "I attack", "I strike", "I shoot", "I close with
+  them", "clash", "I parry", "stand my ground", "fight them", "battle",
+  "end the fight", "kill them", "finish him", "decisive action", "we throw
+  down", "draw steel", or any phrase that opens hostilities with a foe.
+  Owns initiative, harm tracking, and the combat progress track. Never
+  improvise combat resolution — route every beat through this skill.
+---
+
+# Ironsworn Combat
+
+Combat is a distinct mode of play. The clock runs faster, the fiction is sharper, and momentum is the difference between winning the exchange and bleeding out. This skill is the single source of truth for combat moves, initiative, harm, and the foe's progress track.
+
+For all progress-track mechanics (ticks, glyphs, fulfill flow), defer to `ironsworn-progress-tracks`. For Endure Harm / Endure Stress / Face Death triggered by a Pay the Price, defer to `ironsworn-suffer`. For oracle prompts during combat, defer to `ironsworn-oracle`.
+
+---
+
+## Tools This Skill Governs
+
+| Tool | When |
+|---|---|
+| `create_progress_track` | Open a combat track (kind="combat") at the start of a meaningful fight |
+| `resolve_move` | Enter the Fray, Strike, Clash, Battle, Turn the Tide |
+| `tick_progress` | Apply harm to the foe — rank-dependent ticks per harm point |
+| `roll_progress` | End the Fight (progress roll) |
+| `fulfill_progress` | Close out the foe after End the Fight resolves on a hit |
+| `close_track` | Combat ended fictionally (foe surrendered, fled offscreen) |
+| `burn_momentum` / `take_momentum` | Convert momentum into hits / harvest from outcomes |
+| `suffer_harm` / `suffer_stress` | Apply consequences from misses, weak hits, Pay the Price |
+| `search_lore_global` | Fiction Grounding Protocol — call before narrating any non-trivial beat |
+
+---
+
+## When to Invoke This Skill
+
+- The player attacks or is attacked: "I attack", "I strike", "I shoot", "I draw steel", "I close in"
+- A hostile NPC enters and the player engages
+- Initiative is in question or shifting
+- Harm needs to be applied to a foe (always `tick_progress`, never `reach_milestone`)
+- The player commits to an ending: "end the fight", "finish him", "kill them", "decisive action"
+- Any call to the tools listed above
+- Even if combat is brief — invoke first, then decide whether to abstract via Battle
+
+---
+
+## Step 1 — Enter the Fray
+
+When fiction crosses into hostilities, open the fight.
+
+1. Decide if a progress track is warranted. **Open one** for any foe meaningful enough to threaten the character. Skip the track only for trivial mooks resolved in a single Strike — narrate, apply harm fictionally, move on.
+2. `create_progress_track` with `name` (e.g. "Bandit Captain at the Crossing"), `rank` matching the foe (troublesome to epic), `kind: "combat"`.
+3. `resolve_move` "Enter the Fray". Stat is fictional: heart (facing off), shadow (ambushing from cover), wits (ambushed and reacting).
+
+**Fiction Notes.** Enter the Fray is the threshold beat — the moment the conversation ends and dice come out. Establish range, terrain, and stakes. On a miss, the foe's first move lands before the player reacts; on a strong hit, the player is already moving when the foe registers the threat.
+
+Outcomes table → `references/combat-flow.md` ("Enter the Fray").
+
+---
+
+## Step 2 — In the Fight (Strike / Clash)
+
+Initiative dictates which move you roll. Track who has it.
+
+- **Strike** — when YOU have initiative. Iron close, Edge at range. `resolve_move` "Strike".
+- **Clash** — when the FOE has initiative. Iron close, Edge at range. `resolve_move` "Clash".
+
+Both inflict harm on hits. **Harm = marks on `tick_progress`.** Base harm is 1 (or 2 from a deadly weapon/asset); strong-hit Strike and the "find an opening" Clash bonus add +1 mark. Pass marks to the tool — never compute ticks yourself; the tool reads rank and converts (troublesome 12, dangerous 8, formidable 4, extreme 2, epic 1 ticks per mark).
+
+**Initiative migrates with results** — strong-hit Strike retains, weak-hit Strike loses; strong-hit Clash takes initiative back, weak/miss Clash leaves it with the foe. Always restate who currently has initiative before the next exchange.
+
+**Fiction Notes — Strike vs Clash.** Strike is the prepared attack: you chose this exchange. Clash is the reaction: you're answering their swing, their volley, their grasp. A weak-hit Strike still lands, but the foe has answered before you can press.
+
+### Turn the Tide
+
+Once per fight, when the player risks it all (low health, dire stakes): `resolve_move` "Turn the Tide". Outcomes are **player-defined** — let the player declare the dramatic stake before rolling. Adjudicate from fiction.
+
+Full Strike/Clash/Turn-the-Tide outcomes and tool sequences → `references/combat-flow.md`.
+
+---
+
+## Step 3 — Battle (the abstraction)
+
+Use Battle when the fight is best handled as a single dramatic beat — a blur, a brief skirmish, a montage — not exchange by exchange.
+
+`resolve_move` "Battle", stat per tactic (edge=range/speed, heart=courage/allies, iron=overpower, shadow=trickery, wits=tactics).
+
+Battle does **not** use the combat progress track — it skips past it. If a track already exists, close it with `close_track` after a Battle hit.
+
+**Fiction Notes.** Battle is not "skip the fight." Use it when the granular exchange would slow the story — clearing a hallway, holding a wall, bringing down a beast that doesn't deserve a track. Don't reach for Battle to escape Strike/Clash discipline mid-fight; commit to one mode per encounter.
+
+Outcomes → `references/combat-flow.md` ("Battle").
+
+---
+
+## Step 4 — End the Fight (Take Decisive Action)
+
+When the foe is sufficiently worn down and the player commits to the ending — kill, capture, rout — they take decisive action.
+
+**This is a progress roll, not an action roll.** Use `roll_progress`, never `resolve_move`.
+
+1. The RAW trigger: "When you make a move to take decisive action, and score a strong hit." End the Fight is *unlocked* by a strong-hit Strike, Clash, or another move where the player declares decisive intent. Confirm the player is committing to the ending before rolling.
+2. `roll_progress` with `track_name=<foe track name>`.
+3. `fulfill_progress` with `track_name`, `outcome`. **Combat tracks award 0 XP** — the reward is in the surviving fiction, not on the sheet.
+
+**On weak hit — always offer the cost choice via `AskUserQuestion`** (six canonical options: Endure Harm, Endure Stress, new danger, collateral damage, objective slips, marked for vengeance). Apply the chosen consequence via the appropriate tool — defer to `ironsworn-suffer` for harm/stress flows.
+
+**Fiction Notes.** Decisive action is the player declaring the ending. The progress roll asks: did the fight earn that ending? A strong-hit Strike followed by `roll_progress` is the canonical sequence — the strong hit unlocks intent, the progress roll spends the marks already on the track. Don't roll End the Fight prematurely; without enough progress, even a strong hit on the d6 may be eaten by the challenge dice.
+
+Full End-the-Fight outcomes, the AskUserQuestion option block, and worked sequences → `references/combat-flow.md`.
+
+---
+
+## After the Fight — Vows
+
+If the combat directly advanced an open vow (defeating a sworn enemy, rescuing a hostage tied to a vow), call `reach_milestone` on that vow **separately** after `fulfill_progress` on the combat track. Do not double-tick. See `ironsworn-progress-tracks` for vow advancement.
+
+---
+
+## Pay the Price in Combat
+
+Combat misses and weak-hit costs trigger Pay the Price. Pay it as: harm (`suffer_harm`), stress (`suffer_stress`), broken gear, ally hit, debility (`inflict_debility`), or fictional setback. **Defer to `ironsworn-oracle` for the Pay the Price discipline (preference order, recent-complication checks) and to `ironsworn-suffer` for the Endure Harm / Endure Stress / Face Death move flows.** Call `get_recent_complications` before narrating to avoid recycling beats.
+
+When End the Fight strong-hit RAW says "Ask the Oracle if unsure" (re: kill / out of action / flees / surrenders), defer to `ironsworn-oracle` for `roll_yes_no` likelihood selection.
+
+---
+
+## Fiction Grounding Protocol (#103)
+
+Before narrating any non-trivial combat beat — the foe's tactics, terrain, an NPC ally's reaction, wider stakes — call `search_lore_global` with relevant terms. Only invent when the search returns nothing. The lore graph is the canon; combat doesn't get a pass.
+
+---
+
+## Common Mistakes
+
+- **Combat tracks tick via `tick_progress`, never `reach_milestone`** — milestones are vows only.
+- **End the Fight is a progress roll** — `roll_progress` + `fulfill_progress`, never `resolve_move`.
+- **End the Fight requires decisive intent** — confirm the player is committing to the ending.
+- **Don't roll End the Fight prematurely** — the marks have to be on the track.
+- **Strike vs Clash is initiative-keyed** — always restate who has initiative before each exchange.
+- **Pass marks, not ticks, to `tick_progress`** — the tool handles rank conversion.
+- **Weak-hit End the Fight requires a player choice** — never auto-pick the cost.
+- **Battle skips the track** — if a track already exists, close it with `close_track` after the Battle hit.
+- **Combat awards 0 XP from `fulfill_progress`** — XP comes only from related vows, called separately.
+- **Ground combat fiction in lore** — `search_lore_global` before improvising terrain, factions, or stakes.
+
+---
+
+## Reference
+
+Full per-move outcome tables, worked sequences, momentum tactics, and the End-the-Fight cost prompt: `references/combat-flow.md`.

--- a/plugins/ironsworn/skills/ironsworn-combat/references/combat-flow.md
+++ b/plugins/ironsworn/skills/ironsworn-combat/references/combat-flow.md
@@ -1,0 +1,195 @@
+# Combat Flow Reference
+
+Full procedures for combat play. The main `ironsworn-combat` SKILL.md links here.
+
+---
+
+## 1. Choosing the foe's rank
+
+Set rank from the foe's threat, not just hit points:
+
+| Rank | Use for |
+|---|---|
+| Troublesome | A single bandit, a wild dog, a panicked stranger with a knife |
+| Dangerous | A trained soldier, a small predator, a desperate hunter |
+| Formidable | A skilled warrior, a large beast, a bonded duo |
+| Extreme | A champion, an elite predator, a small monstrous thing |
+| Epic | A legendary foe, a great beast, a horror out of myth |
+
+Lone, brief threats may not need a track at all — narrate, apply harm fictionally, and resolve in a single Strike. **Open a track** the moment the fiction asks "how long does this take to bring down?"
+
+---
+
+## 2. Enter the Fray (action — heart / shadow / wits)
+
+`resolve_move` "Enter the Fray".
+
+| Result | Effect | Tools |
+|---|---|---|
+| Strong hit | +2 momentum. You have initiative. | `take_momentum` n=2 |
+| Weak hit | Choose: bolster (+2 momentum) OR seize initiative. | `AskUserQuestion`; then `take_momentum` n=2 if bolster |
+| Miss | Combat begins at disadvantage. Pay the Price. Foe has initiative. | See Pay the Price |
+
+**Stat choice prompt:**
+```
+question: "How do you enter the fight?"
+options:
+  - value: "heart"   label: "Face them down"   description: "Heart — squaring off, eyes locked."
+  - value: "shadow"  label: "Strike unseen"    description: "Shadow — moving on an unaware foe, or hitting without warning."
+  - value: "wits"    label: "React fast"       description: "Wits — ambushed, scrambling for advantage."
+```
+
+**Weak-hit choice prompt:**
+```
+question: "You have a moment. What do you do with it?"
+options:
+  - value: "bolster"   label: "Bolster your position"  description: "+2 momentum."
+  - value: "initiative" label: "Prepare to act"        description: "Take initiative."
+```
+
+---
+
+## 3. Strike (action — iron / edge) — when YOU have initiative
+
+`resolve_move` "Strike".
+
+| Result | Effect | Tools |
+|---|---|---|
+| Strong hit | Inflict +1 harm. You retain initiative. | `tick_progress` (marks = base harm + 1) |
+| Weak hit | Inflict harm. Lose initiative. | `tick_progress` (marks = base harm) |
+| Miss | Attack fails. Pay the Price. Foe has initiative. | No tick. See Pay the Price |
+
+**Base harm** is 1 by default. Deadly weapons or assets may set it to 2 — read it from the character sheet, don't guess.
+
+**Stat choice prompt (if range is ambiguous):**
+```
+question: "How do you strike?"
+options:
+  - value: "iron"  label: "Close in"  description: "Iron — close quarters, blade on blade."
+  - value: "edge"  label: "At range"  description: "Edge — bow, throwing axe, distance."
+```
+
+---
+
+## 4. Clash (action — iron / edge) — when the FOE has initiative
+
+`resolve_move` "Clash".
+
+| Result | Effect | Tools |
+|---|---|---|
+| Strong hit | Inflict harm + choose: bolster (+1 momentum) OR find an opening (+1 harm). You take initiative. | `tick_progress` (marks = base harm; +1 if opening); `take_momentum` n=1 if bolster |
+| Weak hit | Inflict harm, then Pay the Price. Foe keeps initiative. | `tick_progress` (marks = base harm); see Pay the Price |
+| Miss | Outmatched. Pay the Price. Foe keeps initiative. | No tick. |
+
+**Strong-hit choice prompt:**
+```
+question: "You hit hard — and now?"
+options:
+  - value: "bolster" label: "Bolster your position"  description: "+1 momentum."
+  - value: "opening" label: "Find an opening"        description: "Inflict +1 harm."
+```
+
+---
+
+## 5. Turn the Tide (action — once per fight)
+
+`resolve_move` "Turn the Tide" when the player risks it all. Outcomes are not preset by RAW — let the player declare what they're risking and what success looks like before rolling. Adjudicate from fiction.
+
+Typical use: low health, last-ditch leap, gambling everything on one swing. Do not invoke for routine moments.
+
+---
+
+## 6. Battle (action — any stat per tactic)
+
+Use Battle to abstract a fight into one beat. Skips the combat track entirely.
+
+`resolve_move` "Battle".
+
+| Result | Effect | Tools |
+|---|---|---|
+| Strong hit | Achieve objective unconditionally. +2 momentum. | `take_momentum` n=2; `close_track` if a track existed |
+| Weak hit | Achieve objective, but not without cost. Pay the Price. | `close_track`; see Pay the Price |
+| Miss | Defeated. Objective lost. Pay the Price. | No close — fiction continues; see Pay the Price |
+
+**Stat choice prompt:**
+```
+question: "How do you fight this battle?"
+options:
+  - value: "edge"   label: "Range and speed"  description: "Edge — terrain, mobility, distance."
+  - value: "heart"  label: "Courage / allies" description: "Heart — companions, conviction."
+  - value: "iron"   label: "Overpower"        description: "Iron — close in, break them."
+  - value: "shadow" label: "Trickery"         description: "Shadow — befuddle, deceive, cheat."
+  - value: "wits"   label: "Tactics"          description: "Wits — outsmart, outmaneuver."
+```
+
+---
+
+## 7. End the Fight (progress roll)
+
+When the foe is worn down and the player commits to the ending — kill, capture, rout — they take decisive action.
+
+**Sequence:**
+1. The player declares decisive intent on a Strike, Clash, or other contextual move.
+2. That move scores a strong hit (RAW trigger).
+3. `roll_progress` with `track_name=<foe track name>`.
+4. `fulfill_progress` with `track_name`, `outcome`. **Combat tracks award 0 XP.**
+
+**Outcomes (progress roll):**
+
+| Result | Effect |
+|---|---|
+| Strong hit | Foe is killed, out of action, flees, or surrenders — player choice fitting the fiction. |
+| Weak hit | Foe is finished, but choose one cost (see prompt below). |
+| Miss | You have lost this fight. Pay the Price. |
+
+**Weak-hit cost prompt — always ask:**
+```
+question: "You finish them — but at what cost?"
+options:
+  - value: "harm"        label: "It's worse than you thought"  description: "Endure Harm."
+  - value: "stress"      label: "You are overcome"             description: "Endure Stress."
+  - value: "new_danger"  label: "Victory is short-lived"       description: "A new danger or foe appears, or an existing danger worsens."
+  - value: "collateral"  label: "Collateral damage"            description: "Something of value is lost or broken, or someone important must pay the cost."
+  - value: "objective"   label: "You'll pay for it"            description: "An objective falls out of reach."
+  - value: "vengeance"   label: "Others won't forget"          description: "You are marked for vengeance."
+```
+
+Apply the chosen consequence with the appropriate tool — `suffer_harm` / `suffer_stress` / new threat track / `inflict_debility` / narrative — defer to `ironsworn-suffer` for harm and stress flows.
+
+**On miss:** the foe is not down. Pay the Price (likely Endure Harm or Face Death). The fight may continue, or the player may break off, retreat, surrender. Don't auto-end the scene.
+
+---
+
+## 8. Momentum Tactics
+
+- **Burn momentum on a Strike or Clash miss/weak-hit** when momentum exceeds the lower (miss) or higher (weak-hit) challenge die, to upgrade the result. The scribe surfaces `burnOffered: true` on the move outcome — pass the offer to the player.
+- **Strong-hit Clash with bolster** is the cleanest momentum source in a sustained fight. Suggest it when the player is low on the meter.
+- **Negative momentum** cancels your action die. If the player drops to negative momentum mid-fight, narrate the spiral; the next Strike/Clash is fragile.
+- **Take Decisive Action thrives on momentum** — burn before End the Fight if momentum > both challenge dice. The scribe will offer it; accept on the player's behalf only if they pre-authorized.
+
+---
+
+## 9. Worked example
+
+**Foe:** Bandit Captain (dangerous, 8 ticks per mark).
+
+1. `create_progress_track` name="Bandit Captain at the Crossing", rank="dangerous", kind="combat".
+2. `resolve_move` "Enter the Fray", stat="heart". Strong hit. `take_momentum` n=2. Player has initiative. Track: `○○○○○○○○○○`.
+3. `resolve_move` "Strike", stat="iron". Strong hit. Inflict 1+1=2 harm. `tick_progress` marks=2 → 16 ticks. Track: `●●○○○○○○○○`. Player retains initiative.
+4. `resolve_move` "Strike", stat="iron". Weak hit. Inflict 1 harm. `tick_progress` marks=1 → 24 ticks. Track: `●●●○○○○○○○`. Foe takes initiative.
+5. `resolve_move` "Clash", stat="iron". Strong hit, choose "find an opening". Inflict 1+1=2 harm. `tick_progress` marks=2 → 40 ticks. Track: `●●●●●●●●●●`. Player takes initiative back. Player declares decisive intent: "I drive the blade home."
+6. `roll_progress` track_name="Bandit Captain at the Crossing". Strong hit (10 progress score, low challenge dice). `fulfill_progress` outcome="strong_hit", resolution="killed". 0 XP.
+7. If the captain was tied to an open vow ("Avenge Mara"), call `reach_milestone` track_name="Avenge Mara" — separately, after `fulfill_progress`.
+
+---
+
+## 10. Common Pitfalls
+
+- **Trying to roll End the Fight without progress.** A progress score of 0–2 is a near-guaranteed miss; the player must earn the marks first.
+- **Using `reach_milestone` on a combat track.** Wrong tool. `tick_progress` always.
+- **Auto-picking the weak-hit cost.** Always `AskUserQuestion`.
+- **Computing ticks manually.** Pass marks; the tool reads rank.
+- **Letting Battle escape Strike/Clash mid-fight.** Pick one mode and commit.
+- **Forgetting `close_track` after a Battle hit on an existing track.** The track remains open otherwise.
+- **Skipping `search_lore_global`.** Combat fiction must be grounded; the foe, the terrain, and the stakes are all in the lore.
+- **Treating combat XP as automatic.** Combat tracks award 0 XP from `fulfill_progress`. Vow XP is a separate `reach_milestone` call, only if the foe was bound to a vow.


### PR DESCRIPTION
## Summary

- Adds `ironsworn-combat` skill — owns combat as a distinct mode of play (Enter the Fray, Strike, Clash, Battle, Turn the Tide, End the Fight, decisive-action loop), with Fiction Notes per move and the canonical weak-hit cost prompt
- Bundles tool sequences: `create_progress_track` (kind=combat), `tick_progress` per harm point (rank-dependent), `roll_progress` + `fulfill_progress` for End the Fight (0 XP — vows are a separate `reach_milestone` call)
- Cross-links rather than duplicating: `ironsworn-progress-tracks` (vow advancement, glyphs), `ironsworn-suffer` (Endure Harm / Stress / Face Death), `ironsworn-oracle` (Pay the Price preference order, "Ask the Oracle if unsure" on End-the-Fight strong-hit). Cites the Fiction Grounding Protocol (#103) — `search_lore_global` before any non-trivial beat
- Bumps plugin to 0.15.0 (oracle and social already at 0.14.0)

Closes #95.

## Files

- `plugins/ironsworn/skills/ironsworn-combat/SKILL.md` — frontmatter description loaded with literal player phrases ("I attack", "I strike", "clash", "end the fight", "kill them", "draw steel", etc.)
- `plugins/ironsworn/skills/ironsworn-combat/references/combat-flow.md` — full per-move outcome tables, AskUserQuestion blocks for stat choice and weak-hit costs, momentum tactics, and a worked combat example against a dangerous foe
- `plugins/ironsworn/.claude-plugin/plugin.json` — 0.13.0 → 0.15.0

## Test plan

- [ ] Skill triggers on player phrases like "I attack", "I strike", "clash", "end the fight"
- [ ] Combat track ticking uses `tick_progress` with marks (not ticks); rank-conversion happens in the tool
- [ ] End the Fight flows: `roll_progress` → `fulfill_progress` (0 XP); weak hit prompts cost choice via `AskUserQuestion`
- [ ] After combat, vow milestone is a separate `reach_milestone` call (no double-tick)
- [ ] Cross-links to `ironsworn-suffer` and `ironsworn-oracle` resolve once those PRs merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)