### PR TITLE
feat(skill): add ironsworn-pacing mode-of-play skill (#101)

### DIFF
--- a/plugins/ironsworn/skills/ironsworn-pacing/SKILL.md
+++ b/plugins/ironsworn/skills/ironsworn-pacing/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: ironsworn-pacing
+description: >
+  Cross-cutting fiction-craft skill governing pacing decisions: montage vs
+  scene, time fluidity (one roll = hours OR days), tension shaping, and the
+  rising/breath/decisive shape of a session. ALWAYS invoke this skill at every
+  transition between beats — when the player says things like "we ride for
+  three days", "the days pass", "time skip", "we travel", "later that night",
+  "next morning", "we head out", "let's montage", "weeks later", or whenever a
+  scene ends, an arrival looms, a recovery moment opens, or the GM is about to
+  decide between zooming in and zooming out. Defers scene framing once you've
+  zoomed in to `ironsworn-scene-craft`; defers journey-arrival pacing to
+  `ironsworn-progress-tracks/references/journeys.md`. Never improvise rules
+  about "how much time per roll" — the rulebook is explicit that time is fluid.
+---
+
+# Ironsworn Pacing
+
+Pacing is the GM's decision about **where the camera lives**: zoomed out across days, or zoomed into a single breath. Ironsworn breathes in and out; this skill keeps the rhythm honest.
+
+---
+
+## Tools This Skill Governs
+
+| Tool | When |
+|---|---|
+| `search_rules` | Confirm RAW pacing guidance (montage, time fluidity) before improvising |
+| `search_lore` | Region/terrain/threat lookup before *any* travel narration |
+| `search_lore_global` | When the region isn't yet established locally |
+| `get_npc` | Settlement passed through — color from existing NPCs, not invention |
+| `record_scene` | Mark transitions worth indexing — montage close-out and the zoom-in after |
+| `tick_progress` | Cross-link — montage legs still tick; arrival → `ironsworn-progress-tracks` |
+
+---
+
+## When to Invoke
+
+Any transition between beats: travel, time skips, recovery, scene endings, imminent arrivals, breath beats (Make Camp, Sojourn aftermath, post-combat). Trigger phrases include "we ride three days", "the days pass", "later that night", "next morning", "we head out", "let's montage", "weeks later".
+
+---
+
+## The Three Decisions
+
+### 1. Montage or Scene?
+
+**Default to montage.** Zoom in only when at least one is true:
+- A move is triggered by the fiction (combat, social, journey roll)
+- The waypoint is intrinsically interesting (lore hit, named NPC, recurring threat)
+- The player signals investment ("what does X look like?")
+- A miss or match needs to land in detail
+
+Don't montage past a question with mechanical weight ("does she trust me?"). Worked examples → `references/montage-vs-scene.md`.
+
+### 2. Time Fluidity
+
+**RAW: time is fluid.** One roll might be an hour or a week. Set elapsed time *after* the roll, based on terrain, rank, and where the next interesting beat lies. Strong hits fast-forward days in a sentence; misses usually demand a scene. Cite a span only when fiction needs it (supply, deadline, vow timer). Never lock "one roll = one day." Palette → `references/time-fluidity.md`.
+
+### 3. Tension Shape
+
+Sessions breathe in three phases: **rising action** (short, escalating beats; compress travel) → **breath beat** (Make Camp, Sojourn, a quiet talk) → **decisive moment** (fully zoomed in; scene-craft's full kit). After every decisive moment, plan a breath beat. Patterns → `references/session-shape.md`.
+
+---
+
+## Fiction Grounding Protocol
+
+Even a one-sentence montage references established lore. Before narrating *any* travel or time skip:
+
+1. `search_lore` for the region/path
+2. Name terrain, settlements, and recurring threats from results — not invention
+3. If empty, `search_lore_global` then `roll_oracle` once, and commit the result
+
+A montage that names "the Deep Wilds" without checking what the world already established about it will contradict itself by session three.
+
+---
+
+## Boundaries
+
+- **Scene framing once zoomed in** (sensory anchoring, opening/closing) → `ironsworn-scene-craft`
+- **Journey arrival** (Reach Your Destination is a progress roll) → `ironsworn-progress-tracks/references/journeys.md`
+- **Pay the Price** on a journey miss → `ironsworn-oracle`
+- **Complication diversity** when the montage produces a complication → `ironsworn-complications`
+
+---
+
+## Common Mistakes
+
+- **Locking time to rolls.** "One roll = one day" is house-fiction, not RAW.
+- **Montaging past mechanical weight.** If a roll, a vow, or a relationship hangs on it, zoom in.
+- **Zooming in on every leg.** Four campfires in a row is filler.
+- **Skipping `search_lore` before a montage.** Even one sentence cites the world.
+- **No breath beats.** Three decisive moments back-to-back exhaust both player and GM.
+- **Narrating "they arrived" without rolling.** Arrival is a progress move.

--- a/plugins/ironsworn/skills/ironsworn-pacing/references/montage-vs-scene.md
+++ b/plugins/ironsworn/skills/ironsworn-pacing/references/montage-vs-scene.md
@@ -1,0 +1,80 @@
+# Montage vs Scene — Decision Reference
+
+The single most consequential pacing call is whether the next beat is a montage or a scene. The rulebook gives explicit permission to mix:
+
+> "Some waypoints will pass as a cinematic montage (doubtlessly depicted in a soaring helicopter shot as you trudge over jagged hills). Other waypoints offer opportunities to zoom in, enriching your story and your world."
+> — *Ironsworn*, "Waypoints" (search_rules: "montage scene zoom in zoom out")
+
+> "Time is fluid. The moves help dictate this flow, but you also have control. If it's interesting to you, if it impacts your story, focus on it. If not, abstract it."
+> — *Ironsworn* p. 222 (search_rules: "how much time passes per roll fluid")
+
+---
+
+## The Decision Palette
+
+| Signal | Default |
+|---|---|
+| Move is triggered by the fiction | Scene (zoom in for the move) |
+| Waypoint is intrinsically interesting (lore hit, recurring threat, named NPC) | Scene |
+| Player asks a question only a scene can answer ("does she trust me?") | Scene |
+| Miss + match on the move | Scene (the rulebook explicitly says: "It's time to zoom in") |
+| Strong hit on a routine leg | Montage |
+| Return trip through known territory | Montage (often troublesome, fast) |
+| Player wants mechanical benefit only (Make Camp for +momentum) | Compressed scene — one beat, then resolve |
+| Player narrates investment ("I want to play out the campfire") | Scene |
+
+The two safest defaults: **most legs are montages; misses and matches almost always zoom in.**
+
+---
+
+## Worked Example: Outbound (heavy montage)
+
+> Saskia rides south from the village. *(GM: search_lore on "south road" — returns the trade road through low hills.)*
+>
+> **Undertake a Journey** (Wits) → strong hit. She mostly stays zoomed out: a fair day's travel along the muddy trade road, a fat rabbit caught for dinner. *One sentence per leg. The first three rolls compress into a paragraph.*
+>
+> Fourth roll → miss + match. **Zoom in.** Standing stones called The Three Maidens. A vision in the night. The camera pulls in tight; this is no longer travel, it is a story beat.
+
+The rulebook explicitly walks through this pattern (p. 222). Treat it as the canonical model: montage compresses until something earns a scene.
+
+---
+
+## Worked Example: Return Trip (almost pure montage)
+
+> "Since this is a return trip, and you don't want to give it much story focus, you set it as merely troublesome. You are waylaid by a tense encounter with a protective ash bear and her cub, but eventually **Reach Your Destination**. This final journey also serves as a milestone on your quest."
+> — *Ironsworn* p. 219
+
+The whole journey home gets ~30 words. The bear is a *single* zoom-in. Then arrival. **The return trip is a textbook montage candidate.**
+
+---
+
+## Worked Example: Sojourn (montage with selective zoom-in)
+
+> "Narratively, you can imagine much of the time in this community passing as a montage. If you choose to focus on a recovery action, zoom into that scene and envision what happens."
+> — *Ironsworn* p. 83 (Sojourn move)
+
+The whole stay in town can be a paragraph; the *one* beat that matters (the conversation in the mead hall, the healer's room) gets the full scene-craft treatment. Don't play out every drink, every market visit, every street. Pick the moment that has weight.
+
+---
+
+## When to Resist a Zoom-In
+
+- **Four campfires in a row.** If the last three Make Camps were full scenes, this one is a sentence.
+- **Player is bored.** If the player is leaning back, you've already over-zoomed. Cut.
+- **No fiction question outstanding.** If you can't say what the scene is *for*, montage instead.
+
+---
+
+## When to Resist a Montage
+
+- **A vow's timer is real.** If a deadline is closing and the elapsed time matters, the player needs to feel days passing — slow down enough that supply and morale erode visibly.
+- **A relationship is unresolved.** If an NPC's trust is in question, the next beat with that NPC is a scene.
+- **The player is invested.** If they ask a follow-up question, that's a request to zoom in.
+
+---
+
+## Cross-Links
+
+- Once you've decided to zoom in: `ironsworn-scene-craft` owns framing, sensory anchoring, opening/closing beats.
+- Journey arrival is **always** a progress roll, never a montage past it: `ironsworn-progress-tracks/references/journeys.md`.
+- A miss-driven complication during montage uses the diversity protocol: `ironsworn-complications`.

--- a/plugins/ironsworn/skills/ironsworn-pacing/references/session-shape.md
+++ b/plugins/ironsworn/skills/ironsworn-pacing/references/session-shape.md
@@ -1,0 +1,78 @@
+# Session Shape — Rising Action, Breath, Decisive Moment
+
+A session breathes. Three phases recur; the GM's job is to keep the pattern legible.
+
+---
+
+## The Three Phases
+
+### Rising Action
+Short, escalating beats. Travel compressed. Each beat raises the stakes or narrows the options. **Pace: fast.** Most rolls are montage-leaning. Misses introduce complications without expanding into full scenes.
+
+### Breath Beat
+A pause. Make Camp. Sojourn aftermath. A quiet conversation by the fire. **Pace: slow.** One zoomed-in scene, often without combat or a major move. The point is to feel the weight of what's been spent and re-anchor character voice. The rulebook explicitly endorses this through Sojourn:
+
+> "Narratively, you can imagine much of the time in this community passing as a montage. If you choose to focus on a recovery action, zoom into that scene and envision what happens."
+> — *Ironsworn*, Sojourn (p. 83)
+
+### Decisive Moment
+Fully zoomed in. Every detail concrete. Combat climaxes, Fulfill Your Vow, End the Fight, Face Death. **Pace: dilated to seconds.** Use the full scene-craft kit. These earn their weight from contrast with the montaged rising action that preceded them.
+
+---
+
+## The Rhythm Rule
+
+**After every decisive moment, plan a breath beat.** After every breath beat, restart rising action. Three decisive moments back-to-back without a breath beat will exhaust the player and flatten the dramatic curve.
+
+If the previous session ended in a decisive moment, **open the next one with a breath beat** — the player needs to feel the cost before climbing again.
+
+---
+
+## Session Length and Quest Rank
+
+The rulebook's one-shot guidance is a useful pacing yardstick even for ongoing campaigns:
+
+> "Give your quest a rank of troublesome (for a session of an hour or two) or dangerous (for a session of three to four hours)... Adjust the pace of your milestones and the detail of your scenes as appropriate for the time you have available. Focus on what is interesting, and zoom out or abstract what is unimportant."
+> — *Ironsworn* p. 231 (search_rules: "session length quest rank pace")
+
+**Implication for pacing:** the higher the rank, the more aggressively you should montage non-decisive beats. A formidable vow can't be played out in granular detail without bloating the campaign.
+
+---
+
+## Milestone Cadence Sets the Macro Pace
+
+> "How you define milestones determines the pace of your game... if you come up against relatively simple obstacles and call them milestones, you'll mark progress and move quickly toward completing the quest. But, if you do, you'll miss out on storytelling opportunities."
+> — *Ironsworn*, Reach a Milestone (p. 111)
+
+> "If your progress track is filling up well ahead of your story, slow down the pace and focus on key objectives and turning points as milestones. If you find your story moving to a resolution well ahead of your progress track, envision some complications or twists which alter your path."
+> — *Ironsworn* p. 219
+
+Pacing is not just within a session. Track-vs-story alignment is the macro lens. If milestones are coming faster than dramatic weight, slow them down. If the fiction is racing ahead of progress, introduce twists.
+
+---
+
+## Common Session-Shape Failures
+
+- **All rising action, no breath beats.** Player burns out. Insert a Make Camp or Sojourn even if the player doesn't ask.
+- **All breath beats.** Cozy but stalled. Restart rising action with an oracle-driven complication or a thread escalation.
+- **Decisive moment without setup.** A boss fight with no rising action is a boss fight without weight. Compress 2-3 montaged rising-action beats first.
+- **Decisive moment without aftermath.** The big fight ends, immediately into the next quest. Always give a breath beat after a climax.
+
+---
+
+## A Heuristic: The Camera Distance Per Beat
+
+Across a 2-3 hour session, aim for roughly:
+- **60-70%** of beats at montage / wide-shot distance (rising action, travel)
+- **20-25%** at scene distance (breath beats, key conversations, mid-tier moves)
+- **5-15%** at dilated decisive distance (climactic moves, Fulfill, End the Fight)
+
+If your last hour was 80% scene-distance, you've over-zoomed. Cut to a montage and re-establish rising action.
+
+---
+
+## Cross-Links
+
+- Scene-distance beats are framed by `ironsworn-scene-craft`.
+- Decisive-moment moves (End the Fight, Fulfill Your Vow, Reach Your Destination) live in `ironsworn-progress-tracks` (and `ironsworn-combat` for combat).
+- Breath-beat recovery moves (Make Camp, Sojourn, Resupply) are mechanically governed by `ironsworn-progress-tracks` and `ironsworn-social`.

--- a/plugins/ironsworn/skills/ironsworn-pacing/references/time-fluidity.md
+++ b/plugins/ironsworn/skills/ironsworn-pacing/references/time-fluidity.md
@@ -1,0 +1,80 @@
+# Time Fluidity — How Much Time Passes Per Roll
+
+The rulebook is explicit and load-bearing on this:
+
+> "Depending on the scale of the current action, you might be visualizing a montage of days (a journey, for example) or the passing of a mere second (an intense fight). Always think from the standpoint of the fiction—even if it's obvious what move you'll make."
+> — *Ironsworn*, "Best Practices for Moves" p. 61
+
+> "Time is compressed. An entire day passes. If your roll had failed, something went wrong... This is the ebb and flow of play. Time is fluid. The moves help dictate this flow, but you also have control. If it's interesting to you, if it impacts your story, focus on it. If not, abstract it."
+> — *Ironsworn* p. 222
+
+**There is no canonical "one roll = X time" rule.** Anyone telling you otherwise is improvising.
+
+---
+
+## Setting Elapsed Time (After the Roll)
+
+Decide *after* the roll, using these inputs:
+
+| Input | Effect |
+|---|---|
+| **Rank of the journey/track** | Higher rank → longer span per roll. Troublesome leg: hours; epic leg: weeks. |
+| **Terrain & speed** | Open road on horseback compresses; broken country on foot dilates. |
+| **Outcome** | Strong hit can fast-forward; weak hit/miss usually demands a scene with detail. |
+| **Story focus** | If the next interesting beat is far ahead, compress. If close, dilate. |
+| **Pressure** | Vow deadline, supply crunch, pursuit — these favor citing exact spans (days, watches). |
+
+**Default by rank (loose guideline, not RAW):**
+
+| Rank | Typical span per Undertake roll |
+|---|---|
+| Troublesome | Hours to a day |
+| Dangerous | A day to a few days |
+| Formidable | Several days to a week |
+| Extreme | A week to weeks |
+| Epic | Weeks to a month-plus |
+
+These are *defaults the GM can override* whenever the fiction calls for compression or dilation. A troublesome roll across the Deep that's set up as the first leg of a long voyage might cover three days. A formidable roll on a tight deadline might be a single tense night.
+
+---
+
+## When to State the Span
+
+State the span explicitly when:
+- Supply is in play (the player needs to feel it draining)
+- A vow has a deadline (days remaining have narrative weight)
+- A pursuer is closing
+- The world is changing in the background (winter coming, a war escalating)
+
+State the span *vaguely* otherwise — "some days later", "eventually", "after a long ride". The player doesn't need a calendar most of the time.
+
+---
+
+## Common Anti-Patterns
+
+- **"One roll = one day" lock.** Houserule masquerading as rules. Drop it.
+- **Counting hours during montage.** If you're counting, you've under-zoomed.
+- **Compressing a deadline beat.** The player needs to feel the days pass when a vow timer is closing — that's *exactly* when granularity matters.
+- **Dilating a routine leg.** If three rolls cover the same uneventful ride, montage them into a paragraph.
+
+---
+
+## Worked Examples
+
+**Strong hit, formidable journey (compress):**
+> "You ride east for the better part of a week. The hills give way to the high moors, and by the seventh evening you smell the sea."
+*One roll, ~6 days, one paragraph.*
+
+**Weak hit, dangerous journey (state the cost):**
+> "Two days of hard riding. A storm catches you on the second night and the wineskin freezes through. (-1 supply.) You make Holtfen by dusk on the third day."
+*One roll, 2-3 days, supply called out because it matters.*
+
+**Miss, troublesome journey (zoom in):**
+> "You're three hours out of the village when..."
+*Roll → scene. Time becomes minutes; the camera pulls tight.*
+
+---
+
+## Cross-Link
+
+Journey arrival itself (Reach Your Destination) is a **progress roll**, governed by `ironsworn-progress-tracks/references/journeys.md`. Don't narrate "they arrived" without rolling.


### PR DESCRIPTION
Closes #101

## Summary
- Adds `plugins/ironsworn/skills/ironsworn-pacing/` — a cross-cutting fiction-craft skill teaching the GM **when to montage, when to zoom in, and how to manage time fluidity**
- 558-word `SKILL.md` (within the umbrella's ~500-word ceiling for pacing)
- Three references for progressive disclosure: `montage-vs-scene.md`, `time-fluidity.md`, `session-shape.md`
- Activates on transitions between beats — trigger phrases include `"we ride for three days"`, `"the days pass"`, `"later that night"`, `"we head out"`, scene endings, arrivals, and recovery moments
- Cross-links to peer skills: defers scene framing once zoomed in to `ironsworn-scene-craft`; defers journey-arrival pacing to `ironsworn-progress-tracks/references/journeys.md`; defers Pay the Price to `ironsworn-oracle`; defers complication diversity to `ironsworn-complications`
- Cites RAW pages for every pacing claim (p. 61, p. 65 Waypoints, p. 83 Sojourn, p. 219, p. 222 "Time is fluid", p. 232 milestones) — pulled via `search_rules`, not improvised
- Includes Fiction Grounding Protocol (#103): even one-sentence montages must `search_lore` for terrain/settlements/recurring threats before narrating

## Test plan
- [ ] `SKILL.md` body is ~500-600 words (verified 558)
- [ ] Front-matter `description` includes literal trigger phrases and an "ALWAYS invoke" sentence
- [ ] "Tools This Skill Governs" table lists `search_rules`, `search_lore`, `search_lore_global`, `get_npc`, `record_scene`, `tick_progress`
- [ ] Cross-links resolve to existing peer skill paths
- [ ] All rule paraphrases cite chapter/page or the `search_rules` query used
- [ ] No version bump in `plugin.json` (lead handles single sequenced bump after all 4 PRs merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)