### PR TITLE
feat(skill): add ironsworn-npc-voice mode-of-play skill (#100)

### DIFF
--- a/plugins/ironsworn/skills/ironsworn-npc-voice/SKILL.md
+++ b/plugins/ironsworn/skills/ironsworn-npc-voice/SKILL.md
@@ -75,20 +75,19 @@ Three answers held in the moment:
 These flow from recorded **drives** (rulebook p. 146). Drives are an outline; this scene's want/fear is the shape drives take *now*. If unclear, `roll_oracle("what do they want from this exchange?")` and `upsert_npc`.
 
 ### 3. Reaction — how they respond under pressure
-Rulebook discipline (p. 80, 146, 148):
+Rulebook discipline (p. 80, 146, 148): strong hit → they comply, but *how* reflects drives; weak hit → the ask back echoes want/fear, never a generic favor; miss → refusal or costly demand voiced from what they will not budge on. Under bond strain (Test Your Bond, Compel against a bonded NPC) the recorded bond shapes how loud and how wounded the reaction sounds. NPCs do not roll dice — when next action is unclear, **Ask the Oracle** (rulebook p. 89, 215).
 
-- Strong hit on a player's social move → they comply, but *how* still reflects drives
-- Weak hit → the ask back must echo their want/fear, never a generic favor
-- Miss → refusal or costly demand voiced from what they will not budge on
-- Under bond strain (Test Your Bond, Compel against a bonded NPC) the recorded bond shapes how loud and how wounded the reaction sounds
+---
 
-NPCs do not roll dice. When tone or next action is unclear, **Ask the Oracle** (rulebook p. 89, 215).
+## Where Voice Lands in a Scene
+
+Delivered inside `ironsworn-scene-craft`'s structure: the NPC's **scene-want** is usually the **visible-stake** line of framing; a delivered line lands best as the scene's **closing image** or **question** (see `ironsworn-scene-craft/references/closing-beats.md`); reactions under bond strain belong in a *zoomed-in* beat — if the beat can't be named in one sentence, defer to `ironsworn-pacing`.
 
 ---
 
 ## Capturing Development
 
-When a beat reveals or shifts something durable — a secret named, a disposition changed by betrayal or kindness, a new drive surfaced — call `upsert_npc` with the updated impression and tags. Without this step, the next session's voice drifts. Bond increments themselves are governed by `ironsworn-social`; this skill captures the *character note* that should follow.
+When a beat reveals something durable — a secret named, a disposition shifted, a new drive surfaced — call `upsert_npc` with the updated impression and tags. Without this, next session's voice drifts. Bond increments themselves are governed by `ironsworn-social`.
 
 ---
 

--- a/plugins/ironsworn/skills/ironsworn-npc-voice/SKILL.md
+++ b/plugins/ironsworn/skills/ironsworn-npc-voice/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: ironsworn-npc-voice
+description: >
+  Governs NPC voice, motivation, reactions, and continuity in Ironsworn fiction.
+  ALWAYS invoke this skill whenever an NPC has a non-trivial line of dialogue
+  or reaction — when the player narrates or asks things like "<name> says",
+  "how does <name> respond", "what does <name> think of this", "I talk to
+  <name>", "what does <name> do", "they reply", or whenever the GM is about
+  to put words in an NPC's mouth or describe their reaction. Cross-cuts every
+  mechanics skill; activates on the *moment of speech or reaction*, not on a
+  specific move. Defers bond mechanics to ironsworn-social and initial NPC
+  creation to ironsworn-character-builder. Never improvise NPC voice from
+  memory alone — always ground in lore first.
+---
+
+# Ironsworn NPC Voice
+
+NPCs in Ironsworn have no stats — they exist entirely in fiction (rulebook p. 24, 133). This skill is the craft layer for keeping them **distinctive, motivated, and continuous** across sessions. Every line and reaction must be grounded in the lore record.
+
+---
+
+## Tools This Skill Governs
+
+| Tool | When |
+|---|---|
+| `get_npc` | Read full NPC record before generating any dialogue or reaction |
+| `search_lore_global` | Pull faction, prior scenes, related entities, debts |
+| `search_rules` | Confirm rulebook texture (Compel, NPC drives) before paraphrasing |
+| `upsert_npc` | Capture significant development — new disposition, revealed secret, shifted impression |
+
+---
+
+## When to Invoke
+
+- An NPC is about to speak — any quoted line, any "they reply", any "<name> says..."
+- The player asks "how does <name> respond / feel / react?"
+- An NPC must react under pressure (Compel weak/miss, Test Your Bond, betrayal, reveal)
+- The GM is describing tone or body-language in a beat that matters
+- A returning NPC steps onstage — voice continuity check is mandatory
+
+Defer bond increments and the social-move outcome tables (Compel, Sojourn, Forge/Test Your Bond) to `ironsworn-social`. Defer first-time NPC scaffolding inside character creation to `ironsworn-character-builder`. This skill teaches *how they sound*, not *what mechanic resolves the beat*.
+
+---
+
+## Fiction Grounding Protocol (#103) — Mandatory Before Speech
+
+Before generating any line, body-language beat, or reaction:
+
+1. `get_npc(name)` — disposition, drives, impressions, bonds.
+2. `search_lore_global(query)` for the NPC's faction, community, related entities, recent scenes.
+3. If a fact is missing (accent, opinion of player, secret), `roll_oracle` first, then `upsert_npc` so the answer is durable.
+
+**Voice must match what is recorded.** A returning NPC who was "warily curious" last scene cannot suddenly be effusive without an in-fiction reason. If the recorded fact contradicts the moment you want, either play the recorded fact or have the NPC visibly change — and `upsert_npc` to capture the shift.
+
+---
+
+## The Three Pillars
+
+### 1. Voice — how they sound
+Three tight constraints per significant NPC, drawn from disposition tags, faction, and rulebook NPC features (p. 146):
+
+- **Vocabulary** — words they use *and words they avoid*
+- **Rhythm** — clipped vs flowing, riddled vs blunt, formal vs intimate
+- **Negative space** — truths they hide, names they refuse, oaths they will not break
+
+Continuity across sessions comes from re-reading the record every time. Palette in `references/voice-archetypes.md`.
+
+### 2. Motivation — what they want this scene
+Three answers held in the moment:
+
+- **Want** — what they are trying to get out of this scene
+- **Fear** — what they are trying to avoid or hide
+- **Will not budge on** — the line they will pay any cost to defend
+
+These flow from recorded **drives** (rulebook p. 146). Drives are an outline; this scene's want/fear is the shape drives take *now*. If unclear, `roll_oracle("what do they want from this exchange?")` and `upsert_npc`.
+
+### 3. Reaction — how they respond under pressure
+Rulebook discipline (p. 80, 146, 148):
+
+- Strong hit on a player's social move → they comply, but *how* still reflects drives
+- Weak hit → the ask back must echo their want/fear, never a generic favor
+- Miss → refusal or costly demand voiced from what they will not budge on
+- Under bond strain (Test Your Bond, Compel against a bonded NPC) the recorded bond shapes how loud and how wounded the reaction sounds
+
+NPCs do not roll dice. When tone or next action is unclear, **Ask the Oracle** (rulebook p. 89, 215).
+
+---
+
+## Capturing Development
+
+When a beat reveals or shifts something durable — a secret named, a disposition changed by betrayal or kindness, a new drive surfaced — call `upsert_npc` with the updated impression and tags. Without this step, the next session's voice drifts. Bond increments themselves are governed by `ironsworn-social`; this skill captures the *character note* that should follow.
+
+---
+
+## References
+
+- `references/voice-archetypes.md` — voice archetypes as a starting palette
+- `references/example-dialogues.md` — worked examples: returning-NPC continuity, bond strain, miss-on-Compel refusal in-voice

--- a/plugins/ironsworn/skills/ironsworn-npc-voice/references/example-dialogues.md
+++ b/plugins/ironsworn/skills/ironsworn-npc-voice/references/example-dialogues.md
@@ -1,0 +1,114 @@
+# Example Dialogues — Worked Beats
+
+Three worked examples covering the cases that go wrong most often: continuity across sessions, reaction under bond strain, and refusing in-voice on a Compel miss.
+
+Each example shows the **lore record** the GM read first, the **want / fear / will-not-budge** for the scene, and the **delivered beat**. Read these to internalize the discipline — *then* improvise.
+
+---
+
+## Example 1 — Returning NPC, voice continuity
+
+**Setup.** Three sessions ago the player met **Branwen**, a smuggler-captain on the Veiled Coast. Last session she ferried them across the Sound and asked for a future favor (open thread, kind=`debt`). Tonight the player returns to her dock.
+
+**What the GM reads first:**
+
+```
+get_npc(name: "Branwen")
+  → disposition: "wary, transactional, faintly amused"
+  → drives: "keep the run alive; protect her crew; never owe iron"
+  → impressions: "S2 — called the Ironsworn 'friend' twice, which she
+    reserves for people she may need to disappear"
+  → bonds: 0
+  → tags: ["smuggler", "veiled-coast", "debt-open"]
+
+search_lore_global(query: "Branwen smuggler veiled coast")
+  → top result: scene S5 — she lost a deckhand to a Frostborn patrol last
+    fall; she blames the cleric who tipped them off
+```
+
+**This scene:**
+- **Want**: information about the cleric — but never to ask for it
+- **Fear**: looking like she needs the Ironsworn
+- **Will not budge on**: never naming her dead deckhand out loud
+
+**Delivered beat (player walks onto the dock):**
+
+> She sees you before you see her. Doesn't wave. Coils a line, finishes the coil, *then* looks up.
+>
+> "Ironsworn. Friend. — You came back, and you came back walking. That's two surprises before noon." A half-smile. "I don't suppose you've been east of the Iron Bridge lately. No reason. Just — the wind has been odd this season."
+
+Notice: archetype-5 vocabulary (*friend* as warning), the recorded phrase "friend" is used because the lore *records* she uses it that way, and the dead deckhand is in the negative space — gestured at by "the wind has been odd" but never named. The cleric question is laundered through weather-talk because she will not be seen to ask.
+
+---
+
+## Example 2 — Reaction under bond strain (Test Your Bond, weak hit)
+
+**Setup.** Player has a bond with **Old Halric**, an Iron-Town magistrate (archetype 3) who once vouched for them when their vow was contested. Player rolls Test Your Bond +heart on a weak hit: Halric is fragile in this moment and asks for proof of loyalty.
+
+**What the GM reads first:**
+
+```
+get_npc(name: "Old Halric")
+  → disposition: "principled, weary, secretly afraid of being wrong"
+  → drives: "uphold the law; protect the town; never see a record falsified"
+  → bonds: 1 with Ironsworn
+  → tags: ["magistrate", "iron-town", "bonded"]
+
+search_lore_global(query: "Halric magistrate Iron Town record")
+  → context: Halric's son was hanged on a forged record three years ago;
+    the player helped uncover it but Halric still hasn't spoken of his son
+```
+
+**This scene:**
+- **Want**: the player to *prove* the loyalty so he doesn't have to ask twice
+- **Fear**: that the bond was always one-sided
+- **Will not budge on**: he will not say his son's name out loud
+
+**Delivered beat (Halric's chambers, fire low):**
+
+> Halric does not stand. The third-person form returns — never a good sign.
+>
+> "The magistrate is asked to rule on a quiet matter. The magistrate finds — that he cannot." He sets down the tally-stone. "The Ironsworn knows what was lost in this room. The Ironsworn knows the name we do not speak. Bring me the merchant's ledger by the second bell. Not the copy. The original. — If the Ironsworn cannot, the magistrate must rule alone, and the magistrate is tired of ruling alone."
+
+Notice: rhythm collapses to third-person under bond strain (recorded archetype trait), the dead son is in the negative space ("the name we do not speak"), and the ask back from the weak hit *echoes* his drives (a falsified record is the wound he cannot risk again) — not a generic favor.
+
+After the scene, the GM calls `upsert_npc` to record: *"S9 — Halric named the wound for the first time, obliquely. Disposition shift: still principled, but now visibly leaning on the Ironsworn."*
+
+---
+
+## Example 3 — Compel miss: refusal in-voice
+
+**Setup.** Player attempts to Compel **Sera the Frostborn diplomat** (archetype 6) into withdrawing the levy on their home village. Rolls +iron (threaten) — miss. Rulebook: refusal or costly demand. The GM voices the refusal *as Sera*, then defers the mechanical Pay the Price to `ironsworn-suffer`.
+
+**What the GM reads first:**
+
+```
+get_npc(name: "Sera")
+  → disposition: "courteous, glacial, never raises voice"
+  → drives: "honor the treaty; embarrass nobody including herself; outlast"
+  → impressions: "S3 — declined the player's first overture with a smile;
+    has not forgotten"
+  → tags: ["frostborn", "diplomat", "treaty-keeper"]
+```
+
+**This scene:**
+- **Want**: the levy stands and the conversation ends without a scene
+- **Fear**: any record of being threatened in her own hall
+- **Will not budge on**: she will not break form, even struck
+
+**Delivered beat (player has just made the threat; dice come up a miss):**
+
+> Sera does not move. She is one beat slower than the room. Then she lifts the cup, drinks, sets it down.
+>
+> "You are tired. The road from your village is long, and I have kept you standing. Forgive me." A pause that costs you. "The levy stands. I will have the steward see you to the gate. If you raise your voice in this hall a second time, Ironsworn, the steward will see you to the *border*, and I will be very sorry to have lost you."
+
+Notice: no contraction, no raised voice (archetype 6), implied threat ("the *border*") rather than a stated one. The refusal lands inside the things she will not budge on — form. The GM then hands off to `ironsworn-suffer` for the Pay the Price (likely Endure Stress, possibly a costly demand opened as a debt thread).
+
+---
+
+## What to take away
+
+- The **lore read** is the first beat. Voice that ignores the record contradicts itself within two sessions.
+- The **want / fear / will-not-budge** triple is what makes a line feel pressured rather than ornamental.
+- The most memorable lines often live in the **negative space** — what the NPC *won't* say.
+- After any beat that revealed something durable, **`upsert_npc`** before moving on. The next session is built on what you record, not what you remember.

--- a/plugins/ironsworn/skills/ironsworn-npc-voice/references/voice-archetypes.md
+++ b/plugins/ironsworn/skills/ironsworn-npc-voice/references/voice-archetypes.md
@@ -1,0 +1,94 @@
+# Voice Archetypes — Starting Palette
+
+A starting palette of voice archetypes you can blend with an NPC's recorded faction, disposition, and drives. **Never use these in place of the lore record** — they're a scaffold for *how* a recorded trait should sound, not a substitute for `get_npc` / `search_lore_global`.
+
+For each archetype: **vocabulary** (words they reach for; words they avoid), **rhythm** (sentence shape, pacing), **negative space** (what they will not say, even under pressure).
+
+---
+
+## 1. The Hinterlander Clan-Warrior
+
+- **Vocabulary**: oaths, kin-words, weapon-names, weather. Avoids: abstractions ("perhaps", "concept", "frankly").
+- **Rhythm**: short, declarative. Verbs first. Pauses where a softer speaker would qualify.
+- **Negative space**: will not name a coward; will not explain a debt of blood; will not speak the dead's name lightly.
+
+> "I rode three days. The horse is yours. The matter — that you and I will speak of by the fire."
+
+---
+
+## 2. The Deep Wilds Elder
+
+- **Vocabulary**: river, root, season, breath, the old word for things. Avoids: clock-time, coin-words, "I think".
+- **Rhythm**: long, looping. Ends questions you didn't ask. Trails into silence and lets you fill it.
+- **Negative space**: will not give a straight yes; will not name the spirits casually; will not confirm what you already know.
+
+> "You came down through the alder cut. The hounds were quiet for you, then. That is something."
+
+---
+
+## 3. The Iron-Town Magistrate
+
+- **Vocabulary**: oath, levy, custom, precedent, the law, the records. Avoids: "maybe", endearments, first names without title.
+- **Rhythm**: balanced clauses, weight on the second half. Refers to itself in the third person under pressure.
+- **Negative space**: will not contradict the written record in public; will not concede a favor; will not bend on a sworn matter even if the law is wrong.
+
+> "The matter is recorded. The matter is closed. If the Ironsworn wishes the matter reopened, the Ironsworn will swear it before the stone."
+
+---
+
+## 4. The Smuggler-Captain
+
+- **Vocabulary**: tide, weight, share, the run, *friend* (used as warning). Avoids: oaths, formal titles, the names of authorities.
+- **Rhythm**: fast on the safe topics, slow and exact on numbers. Smiles in the wrong places.
+- **Negative space**: will not name the buyer; will not say "no" — will say "not for that price"; will not ever say "always".
+
+> "We carry. We don't ask. Your iron sees you across the sound — your name doesn't. Friend."
+
+---
+
+## 5. The Cleric of the Old Gods
+
+- **Vocabulary**: wound, vigil, ash, the long road, the cost. Avoids: trivial pleasantries, modern names, anything quick.
+- **Rhythm**: liturgical. Speaks in pairs. Repeats your own words back at you.
+- **Negative space**: will not absolve without weight; will not lie in the temple; will not name the god they fear.
+
+> "You came hungry. You came hungry and armed. The gods know which to feed first."
+
+---
+
+## 6. The Frostborn Diplomat
+
+- **Vocabulary**: courtesy, distance, the long view, *kin* (used coldly). Avoids: contractions, slang, anger-words.
+- **Rhythm**: even, glacial. Always one beat slower than the room expects.
+- **Negative space**: will not raise voice; will not threaten directly — implies; will not break form even when struck.
+
+> "You are tired. Sit. The wine is from your river. I had it brought up the day I was told you were coming."
+
+---
+
+## 7. The Broken Veteran
+
+- **Vocabulary**: weight, the cold, *that one*, *the boy*, names not spoken. Avoids: grand words, present tense for old things.
+- **Rhythm**: jagged. Starts strong, dies mid-sentence, restarts somewhere else.
+- **Negative space**: will not look directly at certain objects; will not say the place-name; will not ask for help in plain words.
+
+> "I — no. The pass. We took the pass. Most of us. Don't put me back there, Ironsworn. Don't."
+
+---
+
+## 8. The Trickster Stranger
+
+- **Vocabulary**: questions, riddles, your own name said too often, fragments of three other dialects. Avoids: clarity.
+- **Rhythm**: unpredictable. Answers a different question than the one asked. Repeats with a twist.
+- **Negative space**: will not give a true name; will not stand still in a doorway; will not confirm what they did yesterday.
+
+> "Yes. No. Both. — You asked it that way last time, too. Did you like the answer?"
+
+---
+
+## How to Use
+
+1. Read the NPC record (`get_npc`) and lore (`search_lore_global`).
+2. Find the archetype whose vocabulary/rhythm/negative-space *most matches* the recorded faction and disposition.
+3. **Blend, don't copy.** Take the rhythm from one, the negative space from another, the vocabulary from the lore. The archetype is a starting frequency, not a costume.
+4. After the scene, if a memorable phrase or refusal emerged, `upsert_npc` to make it durable.


### PR DESCRIPTION
Closes #100

## Summary
- Adds `plugins/ironsworn/skills/ironsworn-npc-voice/` — cross-cutting fiction-craft skill activated whenever an NPC has a non-trivial line of dialogue or reaction (`" says"`, `"how does <name> respond"`, `"what does <name> think"`, etc.).
- Main SKILL.md (~670 words main body) covers: Tools governed (`get_npc`, `search_lore_global`, `search_rules`, `upsert_npc`), When to invoke, mandatory Fiction Grounding Protocol (#103) before any speech, and the three pillars — voice (vocabulary / rhythm / negative space), motivation (want / fear / will-not-budge), reaction under pressure with rulebook-grounded discipline (Compel p.80, NPC features p.146, NPC components p.133).
- `references/voice-archetypes.md` — eight archetype voices as a starting palette (Hinterlander warrior, Deep Wilds elder, Iron-Town magistrate, smuggler-captain, cleric, Frostborn diplomat, broken veteran, trickster stranger), each with vocabulary/rhythm/negative-space.
- `references/example-dialogues.md` — three worked beats: returning-NPC continuity, bond-strain reaction (Test Your Bond weak hit), Compel miss with refusal voiced in-character.
- Cross-links: defers bond increments and social-move outcome tables to `ironsworn-social`; defers initial NPC creation to `ironsworn-character-builder`.
- Per umbrella #105 protocol, this PR does **not** bump `plugin.json` — the lead handles a single sequenced version bump after all four umbrella PRs merge.

## Test plan
- [ ] Skill loads (no malformed front-matter): `cat plugins/ironsworn/skills/ironsworn-npc-voice/SKILL.md`
- [ ] Trigger phrases match player narration patterns the GM agent would see (`" says"`, `"how does X respond"`, `"what does X think of this"`)
- [ ] Manual GM session: when an NPC speaks, the skill activates, the GM calls `get_npc` + `search_lore_global` before generating dialogue, and voice is consistent with prior recorded impression
- [ ] Cross-link sanity: bond increments still flow through `ironsworn-social` (no duplication of social-move tables here); initial NPC creation still flows through `ironsworn-character-builder`
- [ ] No `plugin.json` change in this PR (umbrella #105 sequences the version bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)