### PR TITLE
feat(skill): add ironsworn-suffer mode-of-play skill (#98)

### DIFF
--- a/plugins/ironsworn/.claude-plugin/plugin.json
+++ b/plugins/ironsworn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ironsworn",
-  "version": "0.16.0",
+  "version": "0.13.0",
   "description": "Solo Ironsworn GM companion — fiction-first, dice-driven, with a living lore graph",
   "author": {
     "name": "Karim Naguib"

--- a/plugins/ironsworn/.claude-plugin/plugin.json
+++ b/plugins/ironsworn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ironsworn",
-  "version": "0.13.0",
+  "version": "0.16.0",
   "description": "Solo Ironsworn GM companion — fiction-first, dice-driven, with a living lore graph",
   "author": {
     "name": "Karim Naguib"

--- a/plugins/ironsworn/skills/ironsworn-suffer/SKILL.md
+++ b/plugins/ironsworn/skills/ironsworn-suffer/SKILL.md
@@ -1,0 +1,181 @@
+---
+name: ironsworn-suffer
+description: >
+  Governs Ironsworn Suffer moves — every consequence beat where the character
+  pays a cost. Covers Endure Harm, Endure Stress, Companion Endure Harm,
+  Sacrifice Resources, Out of Action, Face Death, Face Desolation. ALWAYS
+  invoke this skill whenever harm, stress, supply loss, debilities, or
+  companion injury must resolve, or when the player says things like
+  "I take harm", "I'm hit", "endure stress", "out of action", "face death",
+  "sacrifice", "I lose supply", "I'm wounded", "shaken", "my companion is
+  hurt". Fires from any context — combat hits, journey misses, social
+  betrayals, oracle Pay the Price, dramatic fiction. Discipline: a hit that
+  costs nothing isn't a hit. Never improvise consequence numbers.
+---
+
+# Ironsworn Suffer Moves
+
+Suffer moves apply costs when the world pushes back. This skill is the single source of truth for **applying** consequences. Choosing *which* consequence belongs to `ironsworn-oracle` Pay the Price; this skill takes it from there.
+
+**The discipline:** *A hit that costs nothing isn't a hit.* Never narrate "you take a wound" without `suffer_harm`; never narrate "you're rattled" without `suffer_stress`. The journal is how the campaign remembers wounds.
+
+---
+
+## Tools This Skill Governs
+
+| Tool | When |
+|---|---|
+| `suffer_harm` | Endure Harm |
+| `suffer_stress` | Endure Stress |
+| `consume_supply` | Sacrifice Resources / supply loss |
+| `inflict_debility` | wounded, shaken, maimed, corrupted, cursed, tormented, battered, encumbered, unprepared |
+| `clear_debility` | Recover from a debility |
+| `companion_suffer_harm` / `companion_restore_health` | Companion harm and recovery |
+| `resolve_move` | Endure Harm / Endure Stress / Companion Endure Harm / Face Death / Face Desolation |
+| `roll_oracle` | Endure Harm / Endure Stress consequence tables |
+
+---
+
+## When to Invoke
+
+Any time the fiction inflicts a cost: combat hits (from `ironsworn-combat`), journey misses, social betrayal (from `ironsworn-social`), Pay the Price that names harm/stress/supply/debility (from `ironsworn-oracle`), peril at 0 health/spirit, companion takes a blow.
+
+If a peer skill hands off, **trust their framing** but apply the mechanics here.
+
+---
+
+## Fiction Grounding Protocol (#103)
+
+**Before narrating any consequence beat, pull on existing lore.** A wound has roots: who struck the blow, why, what grudge it settles. Stress has a face: the NPC whose betrayal is finally landing.
+
+1. `search_lore_global` for terms relevant to the consequence (the foe, the location, an open thread).
+2. Optionally `get_npc` for the inflicting party, or `search_beats` for prior fiction touching the wound.
+3. Tie the cost to *something already in the campaign* — a faction grudge, a community wound, an NPC's history.
+
+Skip only if the source is already loaded mid-scene.
+
+---
+
+## Endure Harm (Iron)
+
+**Apply harm first**, then roll. The roll is whether you press on, not whether you take the wound.
+
+1. `suffer_harm` n=`<harm>`.
+2. `resolve_move` move "Endure Harm", stat "iron".
+
+| Result | Effect |
+|---|---|
+| Strong hit | Choose: Shake it off (+1 health, -1 momentum) OR Embrace the pain (+1 momentum) |
+| Weak hit | Press on. |
+| Miss | -1 momentum. If at 0 health: mark **wounded** or **maimed** (if unmarked) OR roll Endure Harm oracle |
+
+**Fiction Notes.** A wound is not "you lose 2 health" — it is the spear through your mail, the leg that won't bear weight on stairs. At 0 health you are not dead, but a step from it. *Wounded* slows you; *maimed* lasts.
+
+Full oracle table (1d100, including the Face Death triggers), the strong-hit `AskUserQuestion`, and worked examples → `references/endure-harm.md`.
+
+---
+
+## Endure Stress (Heart)
+
+Apply stress first, then roll.
+
+1. `suffer_stress` n=`<amount>`.
+2. `resolve_move` move "Endure Stress", stat "heart".
+
+| Result | Effect |
+|---|---|
+| Strong hit | Choose: Shake it off (+1 spirit, -1 momentum) OR Embrace the darkness (+1 momentum) |
+| Weak hit | Press on. |
+| Miss | -1 momentum. If at 0 spirit: mark **shaken** or **corrupted** (if unmarked) OR roll Endure Stress oracle |
+
+**Fiction Notes.** Stress at -2 spirit is not anxiety — it is the silence after a friend's body hits the dirt. *Shaken* is jumping at shadows; *corrupted* is making peace with darker thoughts. The 11-25 oracle that forces a Forsake is the most narratively dangerous outcome in the game.
+
+Full oracle and the Forsake handoff to `ironsworn-progress-tracks` → `references/endure-stress.md`.
+
+---
+
+## Companion Endure Harm (Heart)
+
+1. `companion_suffer_harm` companion_name=`<name>` amount=`<n>`.
+2. `resolve_move` move "Companion Endure Harm", stat "heart".
+
+| Result | Effect |
+|---|---|
+| Strong hit | Companion rallies. `companion_restore_health` n=1. |
+| Weak hit | Battered. If at 0 health, cannot assist until ≥1. |
+| Miss | -1 momentum. If companion at 0: gravely wounded, **out of action**; without aid, dies in an hour or two. |
+| Miss + action die = 1, companion at 0 | Companion **dead**. 1 XP per marked ability; remove the asset. |
+
+**Out of action ≠ dead.** Heal or fictional aid can save them. Always pause for the player before applying death.
+
+**Fiction Notes.** A companion is the second voice in a hard scene. *Battered* is a beat to play; *gravely wounded* is a clock; *dead* is an epilogue beat for that bond.
+
+---
+
+## Sacrifice Resources
+
+Not a roll — a cost. Triggered by Face Danger weak hits, Pay the Price, Sacrifice a Resource asset.
+
+- Supply: `consume_supply` n=`<amount>`. At 0 supply, the next loss triggers **Out of Supply** — apply a separate consequence (mark unprepared, lose an asset, journey halts) instead of going negative.
+- Other resources (a relic given up, a name owed) live in lore. Update via `upsert_lore` or close a thread.
+
+**Fiction Notes.** Supply is the cold camp without flint, the sword that finally broke. When supply hits 0, *something* breaks; do not silently clamp.
+
+---
+
+## Out of Action
+
+Fiction status, not a tool call. Triggered by Endure Harm oracle 21-35 (player unconscious) or Companion Endure Harm miss at 0 health.
+
+The character cannot act, assist, or move until restored. For the player, the scene continues *around* them — the GM may invoke Face Death if they are vulnerable. For a companion, the clock is ticking toward death.
+
+---
+
+## Face Death (Heart) — rare, dramatic
+
+| Result | Effect |
+|---|---|
+| Strong hit | Death rejects you. Cast back into the mortal world. |
+| Weak hit | Choose: noble sacrifice (you die) OR Death demands a Vow (formidable/extreme). Fail or refuse → dead. Otherwise return, **cursed**. |
+| Miss | You are dead. |
+
+Use `AskUserQuestion` for the weak-hit choice. Vow path → `ironsworn-progress-tracks` `create_progress_track`, then `inflict_debility` "cursed". Clear cursed only by completing the quest.
+
+**Fiction Notes.** Face Death may be the player's epilogue — pause; never rush. If they pick noble sacrifice, work with them on a closing scene worthy of the campaign.
+
+Full procedure → `references/face-death-desolation.md`.
+
+---
+
+## Face Desolation (Heart) — rare, dramatic
+
+| Result | Effect |
+|---|---|
+| Strong hit | Resist and press on. |
+| Weak hit | Choose: noble sacrifice (sanity breaks) OR vision-Vow (formidable/extreme) to prevent a dreaded future. Fail/refuse → lost. Otherwise return, **tormented**. |
+| Miss | Lost to despair or horror. |
+
+Same shape as Face Death, applied to spirit. `inflict_debility` "tormented"; clear only by completing the quest.
+
+**Fiction Notes.** Face Desolation is the quiet apocalypse — death of the will. The vision in the weak-hit branch must pull on lore the campaign already cares about; invoke the Fiction Grounding Protocol before narrating it.
+
+---
+
+## Cross-Skill Handoffs
+
+- **Combat hits** → `ironsworn-combat` rolls Strike/Clash/Battle, then hands here for `suffer_harm`. Combat does not own the harm number; this skill does.
+- **Pay the Price** → `ironsworn-oracle` decides *what* the cost is, then hands here for application.
+- **Vow forsake from Endure Stress (11-25)** → `ironsworn-progress-tracks` `forsake_vow`.
+- **Face Death / Desolation Vow path** → `ironsworn-progress-tracks` `create_progress_track`.
+
+---
+
+## Common Mistakes
+
+- **Narrating harm without `suffer_harm`.** The journal must record it.
+- **Rolling Endure Harm before applying the harm.** Apply first; roll second.
+- **Skipping the 0-health miss branch.** It forces a debility OR oracle, not just -1 momentum.
+- **Treating Out of Action as dead.** It is unconscious / gravely wounded.
+- **Auto-applying Face Death/Desolation weak hit.** Use `AskUserQuestion`.
+- **Inventing consequence severity.** Amounts come from rules or the move's effect.
+- **Narrating a wound without lore grounding.** Pull on the lore graph first.

--- a/plugins/ironsworn/skills/ironsworn-suffer/references/endure-harm.md
+++ b/plugins/ironsworn/skills/ironsworn-suffer/references/endure-harm.md
@@ -1,0 +1,80 @@
+# Endure Harm — Full Workflow
+
+The main `SKILL.md` covers the basics. This reference holds the oracle table, the strong-hit choice prompt, and edge cases.
+
+---
+
+## Sequence (always)
+
+1. **Apply the harm.** `suffer_harm` n=`<harm amount>`. Harm comes from:
+   - Combat: foe's harm value (rank-based) on a Strike/Clash hit; reduced or amplified by fiction (cover, weakness exposed, etc.)
+   - Journey/social: usually 1 harm unless the source is severe
+   - Pay the Price: as the oracle directs
+2. **Roll the move.** `resolve_move` with move "Endure Harm", stat "iron". (Some assets allow heart instead.)
+3. **Apply the result** per the table below.
+
+---
+
+## Outcome Table
+
+| Result | What happens | Tool sequence |
+|---|---|---|
+| Strong hit | Choose: Shake it off (+1 health, -1 momentum) OR Embrace the pain (+1 momentum) | `restore_health` n=1 + `take_momentum` n=-1, OR `take_momentum` n=1 |
+| Weak hit | Press on. No further effect. | — |
+| Miss | -1 momentum; if at 0 health, mark wounded or maimed (whichever is unmarked) OR roll Endure Harm oracle | `take_momentum` n=-1; `inflict_debility` OR `roll_oracle` "Endure Harm" |
+
+### Strong-hit `AskUserQuestion`
+
+```
+question: "You shrug it off. How?"
+options:
+  - value: "shake"   label: "Shake it off"      description: "+1 health, -1 momentum (only if health > 0)"
+  - value: "embrace" label: "Embrace the pain"  description: "+1 momentum, no health change"
+```
+
+If health is 0, "shake it off" is unavailable — only "embrace the pain" is offered.
+
+---
+
+## 0-Health Miss: Debility OR Oracle
+
+When the miss happens *and* the character is already at 0 health, the rule says: **mark wounded or maimed (if unmarked)** OR roll the Endure Harm oracle.
+
+- If wounded is unmarked: `inflict_debility` "wounded".
+- If wounded is marked but maimed is unmarked: `inflict_debility` "maimed".
+- If both are marked: `roll_oracle` "Endure Harm".
+
+The choice — debility vs oracle — is the player's. Offer it via `AskUserQuestion` only if both wound debilities are unmarked. Otherwise auto-apply the available one; if both marked, go straight to the oracle.
+
+---
+
+## Endure Harm Oracle (1d100)
+
+| Roll | Outcome |
+|---|---|
+| 1-10 | The harm is mortal. **Face Death.** |
+| 11-20 | You are dying. Heal within an hour or two, or **Face Death**. |
+| 21-35 | Unconscious and **out of action**. Come back to your senses in an hour or two if left alone. If vulnerable to a foe not inclined to show mercy, **Face Death**. |
+| 36-50 | Reeling and fighting to stay conscious. Vigorous activity (running, fighting) before a few minutes of breather → roll on this table again before resolving the other move. |
+| 51-100 | Battered but still standing. |
+
+Note the recursive 36-50 result: the next time the character pushes, roll Endure Harm oracle *first*, then resolve the move they were attempting.
+
+---
+
+## Worked Examples
+
+**Example 1 — combat hit, full health.** Foe deals 2 harm. `suffer_harm` n=2 (health 5 → 3). Roll Endure Harm vs iron: strong hit. Player picks Embrace the pain. `take_momentum` n=1.
+
+**Example 2 — at 0 health, miss.** Already 0 health, wounded unmarked. Foe deals 1 harm. `suffer_harm` n=1 (clamps at 0). Roll Endure Harm: miss. `take_momentum` n=-1. Wounded is unmarked → `inflict_debility` "wounded".
+
+**Example 3 — at 0 health with both wound debilities marked, miss.** `roll_oracle` "Endure Harm". Roll = 14 → "You are dying." Hand off: Heal within an hour, or Face Death. The clock is now narrative — the player must act.
+
+---
+
+## Common Edge Cases
+
+- **Harm beyond the 5-health bar:** clamps at 0; surplus does not bleed forward. The cost shows up in the Endure Harm roll, not the health number.
+- **Asset modifiers:** some assets (Veteran, Iron Will, etc.) modify Endure Harm. Apply them via `adds` in `resolve_move`.
+- **Recurring 36-50 oracle:** track it on the scene — set a reminder that the next move requires an Endure Harm oracle reroll first.
+- **Companion present:** companion harm is a separate move; do not roll Companion Endure Harm at the same time as Endure Harm. Each takes their own beat.

--- a/plugins/ironsworn/skills/ironsworn-suffer/references/endure-stress.md
+++ b/plugins/ironsworn/skills/ironsworn-suffer/references/endure-stress.md
@@ -1,0 +1,91 @@
+# Endure Stress — Full Workflow
+
+Same skeleton as Endure Harm, applied to spirit. The differences are in the debilities and the oracle.
+
+---
+
+## Sequence
+
+1. **Apply stress.** `suffer_stress` n=`<amount>`. Stress comes from: social betrayal, despair on a journey miss, witnessing horror, broken bond, Pay the Price.
+2. **Roll the move.** `resolve_move` move "Endure Stress", stat "heart".
+3. **Apply the result.**
+
+---
+
+## Outcome Table
+
+| Result | What happens | Tool sequence |
+|---|---|---|
+| Strong hit | Choose: Shake it off (+1 spirit, -1 momentum) OR Embrace the darkness (+1 momentum) | `restore_spirit` n=1 + `take_momentum` n=-1, OR `take_momentum` n=1 |
+| Weak hit | Press on. | — |
+| Miss | -1 momentum; if at 0 spirit, mark shaken or corrupted (if unmarked) OR roll Endure Stress oracle | `take_momentum` n=-1; `inflict_debility` OR `roll_oracle` "Endure Stress" |
+
+### Strong-hit `AskUserQuestion`
+
+```
+question: "You hold yourself together. How?"
+options:
+  - value: "shake"   label: "Shake it off"          description: "+1 spirit, -1 momentum (only if spirit > 0)"
+  - value: "embrace" label: "Embrace the darkness"  description: "+1 momentum, no spirit change"
+```
+
+---
+
+## 0-Spirit Miss: Debility OR Oracle
+
+When the miss happens *and* the character is at 0 spirit, the rule says: mark **shaken** or **corrupted** (if unmarked) OR roll the Endure Stress oracle.
+
+- Shaken unmarked → `inflict_debility` "shaken".
+- Shaken marked, corrupted unmarked → `inflict_debility` "corrupted".
+- Both marked → `roll_oracle` "Endure Stress".
+
+Offer the choice via `AskUserQuestion` only if both stress debilities are unmarked.
+
+---
+
+## Endure Stress Oracle (1d100)
+
+| Roll | Outcome |
+|---|---|
+| 1-10 | You are overwhelmed. **Face Desolation.** |
+| 11-25 | You give up. **Forsake Your Vow** (one relevant to your current crisis). |
+| 26-50 | You give in to a fear or compulsion, and act against your better instincts. |
+| 51-100 | You persevere. |
+
+### The 11-25 Forsake Branch — Most Dangerous Outcome in the Game
+
+This result *forces* a Forsake. The player does not choose; the dice did. Hand off:
+
+1. Identify the relevant vow. If multiple are open, ask the player which is most tied to the current crisis (`AskUserQuestion` with each open vow as an option).
+2. Hand off to `ironsworn-progress-tracks` to call `forsake_vow` — the tool applies stress equal to rank automatically. (Yes, the character is about to take *more* stress on top of the stress that triggered the oracle. That is the design.)
+3. Narrate: this is not a failed roll — this is the fiction breaking. The character has given up. Let the moment land.
+
+If the player has *no* open vows, the result becomes "you give in to a fear or compulsion" (treat as 26-50) — no Forsake possible.
+
+### The 26-50 Compulsion Branch
+
+The character acts against their better instincts. This is fiction, not a tool call:
+- Strike out at an ally
+- Flee a fight they could have won
+- Speak a truth that breaks a confidence
+- Take a drink, embrace a vice, hand over a relic
+
+Anchor it to lore via `search_lore_global` — what compulsion is *this character* prone to? Existing NPCs / threads will hint at the right shape.
+
+---
+
+## Worked Examples
+
+**Example 1 — social betrayal, mid-spirit.** Trusted NPC sells out the character. `suffer_stress` n=2 (spirit 4 → 2). Roll Endure Stress vs heart: weak hit. Press on. The character takes the blow but pushes forward.
+
+**Example 2 — at 0 spirit, miss.** Spirit is 0, shaken marked, corrupted unmarked. New stress event. `suffer_stress` n=1. Roll: miss. `take_momentum` n=-1. Corrupted is unmarked → `inflict_debility` "corrupted". The character is now corrupted: they are starting to make peace with darker thoughts. Narrate it.
+
+**Example 3 — at 0 spirit, both stress debilities marked, miss → oracle 18.** `roll_oracle` "Endure Stress" returns 18. Forsake. Player has two open vows (rank dangerous, rank formidable). Ask which is most tied to the crisis. Player picks formidable. Hand off to `ironsworn-progress-tracks`: `forsake_vow` track_name=`<vow>`. The tool applies 3 stress (formidable = 3). Spirit was already 0; nothing further to lose mechanically — but narratively the vow is dust.
+
+---
+
+## Edge Cases
+
+- **No open vows, oracle 11-25:** treat as 26-50 (compulsion).
+- **Already-tormented character:** the cursed/tormented debility has its own clear condition (complete a quest); Endure Stress can still happen and can still inflict shaken or corrupted as normal.
+- **Stress and harm in the same beat:** they are separate moves. Pick the one the fiction emphasizes; do not roll both unless the source genuinely inflicts both (e.g., a wraith's touch — physical and mental harm).

--- a/plugins/ironsworn/skills/ironsworn-suffer/references/face-death-desolation.md
+++ b/plugins/ironsworn/skills/ironsworn-suffer/references/face-death-desolation.md
@@ -1,0 +1,95 @@
+# Face Death & Face Desolation — Full Procedure
+
+These are the dramatic moves. They are rare. They may be the player's epilogue. Treat them with the weight they deserve.
+
+---
+
+## When Face Death Triggers
+
+- Endure Harm oracle 1-10 ("the harm is mortal").
+- Endure Harm oracle 11-20 with no Heal in the next hour or two.
+- Endure Harm oracle 21-35 *if* the character is vulnerable to a foe disinclined to mercy.
+- Direct fictional trigger: a killing blow, a fall from a great height, drowning, poison reaching the heart.
+
+## When Face Desolation Triggers
+
+- Endure Stress oracle 1-10 ("you are overwhelmed").
+- Direct fictional trigger: witnessing the unspeakable, watching the world end, crossing into a place that breaks the mind.
+
+---
+
+## Procedure
+
+1. **Pause the table.** Tell the player explicitly: "You are about to Face Death" (or Desolation). This is not a roll to slip past — it is a beat.
+2. **Pull lore.** `search_lore_global` for the threads, NPCs, factions tied to the cause of death/desolation. The fiction here must echo the campaign.
+3. **Roll.** `resolve_move` move "Face Death" or "Face Desolation", stat "heart".
+4. **Apply the outcome** with care.
+
+---
+
+## Face Death Outcomes
+
+| Result | What happens |
+|---|---|
+| Strong hit | Death rejects you. Cast back into the mortal world. Narrate why — what did Death see that turned it away? |
+| Weak hit | **Player chooses.** See below. |
+| Miss | Dead. Narrate the ending. Hand off to Write Your Epilogue if appropriate. |
+
+### Weak-hit choice — `AskUserQuestion`
+
+```
+question: "Death has come. What do you do?"
+options:
+  - value: "sacrifice" label: "Make a noble sacrifice"
+    description: "You die, but on your terms. Envision your final moments — what did your death buy?"
+  - value: "bargain"   label: "Bargain with Death"
+    description: "Death wants something. Swear an Iron Vow (formidable or extreme) to deliver. Fail to hit on the Vow → dead. Otherwise return, cursed."
+```
+
+### Bargain branch
+
+If "bargain":
+1. Decide what Death wants — `roll_oracle` if unsure, anchor it in lore.
+2. Hand off to `ironsworn-progress-tracks` `create_progress_track` kind="vow", rank="formidable" or "extreme" (player's choice; extreme is the harder pact).
+3. Roll Swear an Iron Vow immediately. Miss → dead. Hit → return.
+4. On return: `inflict_debility` "cursed". The cursed debility clears *only* by completing this Vow.
+
+---
+
+## Face Desolation Outcomes
+
+Same shape as Face Death, with spirit instead of body and "tormented" instead of "cursed".
+
+| Result | What happens |
+|---|---|
+| Strong hit | Resist. Press on. |
+| Weak hit | Player chooses: noble sacrifice (sanity breaks — narrate) OR vision-Vow. |
+| Miss | Lost to despair or horror. Narrate — they may walk into the wilderness, fall silent forever, or take their own life. |
+
+### Weak-hit vision-Vow
+
+The character sees a dreaded future. `roll_oracle` if unsure what the vision reveals — anchor it in existing lore (a faction's rise, a friend's fall, a community's end). Swear an Iron Vow (formidable or extreme) to prevent it. Same Swear-or-die structure as Face Death.
+
+On return: `inflict_debility` "tormented". Clears only by completing the Vow.
+
+---
+
+## Discipline
+
+- **Never invoke Face Death/Desolation casually.** They are reserved for the brink — when the mortal/spiritual stakes are at maximum.
+- **Always pause before rolling.** Confirm with the player. Some players want to play this beat fully; some need a breath.
+- **Narrate the outcome with care.** Even a strong hit deserves prose — Death looking at the character and turning away is a gift, and the moment matters.
+- **A miss is a miss.** If the dice say dead, the character is dead. Don't soften it. Hand off to whatever closing ritual the campaign uses (Write Your Epilogue if available, a final scene, a scribe of the events).
+- **The bargain Vow is sacred.** It is the most narratively important vow the character will ever take. The cursed/tormented debility persists as a constant reminder until it is complete.
+
+---
+
+## Worked Example — Face Death
+
+Character at 0 health, both wound debilities marked. New harm event. Endure Harm oracle returns 6 ("the harm is mortal"). GM pauses; tells player: "You are about to Face Death."
+
+`search_lore_global` "ravager" and "old Holtfen feud" — pulls in the rival the character has been hunting; the wound was theirs.
+
+Roll Face Death: weak hit. `AskUserQuestion`. Player picks "bargain". Asks the oracle: what does Death want? Oracle hint + the Holtfen feud → Death wants the rival's name struck from every stone in the Ironlands; the character must hunt down every grave-marker.
+
+`create_progress_track` name="Erase the Ravager's Name" rank="extreme" kind="vow". Roll Swear an Iron Vow (heart, +1 if bonded to Holtfen): strong hit. +2 momentum. Player returns to the mortal world. `inflict_debility` "cursed". The vow becomes the spine of the next arc.


### PR DESCRIPTION
## Summary

- Adds `ironsworn-suffer` skill covering all consequence beats: Endure Harm, Endure Stress, Companion Endure Harm, Sacrifice Resources, Out of Action, Face Death, Face Desolation. Skill applies the cost; `ironsworn-oracle` decides which cost.
- Documents the discipline ("a hit that costs nothing isn't a hit"), the apply-then-roll sequence, the 0-stat miss debility-or-oracle branch, and the Out-of-Action vs dead distinction.
- Cross-links combat (hits) → suffer (apply harm), social (betrayal) → suffer (apply stress), Pay the Price → suffer (apply consequence), Endure Stress 11-25 forced Forsake → progress-tracks, Face Death/Desolation Vow path → progress-tracks.
- Cites Fiction Grounding Protocol (#103) — every consequence beat pulls on existing lore via `search_lore_global` before narration.
- Plugin bumped to 0.16.0 (stack: oracle/social 0.14.0, combat 0.15.0, suffer 0.16.0).

Closes #98

## Test plan

- [ ] `SKILL.md` frontmatter description includes the literal player phrases ("I take harm", "I'm hit", "endure stress", "out of action", "face death", "sacrifice")
- [ ] Each Suffer move has 2-3 sentence Fiction Notes in `SKILL.md`
- [ ] Tools-this-skill-governs table is present near the top
- [ ] Endure Harm + Endure Stress full oracle tables live in `references/`
- [ ] Face Death / Face Desolation procedure (including AskUserQuestion + bargain-Vow handoff to progress-tracks) lives in `references/face-death-desolation.md`
- [ ] Cross-links to `ironsworn-combat`, `ironsworn-oracle`, `ironsworn-progress-tracks` resolve to actual sibling skills
- [ ] `plugin.json` version is 0.16.0 (no collision with peer PRs)
- [ ] Trigger smoke test: prompt "I take 2 harm from the wolf's bite" should match the skill description and route through `suffer_harm` + Endure Harm

🤖 Generated with [Claude Code](https://claude.com/claude-code)