### PR TITLE
feat(skill): add ironsworn-complications mode-of-play skill (#102)

### DIFF
--- a/plugins/ironsworn/skills/ironsworn-complications/SKILL.md
+++ b/plugins/ironsworn/skills/ironsworn-complications/SKILL.md
@@ -20,9 +20,7 @@ description: >
 
 # Ironsworn Complications — Craft Layer
 
-A miss without a cost is a lie. A complication without texture is paperwork. This skill is the craft layer between "a cost is owed" and "the player feels it."
-
-It does **not** own the diversity protocol — `agents/ironsworn-gm.md` enforces that via `get_recent_complications`. It does **not** own which Pay the Price consequence applies — `ironsworn-oracle` does. It owns *texture*: how the cost lands in the senses, in the lore, in the campaign's weight.
+A miss without a cost is a lie. A complication without texture is paperwork. This skill is the craft layer between "a cost is owed" and "the player feels it." It does not own diversity-protocol enforcement (`agents/ironsworn-gm.md` does, via `get_recent_complications`) or the Pay the Price *decision* (`ironsworn-oracle` does). It owns *texture* — how the cost lands in the senses, in the lore, in the campaign's weight.
 
 ---
 
@@ -44,22 +42,21 @@ Handoffs: `ironsworn-oracle` (which consequence), `ironsworn-suffer` (the harm/s
 ## When to Invoke
 
 - Any miss whose outcome reads "Pay the Price" — combat, journey, social, scene challenge.
-- A **match** on the challenge dice — strong-hit twist or miss-heightened complication (p.9, p.117). Matched 10s on a miss = "as bad as things get."
-- A weak-hit "victory comes at a cost" beat.
-- The GM volunteers a complication to escalate stakes outside a specific roll.
-- The player narrates "things get worse" or asks "what does the world do."
+- A **match** on the challenge dice (p.9, p.117) — twist on strong hits, heightened complication on misses. Matched 10s on miss = *"as bad as things get."* On social moves a match makes the refusal louder and the demand more pointed — defer voice to `ironsworn-npc-voice`.
+- A weak-hit "victory comes at a cost" beat — including social weak hits where the NPC asks something in return (rulebook p.80). The favor *is* a complication; it lands as a debt thread that must echo the NPC's drives.
+- The GM volunteers a complication to escalate stakes; the player narrates "things get worse" or asks "what does the world do."
 
-If the fiction obviously points at one cost (combat miss → harm; storm scene → freeze), skip to texture — but never skip the diversity check.
+If the fiction obviously points at one cost (combat miss → harm), skip to texture — but never skip the diversity check.
 
 ---
 
 ## The Discipline
 
-1. **Ground first.** `search_lore_global` + `list_threads`. The world has unfinished business — complications grown from existing threads, NPC grudges, or world truths land harder than invention.
-2. **Diversity check.** `get_recent_complications` (k=5). Pick a category not dominating recent history. Palette menu in `references/palette.md`.
+1. **Ground first.** `search_lore_global` + `list_threads`. Complications grown from existing threads, NPC grudges, or world truths land harder than invention. If an NPC is onstage, ground the consequence in *their drives* (per `ironsworn-npc-voice`) before reaching for the palette — the diplomat who will not budge is the consequence.
+2. **Diversity check.** `get_recent_complications` (k=5). Pick a category not dominating recent history (palette in `references/palette.md`).
 3. **Choose the consequence type** — defer to `ironsworn-oracle`'s Pay the Price discipline (flat cost → escalate existing thread → invent rarely, 0–1/session).
 4. **Texture.** One sensory beat — sound, smell, weight, cold, posture. No "you feel," "you notice," "perhaps."
-5. **Apply the mutation.** Defer to `ironsworn-suffer` for `suffer_harm` / `suffer_stress` / `consume_supply` / `inflict_debility`. Never narrate harm without the tool call.
+5. **Apply the mutation.** Defer to `ironsworn-suffer` (`suffer_harm` / `suffer_stress` / `consume_supply` / `inflict_debility`). Never narrate harm without the tool call.
 6. **Tag the scene.** `record_scene` with `complication_theme` set.
 
 ---
@@ -69,25 +66,24 @@ If the fiction obviously points at one cost (combat miss → harm; storm scene �
 - **One sense, one detail.** The bowstring sounds like a snapped bone. The wind is suddenly inside the hood. The map page is wet and tearing.
 - **Inevitable in retrospect.** The world catching up, not the GM punishing. *"Of course the snares were empty — something larger walked through."*
 - **Land it on something the player cares about.** The bonded NPC, the cherished asset, the open vow — not the cheapest item on the menu.
-- **Match size to moment.** Small misses cost supply or time; climactic misses change the campaign's shape. Curve in `references/escalation.md`.
+- **Match size to moment.** Small misses cost supply or time; climactic misses change the campaign's shape (`references/escalation.md`).
 
 ---
 
-## Cross-Links
+## References
 
-- **Pay the Price decision** (which d100 category) → `ironsworn-oracle`. Not duplicated here; `references/palette.md` is craft translation only.
-- **Diversity Protocol enforcement** → `agents/ironsworn-gm.md`. This skill honors it; the agent prompt is the source of truth.
-- **Mechanical mutation** (−1 supply, suffered harm) → `ironsworn-suffer`.
-- **Region/biome archetypes** → `references/by-region.md`. **Escalation curve** → `references/escalation.md`.
+- `references/palette.md` — thematic palette + Pay the Price d100 (p.105/116) translation patterns + match handling.
+- `references/by-region.md` — complication archetypes per Ironlands biome.
+- `references/escalation.md` — small/medium/large arc with worked session examples.
 
 ---
 
 ## Common Mistakes
 
-- **A miss that costs nothing.** A hit that costs nothing isn't a hit (rulebook p.117). Always extract a price.
+- **A miss that costs nothing.** A hit that costs nothing isn't a hit (rulebook p.117).
 - **Skipping `get_recent_complications`.** Three weather-misses in a row dulls the world.
 - **Inventing when an old thread fits.** `list_threads` first; escalate before invention.
 - **Generic texture.** *"It is harmful"* → *"you take harm"* is paperwork. Render the wound.
+- **Reaching past the NPC.** When one is onstage, the consequence often *is* their drives — don't bypass.
 - **Treating the d100 as a script.** It is a prompt — translate through campaign theme.
-- **Re-rolling for a softer result.** The oracle has spoken.
 - **Forgetting `record_scene`'s `complication_theme`.** The protocol can't enforce diversity it can't see.

--- a/plugins/ironsworn/skills/ironsworn-complications/SKILL.md
+++ b/plugins/ironsworn/skills/ironsworn-complications/SKILL.md
@@ -20,7 +20,7 @@ description: >
 
 # Ironsworn Complications — Craft Layer
 
-A miss without a cost is a lie. A complication without texture is paperwork. This skill is the craft layer between "a cost is owed" and "the player feels it." It does not own diversity-protocol enforcement (`agents/ironsworn-gm.md` does, via `get_recent_complications`) or the Pay the Price *decision* (`ironsworn-oracle` does). It owns *texture* — how the cost lands in the senses, in the lore, in the campaign's weight.
+A miss without a cost is a lie. A complication without texture is paperwork. This skill owns *texture* — how a cost lands in the senses, in the lore, in the campaign's weight. It does not own diversity-protocol enforcement (`agents/ironsworn-gm.md` does, via `get_recent_complications`) or the Pay the Price *decision* (`ironsworn-oracle` does).
 
 ---
 
@@ -42,11 +42,11 @@ Handoffs: `ironsworn-oracle` (which consequence), `ironsworn-suffer` (the harm/s
 ## When to Invoke
 
 - Any miss whose outcome reads "Pay the Price" — combat, journey, social, scene challenge.
-- A **match** on the challenge dice (p.9, p.117) — twist on strong hits, heightened complication on misses. Matched 10s on miss = *"as bad as things get."* On social moves a match makes the refusal louder and the demand more pointed — defer voice to `ironsworn-npc-voice`.
-- A weak-hit "victory comes at a cost" beat — including social weak hits where the NPC asks something in return (rulebook p.80). The favor *is* a complication; it lands as a debt thread that must echo the NPC's drives.
-- The GM volunteers a complication to escalate stakes; the player narrates "things get worse" or asks "what does the world do."
+- A **match** on the challenge dice (p.9, p.117) — twist on strong hits, heightened complication on misses; matched 10s on miss = *"as bad as things get."* A match during montage is also the rulebook's cue to **zoom in** (p.222) — defer the camera to `ironsworn-pacing`, return here for texture. On social misses a match makes the refusal louder, the demand more pointed — defer voice to `ironsworn-npc-voice`.
+- A weak-hit "victory comes at a cost" beat — including social weak hits where the NPC asks something in return (p.80). The favor *is* a complication; it lands as a debt thread echoing the NPC's drives.
+- The GM volunteers a complication; the player narrates "things get worse" or asks "what does the world do."
 
-If the fiction obviously points at one cost (combat miss → harm), skip to texture — but never skip the diversity check.
+If the fiction points at one cost (combat miss → harm), skip to texture — but never skip the diversity check.
 
 ---
 
@@ -61,9 +61,10 @@ If the fiction obviously points at one cost (combat miss → harm), skip to text
 
 ---
 
-## Four Texture Rules
+## Texture Rules
 
 - **One sense, one detail.** The bowstring sounds like a snapped bone. The wind is suddenly inside the hood. The map page is wet and tearing.
+- **Land it in a scene slot.** Per `ironsworn-scene-craft`, complications belong in the **visible stake** of the framing paragraph (smoke on the horizon, the empty chair) or the **image** of the close (blood on iron, an empty doorway). A weak-hit "ask in return" *is* the closing question. Anywhere else is narration noise.
 - **Inevitable in retrospect.** The world catching up, not the GM punishing. *"Of course the snares were empty — something larger walked through."*
 - **Land it on something the player cares about.** The bonded NPC, the cherished asset, the open vow — not the cheapest item on the menu.
 - **Match size to moment.** Small misses cost supply or time; climactic misses change the campaign's shape (`references/escalation.md`).
@@ -72,18 +73,17 @@ If the fiction obviously points at one cost (combat miss → harm), skip to text
 
 ## References
 
-- `references/palette.md` — thematic palette + Pay the Price d100 (p.105/116) translation patterns + match handling.
-- `references/by-region.md` — complication archetypes per Ironlands biome.
-- `references/escalation.md` — small/medium/large arc with worked session examples.
+- `references/palette.md` — palette + d100 (p.105/116) translation + match handling + NPC-as-consequence.
+- `references/by-region.md` — archetypes per Ironlands biome.
+- `references/escalation.md` — small/medium/large arc with worked sessions.
 
 ---
 
 ## Common Mistakes
 
-- **A miss that costs nothing.** A hit that costs nothing isn't a hit (rulebook p.117).
+- **A miss that costs nothing.** A hit that costs nothing isn't a hit (p.117).
 - **Skipping `get_recent_complications`.** Three weather-misses in a row dulls the world.
 - **Inventing when an old thread fits.** `list_threads` first; escalate before invention.
 - **Generic texture.** *"It is harmful"* → *"you take harm"* is paperwork. Render the wound.
-- **Reaching past the NPC.** When one is onstage, the consequence often *is* their drives — don't bypass.
 - **Treating the d100 as a script.** It is a prompt — translate through campaign theme.
 - **Forgetting `record_scene`'s `complication_theme`.** The protocol can't enforce diversity it can't see.

--- a/plugins/ironsworn/skills/ironsworn-complications/SKILL.md
+++ b/plugins/ironsworn/skills/ironsworn-complications/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: ironsworn-complications
+description: >
+  Cross-cutting fiction-craft skill for choosing, texturing, and delivering
+  complications — the texture work behind every Pay the Price miss, every
+  match, every "the world pushes back" beat. Covers palette diversity (weather,
+  terrain, beasts, factions, internal, social, supply, supernatural), tying
+  complications to open threads and lore, sensory delivery (show, don't tell),
+  and the small → medium → large escalation curve across a session. ALWAYS
+  invoke this skill on every miss with consequences, every match (strong-hit
+  twist or miss complication), and every "things get worse" beat — when the
+  player or GM says things like "and then things get worse", "what's the
+  cost", "pay the price", "the dice say miss", "a twist", "matched dice",
+  "what does the world do", "they got unlucky". The Complication Diversity
+  Protocol's mechanical enforcement (`get_recent_complications`) lives in the
+  GM agent — this skill is the **craft layer on top**. Defers Pay the Price
+  *decision* (which consequence applies) to `ironsworn-oracle`. Never let a
+  miss cost nothing; never let a complication be generic.
+---
+
+# Ironsworn Complications — Craft Layer
+
+A miss without a cost is a lie. A complication without texture is paperwork. This skill is the craft layer between "a cost is owed" and "the player feels it."
+
+It does **not** own the diversity protocol — `agents/ironsworn-gm.md` enforces that via `get_recent_complications`. It does **not** own which Pay the Price consequence applies — `ironsworn-oracle` does. It owns *texture*: how the cost lands in the senses, in the lore, in the campaign's weight.
+
+---
+
+## Tools This Skill Governs
+
+| Tool | When |
+|---|---|
+| `get_recent_complications` | Before narrating any complication — diversity check (k=5). Honors the GM-agent protocol. |
+| `search_lore_global` | Before invention — thematic clusters so the complication grows from the world (Fiction Grounding #103). |
+| `search_lore` | Entity/name resolution: which NPC, faction, or place surfaces. |
+| `list_threads` (open) | Scan for an existing thread to escalate before inventing a new one. |
+| `search_rules` | Pay the Price table (p.105/116), match handling (p.9, p.117), region flavor. |
+| `record_scene` | After narration, tag with `complication_theme` so the protocol can see it. |
+
+Handoffs: `ironsworn-oracle` (which consequence), `ironsworn-suffer` (the harm/stress/supply mutation), `ironsworn-scene-craft` (sensory framing), `ironsworn-pacing` (scene vs. montage), `ironsworn-npc-voice` (when the complication is *who*).
+
+---
+
+## When to Invoke
+
+- Any miss whose outcome reads "Pay the Price" — combat, journey, social, scene challenge.
+- A **match** on the challenge dice — strong-hit twist or miss-heightened complication (p.9, p.117). Matched 10s on a miss = "as bad as things get."
+- A weak-hit "victory comes at a cost" beat.
+- The GM volunteers a complication to escalate stakes outside a specific roll.
+- The player narrates "things get worse" or asks "what does the world do."
+
+If the fiction obviously points at one cost (combat miss → harm; storm scene → freeze), skip to texture — but never skip the diversity check.
+
+---
+
+## The Discipline
+
+1. **Ground first.** `search_lore_global` + `list_threads`. The world has unfinished business — complications grown from existing threads, NPC grudges, or world truths land harder than invention.
+2. **Diversity check.** `get_recent_complications` (k=5). Pick a category not dominating recent history. Palette menu in `references/palette.md`.
+3. **Choose the consequence type** — defer to `ironsworn-oracle`'s Pay the Price discipline (flat cost → escalate existing thread → invent rarely, 0–1/session).
+4. **Texture.** One sensory beat — sound, smell, weight, cold, posture. No "you feel," "you notice," "perhaps."
+5. **Apply the mutation.** Defer to `ironsworn-suffer` for `suffer_harm` / `suffer_stress` / `consume_supply` / `inflict_debility`. Never narrate harm without the tool call.
+6. **Tag the scene.** `record_scene` with `complication_theme` set.
+
+---
+
+## Four Texture Rules
+
+- **One sense, one detail.** The bowstring sounds like a snapped bone. The wind is suddenly inside the hood. The map page is wet and tearing.
+- **Inevitable in retrospect.** The world catching up, not the GM punishing. *"Of course the snares were empty — something larger walked through."*
+- **Land it on something the player cares about.** The bonded NPC, the cherished asset, the open vow — not the cheapest item on the menu.
+- **Match size to moment.** Small misses cost supply or time; climactic misses change the campaign's shape. Curve in `references/escalation.md`.
+
+---
+
+## Cross-Links
+
+- **Pay the Price decision** (which d100 category) → `ironsworn-oracle`. Not duplicated here; `references/palette.md` is craft translation only.
+- **Diversity Protocol enforcement** → `agents/ironsworn-gm.md`. This skill honors it; the agent prompt is the source of truth.
+- **Mechanical mutation** (−1 supply, suffered harm) → `ironsworn-suffer`.
+- **Region/biome archetypes** → `references/by-region.md`. **Escalation curve** → `references/escalation.md`.
+
+---
+
+## Common Mistakes
+
+- **A miss that costs nothing.** A hit that costs nothing isn't a hit (rulebook p.117). Always extract a price.
+- **Skipping `get_recent_complications`.** Three weather-misses in a row dulls the world.
+- **Inventing when an old thread fits.** `list_threads` first; escalate before invention.
+- **Generic texture.** *"It is harmful"* → *"you take harm"* is paperwork. Render the wound.
+- **Treating the d100 as a script.** It is a prompt — translate through campaign theme.
+- **Re-rolling for a softer result.** The oracle has spoken.
+- **Forgetting `record_scene`'s `complication_theme`.** The protocol can't enforce diversity it can't see.

--- a/plugins/ironsworn/skills/ironsworn-complications/references/by-region.md
+++ b/plugins/ironsworn/skills/ironsworn-complications/references/by-region.md
@@ -1,0 +1,109 @@
+# Complication Archetypes by Ironlands Region
+
+Region-specific complication palettes. Use these when the campaign is rooted in a known Ironlands region — the texture should *feel like* the place. Region descriptions are paraphrased from the rulebook (Chapter 4, pages 113-130) — `search_rules` for the canonical text before improvising.
+
+The map is open; pull from your campaign's world truths (chapter 4 truths Q&A) rather than this list when they conflict. This is a **starter palette**, not a constraint.
+
+---
+
+## Barrier Islands (rulebook p.113)
+
+Slate-cliff islands, fierce winds, persistent rain, sparse fisher-folk settlements.
+
+- Sudden squall — visibility cuts to an arm's length; a known landmark vanishes.
+- The wreck on the shore turns out to be recent.
+- A spectral maiden at a ship's bow asks a price for safe passage (canonical quest starter).
+- The fisher-folk have already left — the village is empty and the boats are gone.
+- A seabird carries something in its beak it shouldn't.
+- The cliff path crumbles where it didn't yesterday.
+
+## Ragged Coast
+
+Storm-lashed cliffs, raider-haunted shorelines, fjords thick with mist.
+
+- Smoke on the horizon from the wrong direction.
+- A shoreline that should be familiar isn't — the tide is wrong.
+- Raider sails appear at the bay-mouth where you intended to camp.
+- A fisherman pulls in a net heavy with what isn't fish.
+
+## Deep Wilds (rulebook p.115)
+
+Ancient forest, hanging moss, perpetual mist, elf-haunted, prehuman.
+
+- The path closes behind — looking back, only trees.
+- An elf, watching from the canopy, names the character (knowing-without-meeting).
+- A growl that doesn't match any beast you know.
+- The rain stops everywhere except directly overhead.
+- Trees that are not trees — bark patterned in a way you can't keep looking at.
+- A clearing with stones laid in old patterns; the air smells wrong.
+
+## Flooded Lands
+
+Swamps, fens, bogs, mire-holds, drowned ruins.
+
+- The path through the fen is gone — peat that held yesterday won't today.
+- Foul gas; the lantern flame turns blue.
+- A mire-holdfolk elder won't open the gate without a tally settled.
+- A drowned ruin breaches the waterline — something inside watching.
+- Leeches; supply spoiled; a body in the reeds the locals don't claim.
+
+## Havens (rulebook p.117)
+
+Hill settlements, palisaded holds, deep winters, raider attacks, the seat of "civilization."
+
+- A jarl's banner where it shouldn't be — politics has moved without you.
+- The settlement gate is barred mid-day; no one will say why.
+- A debt comes due at a feast; the tally-stick is produced in front of witnesses.
+- The harvest failed; the holdfolk look at you and your supply.
+- A leader you helped is now a tyrant; the people quietly ask if you'll fix what you started.
+
+## Hinterlands (rulebook p.118)
+
+Forested high country, hunter camps, varou bands, brutal winters.
+
+- A varou war-song from beyond the firelight.
+- The hunters' camp is empty and recently empty — fires still warm.
+- The snowshoe trail you were following ends at a frozen body.
+- A bear that should be hibernating, isn't.
+- Your guide's loyalty cracks — the wages won't be enough to keep them past the next ridge.
+
+## Tempest Hills (rulebook p.119)
+
+Rugged hills, screaming winds, mining settlements, nomad camps, mammoth pastures.
+
+- The wind carries a name (rulebook flavor: *"the winds carry the names of those fated to die"*).
+- A mine entrance that wasn't there yesterday; an entrance gone today.
+- An ironlander caravan, abandoned mid-route, the ore still loaded.
+- A wyvern's shadow passing overhead.
+- A nomad camp moved in the night — the circle of stones still warm.
+
+## Veiled Mountains
+
+High peaks, ancient passes, alpine cold, things older than Ironlanders.
+
+- The pass that was open is filled with snow — not weather, an old door closing.
+- Altitude sickness blurs the senses where it shouldn't.
+- A cairn newly built; the stones still cold.
+- A track of footprints that go up the cliff face.
+- The path forks where there was no fork.
+
+## Shattered Wastes
+
+Stone, ash, ruin, the Old World's broken bones.
+
+- A line of shadow that crosses no light source.
+- A ruin's entrance where the carvings are still wet.
+- The waste is silent in a way that hurts the ears.
+- Iron rusts visibly while you watch.
+- A traveler ahead on the road has been ahead of you for three days.
+
+---
+
+## How to Use This
+
+1. Identify the region of the current scene (`search_lore` if uncertain, `search_rules` for canonical region flavor).
+2. Cross-reference the region archetypes against `get_recent_complications` — pick a category that hasn't been used recently, that fits the region.
+3. Texture it — one sensory detail, one named or describable thing.
+4. Cross-link: if the complication involves an NPC, route voice and reactions through `ironsworn-npc-voice`. If it involves harm/stress/supply, `ironsworn-suffer` applies the cost. If it expands into a scene, `ironsworn-scene-craft` frames it.
+
+Region archetypes are flavor, not destiny. A weather complication can land anywhere; what changes is *the kind of weather* and *what it implies about the place.* The Tempest Hills wind carries names; the Flooded Lands cold rises out of the ground; the Deep Wilds rain falls only on you. Region is the seasoning, not the dish.

--- a/plugins/ironsworn/skills/ironsworn-complications/references/escalation.md
+++ b/plugins/ironsworn/skills/ironsworn-complications/references/escalation.md
@@ -1,0 +1,103 @@
+# Escalation Curve — Small → Medium → Large Across a Session
+
+The size of a complication should match the size of the moment. A small early-session miss should not threaten the campaign; a late-session climactic miss should not cost a wineskin. This file is the curve.
+
+Two principles from the rulebook:
+
+- *"Pay the Price"* costs should be appropriate to the move (rulebook p.117): a Strike miss costs less than an End the Fight miss; a Fulfill Your Vow miss costs more than an Undertake a Journey miss.
+- *"For dramatic moments and decisive moves, up the stakes"* (p.117).
+
+---
+
+## The Three Sizes
+
+### Small (most misses, most of the time)
+
+**Texture:** flat mechanical cost, one sensory detail, no new threads.
+
+**Costs:**
+- −1 supply (wineskin frozen, snares empty)
+- −1 momentum (lost the thread, slipped grip)
+- Lose progress (ground re-covered, foe shrugs off the wound)
+- Minor harm (1 harm — twisted ankle, shallow cut)
+- Equipment degraded (chipped blade, slack bowstring, lantern out of oil)
+- Time lost (a waypoint of bad weather)
+
+**When:** any non-dramatic miss; weak hits with cost; matches on minor moves; routine Pay the Price. The diversity protocol still applies — rotate categories — but the cost stays small.
+
+### Medium (the session's middle, escalation moves)
+
+**Texture:** escalate an existing thread; introduce friction with a known NPC; force a hard mechanical cost.
+
+**Costs:**
+- 2 harm or stress (the wound that doesn't heal cleanly)
+- A debility (wounded, shaken, encumbered) via `ironsworn-suffer`
+- Lose multiple supply or significant track progress
+- A bonded NPC's loyalty cracks (re-enter `ironsworn-npc-voice`, `ironsworn-social`)
+- An old enemy reappears (reuse a closed thread, don't invent)
+- A factional consequence — a hold closes its gates, a jarl turns, a debt is called
+- A vow's situation worsens — milestones harder to reach without addressing the new pressure
+
+**When:** mid-session pressure builds; a major move misses (Battle weak, Compel miss, Forge a Bond miss with a key NPC); a match on a meaningful move.
+
+### Large (climactic, dire, campaign-altering)
+
+**Texture:** the world changes shape. Reserve for end-of-session, decisive misses, matched 10s on a miss (rulebook p.9 — *"as bad as things get"*).
+
+**Costs:**
+- Vow goes toward forsake (defer to `ironsworn-progress-tracks`)
+- Out of Action / Face Death / Face Desolation (defer to `ironsworn-suffer`)
+- A campaign thread breaks open — the secret revealed, the betrayal seen, the truth turned
+- A bonded NPC dies, leaves, or turns
+- A faction war breaks
+- A region of the campaign closes off (the Deep Wilds will not let you back in)
+
+**When:**
+- Match on a miss with matched 10s (rulebook p.9)
+- Miss on End the Fight against a high-rank foe
+- Miss on Fulfill Your Vow at the climax
+- Miss on Face Death / Face Desolation
+- A 99–00 roll on the Pay the Price d100
+
+---
+
+## A Worked Session Arc
+
+A four-hour session where the player's vow is to recover a stolen relic from a Mire-Holtfolk holdfast.
+
+### Early (small)
+
+- **Undertake a Journey** miss → −1 supply + texture: the wineskin froze and split overnight. (Weather/supply category, no new threads.)
+- **Resupply** weak hit at a hunter's camp → −1 supply: the snares are empty; tracks indicate something larger walked through. (Plants the next mid-session beat.)
+
+### Middle (medium)
+
+- **Compel** miss with the holdfast elder → escalate the existing "Debt to the Mire-Holtfolk" thread: the elder produces a tally-stick. The price of help is the price you've been avoiding. (Social/debt category; thread escalation.)
+- **Strike** weak hit in a skirmish with a holdfolk warrior → 1 harm + texture: the ally — the bonded one — takes the cut meant for you. Now there are two bodies bleeding on the floor. (Defer mutation to `ironsworn-suffer`; lands on the bonded NPC.)
+
+### Climactic (large)
+
+- **End the Fight** miss with matched dice against the holdfast's champion → Pay the Price *severe* (rulebook p.94, Fight): roll on the Pay the Price d100, get 99–00 (roll twice). The two results layer:
+  - The relic shatters in the struggle (something of value lost).
+  - The bonded ally Faces Death (defer to `ironsworn-suffer`).
+
+The vow's shape changes. Even if the player survives, the relic is gone; the path forward is to mourn or to invent something new. The session has earned its weight by walking the arc — small → medium → large — instead of stacking apocalypses on small misses.
+
+---
+
+## Anti-Patterns
+
+- **Stacking large complications.** Two large misses in close succession compresses the campaign. Pace them — three small + one medium + one large is a session shape; large + large is an ending.
+- **Skipping the small.** If every miss is medium-or-larger, the world feels relentless and the player learns to brace against everything, not feel anything.
+- **Ignoring the rank of the move.** A Strike miss is not an End the Fight miss. The rulebook's per-move guidance (e.g., the **Fight** move at p.94) explicitly says *"Make it hurt"* on Fight misses but not on Strike misses. Honor the difference.
+- **Climaxing too early.** The first miss of a session shouldn't break the campaign. Save the matched 10s, the Face Death triggers, the thread-breaking revelations for when the fiction has earned them.
+
+---
+
+## Cross-Links
+
+- **Mechanical mutation** — `ironsworn-suffer`. This skill never calls `suffer_harm` directly.
+- **Vow-level consequences** — `ironsworn-progress-tracks` (forsake, recommit).
+- **Pacing the arc** — `ironsworn-pacing` (when to scene-frame the small cost vs. absorb into montage; large complications usually demand a scene).
+- **Texture in scene** — `ironsworn-scene-craft` (one-sense rendering, no "you feel," etc.).
+- **NPC-as-complication** — `ironsworn-npc-voice` for delivery when the cost is *who* responds, not *what* happens.

--- a/plugins/ironsworn/skills/ironsworn-complications/references/escalation.md
+++ b/plugins/ironsworn/skills/ironsworn-complications/references/escalation.md
@@ -91,6 +91,7 @@ The vow's shape changes. Even if the player survives, the relic is gone; the pat
 - **Skipping the small.** If every miss is medium-or-larger, the world feels relentless and the player learns to brace against everything, not feel anything.
 - **Ignoring the rank of the move.** A Strike miss is not an End the Fight miss. The rulebook's per-move guidance (e.g., the **Fight** move at p.94) explicitly says *"Make it hurt"* on Fight misses but not on Strike misses. Honor the difference.
 - **Climaxing too early.** The first miss of a session shouldn't break the campaign. Save the matched 10s, the Face Death triggers, the thread-breaking revelations for when the fiction has earned them.
+- **Double-zooming on Sojourn.** A miss-driven Sojourn complication *is* the Sojourn's zoomed beat (rulebook p.83 — Sojourn pattern is montage with one selective zoom-in; `ironsworn-pacing/references/montage-vs-scene.md`). Don't spawn a separate "and now a scene about the bad thing" — the miss already focused the camera. Texture lands inside the Sojourn frame.
 
 ---
 

--- a/plugins/ironsworn/skills/ironsworn-complications/references/palette.md
+++ b/plugins/ironsworn/skills/ironsworn-complications/references/palette.md
@@ -1,0 +1,93 @@
+# Complication Palette & Pay the Price Translation
+
+This file is the **menu of thematic categories** to rotate through, plus how to translate the rulebook's Pay the Price d100 (page 105/116) into a textured fiction beat. The protocol's enforcement lives in `agents/ironsworn-gm.md`; this is the craft side.
+
+---
+
+## The Palette (rotate among these — none is exhaustive)
+
+The GM agent's master list (lines ~163-175) is the source of truth. Reproduced here for craft reference only — pull from your campaign's world truths to add categories specific to your setting.
+
+| Category | What it draws from | Example beat |
+|---|---|---|
+| **Weather / cold / exhaustion** | The land as antagonist | A wineskin frozen and split; sleet driving sideways into the hood; the warmth in the limbs draining away faster than expected |
+| **Beasts / wildlife** | Natural or corrupted fauna | Tracks in fresh snow that don't match anything you know; a horse refusing to enter a clearing; something following at the treeline that won't be seen |
+| **Supernatural threats** | World-truth darkness | A wound that doesn't bleed; words spoken in sleep that aren't yours; iron suddenly cold to the touch where it shouldn't be |
+| **Political / factional** | Rival communities, jarls, holds | A rider arrives ahead of you with the news already; a name on a tally-stick in a strongbox; a closed gate that should have been open |
+| **Ancient infrastructure** | Old roads, ruins, unstable structures | A bridge that gives under weight that shouldn't have been a problem; a flooded shaft; carvings that move when looked at directly |
+| **Plain physical hazard** | Injury, terrain, structural collapse | A turned ankle on scree; a horse going lame; a rope fraying at the knot |
+| **Interpersonal / social** | Mistrust, conflicting goals, grudges | The bonded ally going quiet; an old slight surfacing under stress; a kept secret leaking |
+| **Supply / resource scarcity** | Hunger, exhaustion, broken gear | Empty snares; arrow shafts shattered; the map page wet through |
+| **Isolation / disorientation** | Lost, cut off, no help coming | The trail simply stops; a fog that doesn't lift; a settlement that should be there isn't |
+
+When in doubt, pick the category least-represented in `get_recent_complications` (k=5).
+
+---
+
+## Translating the Pay the Price d100 (rulebook p.105 / p.116)
+
+Each entry in the table is a **category abstraction** — translate through campaign theme and lore. Always pair the translation with `search_lore_global` (theme) and either `search_lore` (specific names) or `list_threads` (open business).
+
+| Roll | Category | Translation pattern |
+|---|---|---|
+| 1-2 | Worse + roll again | Stack two table results, the second worse than the first. Reserve for genuinely dire moments — combat misses, decisive failures. |
+| 3-5 | Trust lost | A bonded NPC, a holdfolk, a faction turns. Pull from `search_lore` for who; `list_threads` for the betrayal that fits. |
+| 6-9 | Ally in danger | Companion, bonded NPC, or known third party. Use the actual name from lore — never "an ally." |
+| 10-16 | Separated | Lost from the group; cut off from a resource; the path closes behind. Tie to terrain or faction if possible. |
+| 17-23 | Unintended effect | The right action with the wrong consequence. The fire kept the cold off but drew something. |
+| 24-32 | Something lost or destroyed | An asset, a keepsake, a written record. Make it specific from the character sheet, not generic. |
+| 33-41 | Situation worsens | Whatever pressure was already in the scene increases by a step. Storm becomes blizzard; argument becomes accusation. |
+| 42-50 | New danger or foe | The hardest box to fill responsibly — `list_threads` first; reuse a foe before inventing one. |
+| 51-59 | Delay / disadvantage | Time lost, position lost, posture lost. Translates well into momentum drops or progress not gained. |
+| 60-68 | Harmful | Defer mutation to `ironsworn-suffer`. Render the wound — the texture, the wrongness, the cold. Not "you take 1 harm." |
+| 69-77 | Stressful | Fear, despair, fatigue. Defer to `ironsworn-suffer`. Show what cracks — the prayer that doesn't come, the hand that won't stop shaking. |
+| 78-85 | Surprising development | A revelation that changes the shape of the scene. Best when grounded in lore (`search_lore_global`). |
+| 86-90 | Wastes resources | Supply, momentum, gear. Render the loss — the wineskin, the cracked haft, the spilled rations. |
+| 91-94 | Acts against intentions | A choice forced by the moment that the character would not have made. Excellent for moral compromise beats. |
+| 95-98 | Friend/companion/ally in harm's way | Use a specific name from lore. If alone, it lands on the character — but `search_lore` first for any companion or bonded NPC nearby. |
+| 99-00 | Roll twice; both occur | Reserve for matched 10s on a miss (rulebook p.9 — "as bad as things get"). Layer two complications from different categories — diversity built-in. |
+
+**Rule of thumb:** translate the abstract into one specific sensory detail tied to a named entity from lore. *"It is harmful"* is paperwork; *"the bonded ally, exhausted, lashes out — a wounding word that sticks"* is play.
+
+---
+
+## Match Handling (rulebook p.9, p.117)
+
+Matched challenge dice on:
+
+- **Strong hit** → twist, opportunity, unexpected turn. Not always a complication — sometimes a gift with a hook.
+- **Weak hit / miss** → heightened complication, new danger, *worse* than a normal miss. The rulebook recommends **rolling on the Pay the Price table** (rather than choosing) to surface a result you wouldn't have picked.
+- **Matched 10s on a miss** → *"as bad as things get"* (p.9). A campaign-altering complication: a vow goes toward forsake, Face Death triggers, a major thread breaks open.
+
+If matches feel routine, the rulebook's optional rule (p.231) restricts match-effects to even-numbered matches. Note this preference once and stay consistent.
+
+---
+
+## Worked Translations
+
+**Example 1 — Undertake a Journey miss, d100 = 64 ("It is harmful"), recent complications: weather, weather, beast.**
+
+- `search_lore_global` returns a cluster on oath-debt and corrupted fauna.
+- `list_threads` returns "Debt to the Mire-Holtfolk" (open, 3 sessions old) — not what the harm is *about*, but in scope.
+- Diversity check: weather is over-used; beast is recent. Pick **supernatural-corruption** (a category from world truths).
+- Translation: the cold isn't cold — it's *wrong* cold. The fingers go numb in the wrong order. A scratch from a thorn doesn't bleed.
+- Mechanical: defer to `ironsworn-suffer` → `suffer_harm(1)`.
+- `record_scene` `complication_theme: "supernatural-corruption"`.
+
+**Example 2 — Compel miss, d100 = 03 ("trust lost"), recent complications: weather, supply, supply.**
+
+- `search_lore` for the elder being compelled returns a long history with the character.
+- `list_threads` shows "Debt to the Mire-Holtfolk" — same thread can carry this beat.
+- Diversity check: supply is over-used; social is fresh. Use **interpersonal**.
+- Translation: the elder doesn't refuse — she sets a tally-stick on the table, your name on it. The price of her help is the price you've been avoiding.
+- Mechanical: no direct mutation; the open thread escalates.
+- `record_scene` `complication_theme: "debt-economy"`.
+
+**Example 3 — Strike miss with matched 10s, d100 = 99 ("roll twice; both occur").**
+
+- This is the dire-moment branch. Roll twice → 47 (new danger) and 67 (harmful).
+- `search_lore` surfaces a foe from a closed thread three sessions ago, never definitively killed.
+- Diversity check: combine categories — the new danger is **factional**, the harm is **physical** but *also* signals supernatural-corruption (the foe should be dead).
+- Translation: the blade slips past your guard — a shallow cut that burns wrong. From the trees, a second figure steps out: the raider you thought you'd buried, walking again.
+- Mechanical: `ironsworn-suffer` → `suffer_harm(1)`; reopen the thread; consider rank escalation on the foe.
+- `record_scene` with the dominant theme — likely `complication_theme: "supernatural-corruption"`, with a secondary note in the scene body about factional reappearance.

--- a/plugins/ironsworn/skills/ironsworn-complications/references/palette.md
+++ b/plugins/ironsworn/skills/ironsworn-complications/references/palette.md
@@ -91,3 +91,21 @@ If matches feel routine, the rulebook's optional rule (p.231) restricts match-ef
 - Translation: the blade slips past your guard — a shallow cut that burns wrong. From the trees, a second figure steps out: the raider you thought you'd buried, walking again.
 - Mechanical: `ironsworn-suffer` → `suffer_harm(1)`; reopen the thread; consider rank escalation on the foe.
 - `record_scene` with the dominant theme — likely `complication_theme: "supernatural-corruption"`, with a secondary note in the scene body about factional reappearance.
+
+---
+
+## NPC-as-Consequence (when an NPC is onstage)
+
+When the missed move is *aimed at an NPC* (Compel, Forge a Bond, Test Your Bond, Aid Your Ally), the NPC's drives often *are* the complication shape — reach there before the abstract palette. `ironsworn-npc-voice` is the source of truth for drive-shaped delivery; this skill names the discipline.
+
+**Example — Compel miss against a holdfast diplomat whose drive is "preserve appearances at any cost."**
+
+- `search_lore` returns the diplomat (drive: preserve appearances) and a closed thread "The Holtfen Compromise" — half-spoken, never settled.
+- `get_recent_complications`: factional, factional, weather. Social is fresh.
+- The consequence shape *is* the drive: the diplomat does not refuse, does not yield, does not budge. The form they take is itself the cost — every hour spent here is an hour your vow doesn't progress, and they will let you sit through it.
+- Mechanical: defer to `ironsworn-suffer` → `suffer_stress(2)` (the slow grind of unmoved formality), and open a debt thread for the favor implicit in the room.
+- `record_scene` `complication_theme: "interpersonal"`.
+
+The d100 table is *not* the first place to look here. The drive is. Texture follows from voice (`ironsworn-npc-voice`) before it follows from category.
+
+**Weak-hit "ask in return" (rulebook p.80) follows the same rule.** A Compel weak hit where the NPC asks a favor must echo their drives — a war-jarl asks for steel, a holtfen elder asks for a tally settled, a bonded healer asks for the truth told. Generic asks ("they want a favor, TBD") are paperwork. Open the debt thread; close the loop in the next scene.


### PR DESCRIPTION
Closes #102

## Summary

- Adds `plugins/ironsworn/skills/ironsworn-complications/` — a cross-cutting fiction-craft skill that activates on every miss with consequences, every match (strong-hit twist or miss complication), and every "things get worse" beat.
- The skill is the **craft layer on top of the existing Complication Diversity Protocol**: the GM agent enforces the protocol via `get_recent_complications`; this skill teaches how to ground a complication in lore, render it sensorially, and pace it across a session.
- Defers cleanly: Pay the Price *decision* (which d100 category) → `ironsworn-oracle`; mechanical mutations (`suffer_harm`, `consume_supply`, etc.) → `ironsworn-suffer`; scene framing → `ironsworn-scene-craft`; NPC-as-complication → `ironsworn-npc-voice`; scene-vs-montage → `ironsworn-pacing`.
- Front-matter `description` carries literal type-of-moment trigger phrases (`"and then things get worse"`, `"what's the cost"`, `"pay the price"`, `"the dice say miss"`, `"a twist"`, `"matched dice"`, `"what does the world do"`, `"they got unlucky"`) plus an ALWAYS-invoke directive covering miss-with-consequences, matches, and escalation beats.
- Honors the team conventions: ~600-word main body (~700, within 500–700 ceiling), Tools-Governs table near the top, Fiction Grounding Protocol (#103) baked into the discipline, and **no version bump** — sequenced bump is the team lead's job.

## Layout

- `SKILL.md` — tools table, when to invoke, the discipline (ground → diversity check → defer to oracle → texture → defer mutation → tag), four texture rules, cross-links, common mistakes
- `references/palette.md` — thematic palette + d100 translation patterns + match handling + worked translations
- `references/by-region.md` — complication archetypes per Ironlands biome (Barrier Islands, Ragged Coast, Deep Wilds, Flooded Lands, Havens, Hinterlands, Tempest Hills, Veiled Mountains, Shattered Wastes)
- `references/escalation.md` — small/medium/large curve with a worked four-hour session arc

## Rule grounding

All rule-derived content was pulled via `mcp__plugin_ironsworn_scribe__search_rules`:
- Pay the Price d100 table — rulebook page 105/116 (cited in `references/palette.md`)
- Match handling — rulebook page 9 + page 117 ("ROLLING MATCHES"); matched 10s on miss = "as bad as things get"
- "A miss should hurt and move on" / "make it hurt" — Fight (p.94), Pay the Price (p.117)
- Region flavor — rulebook chapter 4, pages 113–130
- "Begin and end with the fiction" GM principle — p.226

## Test plan

- [ ] `gh pr view` shows the PR body and links to issue #102 (closes-#102 keyword present)
- [ ] No diff in `plugins/ironsworn/.claude-plugin/plugin.json`
- [ ] All four files land under `plugins/ironsworn/skills/ironsworn-complications/`
- [ ] `SKILL.md` front-matter description includes the type-of-moment trigger phrases listed above
- [ ] Cross-links resolve to skills that exist (`ironsworn-oracle`, `ironsworn-suffer`, `ironsworn-scene-craft`, `ironsworn-npc-voice`, `ironsworn-pacing`) — note the latter three are concurrent PRs in this umbrella
- [ ] Manual play test: trigger a miss in a campaign, confirm GM consults the skill (diversity check → ground → texture → tag) and produces a complication with sensory specificity rather than generic "you take harm"

🤖 Generated with [Claude Code](https://claude.com/claude-code)