### PR TITLE
feat(skill): add ironsworn-scene-craft mode-of-play skill (#99)

### DIFF
--- a/plugins/ironsworn/skills/ironsworn-scene-craft/SKILL.md
+++ b/plugins/ironsworn/skills/ironsworn-scene-craft/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: ironsworn-scene-craft
+description: >
+  Cross-cutting fiction-craft skill for framing, anchoring, and closing scenes
+  in Ironsworn. Activates on type-of-moment, not a specific move. ALWAYS invoke
+  this skill the moment a beat warrants a real scene rather than narration —
+  arrivals, confrontations, quiet recoveries, ceremonies, reveals — or when the
+  player says things like "we cut to...", "describe the room", "set the scene",
+  "I walk in", "what does it look like", "we arrive at", "I find them", "back
+  at camp", "the next morning", or any phrase that asks the GM to render a
+  place, a tableau, or a moment of visible tension. Owns scene framing
+  (situation + tension + visible stake), sensory anchoring (three details, not
+  five), beat selection (which moment is the scene about — cut the rest), and
+  closing on a question, an image, or a decision rather than a summary. Defers
+  NPC dialogue and reactions to ironsworn-npc-voice; defers the
+  montage-vs-scene zoom decision to ironsworn-pacing. Never improvise GM
+  principles from training memory.
+---
+
+# Ironsworn Scene Craft
+
+A scene has a place, a moment, a stake, and an exit. This skill is the operational form of the rulebook's *Begin and End with the Fiction* principle (Ch. 7, p. 226). It loads alongside any mechanics skill when the texture of a moment matters more than the dice.
+
+---
+
+## Tools This Skill Governs
+
+| Tool | When |
+|---|---|
+| `search_lore_global` | Before framing — anchor place, faces, threads (Fiction Grounding #103) |
+| `search_lore` / `get_npc` | Resolve a named place or NPC the scene needs |
+| `list_threads` | Pick an open thread to surface as visible tension |
+| `search_scenes` | Sanity-check tone/sensory choices against prior scenes (continuity) |
+| `search_rules` | Re-pull rule text whenever this skill is invoked second-hand |
+| `record_scene` | After the scene closes — every recorded scene benefits from this skill |
+
+---
+
+## When to Invoke
+
+- Arrivals, entries, transitions into a place.
+- Confrontations, parleys, ambushes, reveals.
+- Quiet recoveries (Make Camp, Sojourn, after Endure Stress).
+- Ceremonies, oaths, moments of choice.
+- The player asks for description ("describe the room", "set the scene", "we cut to...").
+- Any time `record_scene` is about to fire.
+
+If the moment is a transition or montage, defer to `ironsworn-pacing` *before* framing anything.
+
+---
+
+## Fiction Grounding Protocol (#103) — non-negotiable
+
+Before the first sentence:
+
+1. `search_lore_global` for the place. Prior detail is canon — match it.
+2. `search_lore` / `get_npc` for any face on stage.
+3. `list_threads` (k=3–5) — pick one to surface as visible tension.
+
+Never invent against the lore graph. If search returns nothing, you may invent — then `upsert_lore` so the next scene matches.
+
+---
+
+## Framing — open with three things, one short paragraph
+
+1. **Situation.** Where, when, who. Concrete.
+2. **Tension.** What is unsettled — from a thread, an NPC drive, or the prior move. Show it; don't name it.
+3. **Visible stake.** A thing in frame the player can act on — the sword on the table, the empty chair, the smoke on the horizon.
+
+Missing any of the three = description, not scene. Worked good-vs-bad pairs and the *in media res* model (Ch. 7, p. 198): `references/framing-good-vs-bad.md`.
+
+---
+
+## Sensory anchoring — three details, never five
+
+Pick **three** anchors: one that **places** you (sight/space), one that grounds the **body** (smell, sound, temperature, texture), one that carries **mood** (light, weather, absence). More than three blurs; fewer is a stage set. Lean on smell, sound, and temperature before sight — they are stickier per word.
+
+Ironlands register matters — bog, fen, hinterland, and frostbound coast each have their own palette. Biome+season+time-of-day starting points and the continuity rule (reuse one anchor in returning places, vary the others): `references/sensory-palette.md`.
+
+---
+
+## Beat selection — one beat per scene
+
+Every scene is about one beat — a decision, a reveal, or a cost made visible. **Cut everything not in service of that beat.** The walk to the longhouse is not the scene; the moment the door opens is. If you can't name the beat in one sentence, you don't have a scene — defer to `ironsworn-pacing`.
+
+---
+
+## Closing — exit on a hook, never a summary
+
+End on **one** of: a **question** (explicit or implicit), an **image** that resonates, or a **decision point** that hands the next move to the player. **Never close with a summary** ("the night passes uneventfully") — that's GM voice, not the world. Pair close to beat (reveal → image; confrontation that didn't break → question; arrival before action → decision point). Pairings, examples, and the post-close `record_scene` discipline: `references/closing-beats.md`.
+
+---
+
+## Cross-links — what this skill defers
+
+- **NPC dialogue / reactions / voice** → `ironsworn-npc-voice` (scene-craft places the face; npc-voice gives them a mouth).
+- **Zoom-vs-skip, montage decisions** → `ironsworn-pacing`.
+- **Complication texture inside a scene** → `ironsworn-complications`.
+- **Mechanics of a move resolving in the scene** → the relevant mechanics skill (combat, social, suffer, progress-tracks, oracle).
+- **Recording** → `record_scene` after the close.
+
+---
+
+## Common Mistakes
+
+- **Skipping Fiction Grounding.** `search_lore_global` first, always.
+- **Five sensory details instead of three.** The fourth blunts the first three.
+- **Sight-only descriptions.** Smell, sound, and temperature do more work per word.
+- **Opening without a visible stake.** That's stage dressing.
+- **Naming the tension instead of showing it.** "She is angry" is a label; "She doesn't look up when you enter" is a scene.
+- **Closing with a summary.** End on question, image, or decision.
+- **Inventing in the gap.** If lore is silent, invent — then `upsert_lore`.

--- a/plugins/ironsworn/skills/ironsworn-scene-craft/references/closing-beats.md
+++ b/plugins/ironsworn/skills/ironsworn-scene-craft/references/closing-beats.md
@@ -1,0 +1,115 @@
+# Closing Beats — Question, Image, Decision
+
+A scene closes well when the player feels the *exit* — the moment when the camera holds, then turns. There are exactly three closes that work in Ironsworn, and one anti-pattern.
+
+The Ironsworn rulebook's *Begin and End with the Fiction* principle (Chapter 7, *General Principles*, p. 226) is the rule this implements: "Keep things moving forward, bookending the mechanics of your moves with the fiction." A scene's close is the back bookend.
+
+---
+
+## The three legitimate closes
+
+### 1. Question
+
+End on a question the player must answer. Two flavors:
+
+- **Explicit question** — an NPC asks; an oracle prompt is on the table; a literal "what do you do?" is unavoidable. Use sparingly; over-explicit gets dull fast.
+- **Implicit question** — the situation poses a choice without the GM stating it. Best for scenes that have already done the work of making the choice obvious.
+
+Examples:
+- "She holds out the coin. Her hand does not shake." (implicit: take it or don't)
+- "Sit," he says. (implicit: sit, or don't)
+- "Do you draw your sword, or speak first?" (explicit — only after a beat where speaking is genuinely an option)
+
+### 2. Image
+
+End on a single image that **resonates with the beat the scene was about**. The image is the last thing in the player's mind before the next move; choose it for what it carries forward.
+
+Examples:
+- "Blood on the iron. None of it your own."
+- "The candle she left burning is still burning when you leave. You don't put it out."
+- "Brand has fallen asleep at last. The fire is down to a single coal."
+
+The image works because it is **specific** (not "blood everywhere" — *blood on the iron*) and **carries forward** — every image above is a thread the next scene can pull.
+
+### 3. Decision point
+
+End at the moment the next move is the player's. The scene closes by handing them the dice — sometimes literally.
+
+Examples:
+- "She turns, walks to the door, and pauses with her hand on the latch. — Pay the Price for the miss, or speak now."
+- "The track forks: north into the bog, west toward the smoke. — Undertake a Journey?"
+- "Karek waits. — what do you do?"
+
+Decision-point closes are the cleanest hand-off when a move is about to fire. They make the seam between scene and mechanics invisible.
+
+---
+
+## The anti-pattern: summary close
+
+Never close with a summary of what just happened, what was decided, or what comes next.
+
+Anti-examples (do not write):
+- "And so you rest, and the night passes uneventfully."
+- "You leave the longhouse, having learned what you came for."
+- "The journey ahead will be difficult."
+- "You and Brand are now allies."
+
+These close the scene with **GM voice** rather than with the world. The player has nothing to do with a summary. Summaries also tell the player what to feel ("difficult", "uneventfully") instead of leaving the feeling in the image.
+
+If a scene seems to want a summary close, one of two things is true:
+1. The scene was actually a montage — defer to `ironsworn-pacing`.
+2. The scene has no beat — you don't have a scene yet; cut it or reframe.
+
+---
+
+## Pairing the close to the beat
+
+The close should match the **kind of beat** the scene was about:
+
+| Scene's beat | Best close type |
+|---|---|
+| A reveal | Image |
+| A confrontation that didn't yet break | Question (often implicit) |
+| A confrontation that broke into action | Decision point (a move is firing) |
+| A quiet recovery / Make Camp | Image |
+| A vow-swearing / ceremony | Image |
+| A test of bond / Compel / Sojourn | Question |
+| Arrival before something starts | Image or decision point |
+| A miss that calls for Pay the Price | Decision point — hand off to ironsworn-oracle for the consequence |
+
+---
+
+## How long is a close?
+
+**One sentence to three.** Anything longer is narration creeping back in. The close is the last thing the player reads; it should be the lightest, sharpest thing in the scene.
+
+Compare:
+
+- Three-line close (good): "The candle she left burning is still burning when you leave. You don't put it out. Outside, the wind has dropped."
+- Six-line close (bad): "The candle is burning. You think about putting it out but decide not to. You walk outside and notice that the wind has dropped. You think about your vow and what you must do next. The path home is long. You begin the walk back."
+
+The six-line version isn't worse English — it's *narrating the player's interiority*. Hand interiority back to the player.
+
+---
+
+## After the close — record_scene
+
+Once the scene closes:
+
+1. Call `record_scene` with the situated narration (one short paragraph), `complication_theme` if a complication landed, and `mood`/`tone` tags appropriate to the close type.
+2. If the close revealed lore (a name, a place, a thread), `upsert_lore` and/or `open_thread` immediately — before the next scene fires.
+3. If a move is about to fire from the close, the next skill loads (combat, social, suffer, progress-tracks, oracle). Scene-craft hands off cleanly.
+
+---
+
+## Diagnostic checklist for closes
+
+Before you commit a close, ask:
+
+1. Is it a **question, image, or decision** — not a summary?
+2. Is it **one to three sentences**?
+3. Does it **match the beat** the scene was about?
+4. If it's an image, is it **specific** (a coin, a coal, an empty doorway) rather than generic?
+5. Did I **hand the next move back to the player** — explicitly or implicitly?
+
+If any answer is no, rewrite. The close is the last impression — it carries more weight than any other line in the scene.

--- a/plugins/ironsworn/skills/ironsworn-scene-craft/references/framing-good-vs-bad.md
+++ b/plugins/ironsworn/skills/ironsworn-scene-craft/references/framing-good-vs-bad.md
@@ -1,0 +1,104 @@
+# Framing: Good vs Bad — Paired Examples
+
+Each pair shows the same beat written two ways. The "bad" version is *not* wrong English — it's just not a scene. It lacks situation+tension+visible-stake, anchors poorly, or summarizes instead of opening.
+
+The Ironsworn rulebook's worked example for *in media res* (Chapter 7, p. 198) is the model:
+
+> You envision a scene in the longhouse as you visit your stricken overseer. She lies in bed, her features as pale as death, her breathing ragged. There are others here: The village healer, the overseer's wife, and a rival who feigns concern. Ignoring them, you stride forward. You draw your sword...
+
+Note the construction: **place** (longhouse), **tension** (stricken overseer, rival feigning concern), **visible stake** (the sword being drawn). One short paragraph. That's the bar.
+
+---
+
+## 1. Arrival at a settlement
+
+**Bad — generic backdrop, no stake:**
+
+> You arrive at the village of Ravenmark. It is a small settlement on the edge of the marsh. The villagers go about their business. There is an inn and a few houses. Someone notices you and waves.
+
+What's wrong: no tension, no specific thread surfaced, the sensory load is generic ("small", "few houses"). Five "details" but none anchor. The wave is a stage cue, not a stake.
+
+**Good — situation, tension, visible stake:**
+
+> The boardwalk creaks under your boots — Ravenmark is built on stilts above the bog, and the planks groan with every step. Smoke rises crooked from a roof at the far end; someone is burning wet wood. Ulla is at the rail of her longhouse, watching you come in. She is not waving.
+
+What works: place is concrete (boardwalk, stilts, bog), three sensory anchors (creak, crooked smoke, the watching figure), tension lives in the absence (no wave from a known NPC). The visible stake — what does Ulla know that she didn't last time — is implicit and pulls the player toward her.
+
+---
+
+## 2. A confrontation
+
+**Bad — telegraphs everything, ends with a summary:**
+
+> You walk into the longhouse where the chieftain is waiting. He is angry with you about the missing sword. He demands an explanation. You will need to be careful about what you say. The conversation will determine what happens next.
+
+What's wrong: emotion is named ("angry"), stake is named ("careful what you say"), and the scene ends with a meta-summary. Nothing is in the room.
+
+**Good — shows tension, ends on a decision:**
+
+> The longhouse smells of damp wool and old smoke. Karek does not rise when you enter. The sword's empty scabbard lies across the table between you, still wet from the bog. He sets one hand flat beside it. "Sit," he says.
+
+What works: smell+silence anchor the body; the wet scabbard is the visible stake (everyone in the room knows what it means); "Sit" closes on a decision the player must answer.
+
+---
+
+## 3. A quiet recovery (after Make Camp)
+
+**Bad — narrates time passing, summarizes:**
+
+> You make camp by the river and rest for the night. It is peaceful. You think about your vow and what comes next. In the morning you feel better and continue your journey.
+
+What's wrong: this is a summary of a montage, not a scene. No specific moment. No image. No decision.
+
+**Good — one beat, one image, exit on a question:**
+
+> The fire has burned down to coals. Across the embers, Brand is awake too — you can see the gleam of his eye in the dark, though he hasn't spoken. The river is louder than it was at dusk; the spring melt is running high. He works a thumb over the edge of his knife, slow. After a while he says, without looking at you: "You're going to ask me to come, aren't you."
+
+What works: time-of-night is anchored (coals, dark), three sensory details (gleam, river loudness, slow thumb on knife), the open thread (Brand and the journey ahead) is surfaced through behavior not exposition, the close hands the next beat to the player.
+
+---
+
+## 4. A reveal
+
+**Bad — explains the reveal:**
+
+> You find a hidden room behind the bookcase. Inside is a journal that explains everything about the missing sword and the conspiracy at court. You are surprised to learn the truth.
+
+What's wrong: the reveal is *narrated* rather than *staged*. The player has nothing to do.
+
+**Good — stages the reveal as an image, closes on a question:**
+
+> The bookcase swings inward — heavier than it should be, weighted somehow. The room behind it is no bigger than a closet. A single candle, recently snuffed, still warm under your fingers. On the floor: a journal, open to a page that has your overseer's name on it. The handwriting is the chieftain's.
+
+What works: the heaviness, the still-warm wick, and the open page are three anchors that *do* work. The visible stake is the reader-presumed connection between the chieftain's hand and the overseer's name. The scene ends on the page, not on the conclusion — the player must decide what it means.
+
+---
+
+## 5. A ceremony / vow-swearing
+
+**Bad — pageantry without specificity:**
+
+> The villagers gather around you in a circle. Everyone is silent and respectful. You hold up the iron coin and swear your vow. It is a solemn moment. They cheer when you finish.
+
+What's wrong: "circle", "silent", "solemn", "cheer" — all stock pageantry. No NPC has a face. No detail places the moment in *this* world.
+
+**Good — small specifics, weight by absence:**
+
+> The rain has stopped, but the ground is still soaked, and the iron coin is colder than it should be in your hand. Twelve villagers — Ulla counted them this morning, you'd asked — stand at the edge of the firelight. The overseer's wife is not among them. You speak the words. No one cheers. Ulla nods, once.
+
+What works: rain, cold iron, firelight (three anchors). The visible stake is the absence — the one face that should be there isn't — surfaced from a thread already open. The close (Ulla's single nod) is an image, not a summary.
+
+---
+
+## Diagnostic checklist
+
+Before you commit a scene opening, ask:
+
+1. Can I name the **situation** in one clause? (Where, when, who.)
+2. Can I name the **tension** without using emotion words? (What is unsettled — show it.)
+3. Is there a **visible stake** — a thing in the frame the player can act on?
+4. Are there **exactly three** sensory anchors? (Not two, not five.)
+5. Does **at least one** sense besides sight do work?
+6. Did I **search_lore_global** for the place and faces?
+
+If any answer is no, rewrite the opening before the player reads it.

--- a/plugins/ironsworn/skills/ironsworn-scene-craft/references/sensory-palette.md
+++ b/plugins/ironsworn/skills/ironsworn-scene-craft/references/sensory-palette.md
@@ -1,0 +1,109 @@
+# Sensory Palette by Biome and Season
+
+The Ironlands have a specific texture. These palettes are starting points, not menus to copy — pick **three** anchors per scene, vary across scenes set in the same place, and prefer smell/sound/temperature/light over generic sight description.
+
+The defaults assume the canonical Ironlands tone — heroic but grounded, hostile weather, beauty in the small things (Chapter 7, *Principles*, p. 237). If the campaign has chosen non-default world truths (e.g., warmer climate, different flora), `search_lore_global` for established tone before falling back to these palettes.
+
+---
+
+## How to use
+
+For a given scene:
+
+1. Identify **biome** (deep forest, fen/bog, hinterland scrub, frostbound coast, ruins, settlement, deep wilds, sea).
+2. Identify **season** (deep winter, late winter / spring melt, spring, summer, autumn, freeze-up).
+3. Identify **time of day / weather** (dawn, midday, dusk, full dark, storm, fog, snow, clear cold).
+4. Pick **one anchor per category** — total three, no more:
+   - **Place anchor** (sight or spatial — what kind of room/wilderness this is)
+   - **Body anchor** (smell, sound, temperature, texture — what the body registers)
+   - **Mood anchor** (light, weather, an absence, a small movement)
+
+If you find yourself reaching for a fourth, cut one of the first three.
+
+---
+
+## Deep forest (Veiled Mountains, Tempest Hills foothills)
+
+- Place: leaning pines, moss-furred boulders, the path narrowing where roots cross it, a deer trail you didn't see at first.
+- Body: resin and wet leaf, the hush that swallows footsteps, cold seeping up through bootsoles.
+- Mood: green-filtered light, a single bird that keeps not calling, the way the trees go silent before something moves.
+- Avoid: "ancient", "primeval", "shadows" — these go cheap fast.
+
+## Fen / bog (Deep Wilds, Barrier Woods edges)
+
+- Place: black water between tussocks, a boardwalk of half-rotted planks, reed beds taller than a man.
+- Body: rot and methane, frog-song or the absence of it, water seeping into the third hole in your left boot.
+- Mood: low mist that doesn't lift, lights too far away to be safe, a thing's wake on flat water.
+- Avoid: "swamp" (Ironlands texture is bog/fen/mire); "ominous" (the rot is enough).
+
+## Hinterland scrub / fells (Hinterlands, Havens edges)
+
+- Place: a cairn that wasn't there last year, sheep-cropped grass, wind-bent hawthorns, a stone wall in the middle of nowhere.
+- Body: gorse and woodsmoke from a settlement two valleys over, the wind that doesn't stop, sun on cold cheeks.
+- Mood: very long sight-lines, a single hawk's circle, a thread of smoke far off.
+- Avoid: "rolling hills" — every fantasy has those; specify the wall, the cairn, the bent thorn.
+
+## Frostbound coast (Margins, Veiled Mountains coast)
+
+- Place: black sand, basalt steps cut by hand, a beached longship cracked at the keel, ice rind on tide pools.
+- Body: salt and seal-grease, the slap of waves against rock, the cold that goes through wool to the bone.
+- Mood: gulls that cry once and stop, the horizon line erased by sea-fog, a single seal watching.
+- Avoid: generic "crashing waves" — specify cadence (lull, slap, drag).
+
+## Ruins (Old Wreck, ironbroken halls)
+
+- Place: lintels carved with figures whose faces are gone, a hearth ash-cold for a hundred years, a doorway too tall.
+- Body: stone-cold even in summer, the smell of moss and old iron, your own breath echoing.
+- Mood: the wrong silence — birds don't go inside; light from above through a hole that wasn't a window once.
+- Avoid: "skeletons", "treasure" — specify the missing face, the cold hearth.
+
+## Settlement (longhouse, market, wharf)
+
+- Place: smoke-darkened roofbeams, a hide-curtain doorway, packed-earth floor with a runnel for snowmelt, the bench worn shiny by generations.
+- Body: damp wool, fish-oil lamps, the press of bodies and breath, a baby crying somewhere.
+- Mood: who looks up when you enter, who doesn't, the conversation that drops one note when you cross the threshold.
+- Avoid: "tavern" (it's a longhouse or a hall, not a fantasy tavern); generic "merchants".
+
+## Deep wilds (beyond the Pale)
+
+- Place: trees of a kind you don't know, a track that is too straight to be a deer's, snow that hasn't been broken.
+- Body: cold that has weight, an animal-smell that isn't any animal you've named, the sound of your own pulse loud in the quiet.
+- Mood: the way the light is wrong — too blue, too long, too still.
+- Avoid: "eldritch", "primordial" — let the wrongness be small and specific.
+
+## Sea (open water, a ship)
+
+- Place: the rail wet under your hand, a single gull, the wake straight or curved.
+- Body: salt-rime on lips, the lurch in the gut on the third swell, rope-burn.
+- Mood: the line of a squall on the horizon, the bell that rings without being struck (in a match-roll), a smell of land before you see it.
+- Avoid: stock "endless ocean" — specify cadence, the squall, the bell.
+
+---
+
+## Season modifiers
+
+Season warps every palette. Apply **one** seasonal note to whichever anchor it most affects:
+
+- **Deep winter:** breath frost, the way wool feels frozen at the edges, the brittle silence that follows snowfall, no birds.
+- **Late winter / spring melt:** the smell of wet earth for the first time in months, water running where it shouldn't, the fragility of ice underfoot.
+- **Spring:** new mud, the first green, animals you didn't see all winter.
+- **High summer:** insects you can hear inside conversation, sun that bleaches color out of cloth, the dust on a hot road.
+- **Autumn:** woodsmoke at every hour, geese moving south, the first night it freezes hard.
+- **Freeze-up (just before deep winter):** mud locking up at dawn, the last birds, the bone-cold that is not yet snow-cold.
+
+---
+
+## Time-of-day modifiers
+
+- **Dawn:** the cold that gets worse before it gets better; long shadows.
+- **Midday:** the only hour with no wind in some valleys; smoke goes straight up.
+- **Dusk:** "the blue hour" — go cheap or go specific (a window-light coming on).
+- **Full dark:** what you can hear that you can't see; the size of the fire-circle.
+- **Storm:** the sound *before* the rain; the way a longhouse smells when forty bodies are pressed inside it.
+- **Fog:** distances lie; sounds carry from places you can't put.
+
+---
+
+## Continuity rule
+
+If the player has visited this place before, **search_scenes** for any prior anchor used. Reuse one, vary two. The repeated detail is what makes the place real.


### PR DESCRIPTION
Closes #99

## Summary

- Adds `plugins/ironsworn/skills/ironsworn-scene-craft/` — the cross-cutting fiction-craft skill that teaches the GM how to **frame, anchor, and close scenes**, the operational form of the rulebook's *Begin and End with the Fiction* principle (Ch. 7, p. 226).
- SKILL.md spine: framing (situation + tension + visible stake), sensory anchoring (three details, never five — place / body / mood, smell-sound-temperature before sight), beat selection (one beat per scene, defer to pacing if you can't name it), closing (question / image / decision — never a summary).
- References (pushed for progressive disclosure): `framing-good-vs-bad.md` (paired examples for arrivals, confrontations, recoveries, reveals, ceremonies + diagnostic checklist), `sensory-palette.md` (Ironlands biomes + season + time-of-day modifiers + continuity rule), `closing-beats.md` (close-type-to-beat-type pairings + post-close `record_scene` discipline).
- Front-matter `description` includes literal type-of-moment trigger phrases and an ALWAYS-invoke directive, per umbrella #105 shared constraints.
- Tools-This-Skill-Governs table near the top; Fiction Grounding Protocol (#103) cited as non-negotiable.
- Cross-links established: defers NPC dialogue/voice to `ironsworn-npc-voice`, montage-vs-scene to `ironsworn-pacing`, complication texture to `ironsworn-complications`, mechanics to mechanics skills, recording to `record_scene`.
- All rule-derived content was pulled live via `search_rules`; chapter/page citations included where paraphrased.
- **No version bump** — handled by lead in a single sequenced bump after all four umbrella PRs merge.

## Test plan

- [ ] `ls plugins/ironsworn/skills/ironsworn-scene-craft/` shows `SKILL.md` + `references/`
- [ ] SKILL.md front-matter parses as valid YAML and includes the literal trigger phrases (`"we cut to..."`, `"describe the room"`, etc.) plus an ALWAYS-invoke sentence
- [ ] Spot-check that the GM agent invokes the skill on arrival/confrontation/recovery beats during a manual playtest
- [ ] References render cleanly in markdown viewers (tables, code fences, headers)
- [ ] No version bump in `plugins/ironsworn/.claude-plugin/plugin.json` (lead handles)
- [ ] Cross-links to peer skills (`ironsworn-npc-voice`, `ironsworn-pacing`, `ironsworn-complications`) resolve once those PRs merge