### PR TITLE
feat(narrative): add quality_notes field to record_scene and update_scene

### DIFF
--- a/plugins/ironsworn/.claude-plugin/plugin.json
+++ b/plugins/ironsworn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ironsworn",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Solo Ironsworn GM companion — fiction-first, dice-driven, with a living lore graph",
   "author": {
     "name": "Karim Naguib"

--- a/plugins/ironsworn/scribe/src/rag/scenes.test.ts
+++ b/plugins/ironsworn/scribe/src/rag/scenes.test.ts
@@ -47,6 +47,74 @@ describe("recordScene + searchScenes", () => {
   });
 });
 
+describe("quality_notes", () => {
+  it("stores and retrieves quality_notes on record_scene", async () => {
+    if (!(await ollamaAvailable())) return;
+    const id = await recordScene(campaignDir, "A tense duel at the river crossing.", "combat", undefined, undefined, "Combat felt dangerous — layered pressure with NPC in peril worked well.");
+    const scene = await getScene(campaignDir, id);
+    expect(scene).not.toBeNull();
+    expect(scene!.quality_notes).toBe("Combat felt dangerous — layered pressure with NPC in peril worked well.");
+  });
+
+  it("quality_notes is absent when not set", async () => {
+    if (!(await ollamaAvailable())) return;
+    const id = await recordScene(campaignDir, "A quiet moment by the fire.", "social");
+    const scene = await getScene(campaignDir, id);
+    expect(scene).not.toBeNull();
+    expect(scene!.quality_notes).toBeUndefined();
+  });
+
+  it("searchScenes returns quality_notes in results", async () => {
+    if (!(await ollamaAvailable())) return;
+    await recordScene(campaignDir, "Ambush on the forest road.", "combat", undefined, undefined, "Third consecutive social obstacle — complication theme was repetitive.");
+    const results = await searchScenes(campaignDir, "forest ambush", 3);
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0]!.quality_notes).toBe("Third consecutive social obstacle — complication theme was repetitive.");
+  });
+
+  it("updateScene sets quality_notes on an existing scene", async () => {
+    if (!(await ollamaAvailable())) return;
+    const id = await recordScene(campaignDir, "A diplomatic meeting at the keep.", "social");
+
+    await updateScene(campaignDir, id, { quality_notes: "GM overreached in narrating player intent." });
+
+    const updated = await getScene(campaignDir, id);
+    expect(updated).not.toBeNull();
+    expect(updated!.quality_notes).toBe("GM overreached in narrating player intent.");
+    expect(updated!.text).toBe("A diplomatic meeting at the keep.");
+  });
+
+  it("quality_notes is searchable via its text content", async () => {
+    if (!(await ollamaAvailable())) return;
+    await recordScene(campaignDir, "A scene with unremarkable summary.", "exploration", undefined, undefined, "Pacing was slow — too many travel details without tension.");
+    const results = await searchScenes(campaignDir, "pacing slow travel", 3);
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0]!.quality_notes).toContain("Pacing was slow");
+  });
+
+  it("export/import round-trips quality_notes", async () => {
+    if (!(await ollamaAvailable())) return;
+    const id = await recordScene(campaignDir, "The ward-stone scene.", "social", undefined, undefined, "Strong atmosphere — sensory details landed well.");
+
+    const exported = await exportScenes(campaignDir);
+    const exportedScene = exported.find((s) => s.id === id);
+    expect(exportedScene).toBeDefined();
+    expect(exportedScene!.quality_notes).toBe("Strong atmosphere — sensory details landed well.");
+
+    const dir2 = await mkdtemp(join(tmpdir(), "scribe-quality-import-test-"));
+    try {
+      const inserted = await importScene(dir2, exportedScene!.id, exportedScene!.text, exportedScene!.timestamp, exportedScene!.kind, exportedScene!.complication_theme, exportedScene!.beats, exportedScene!.quality_notes);
+      expect(inserted).toBe(true);
+
+      const reimported = await getScene(dir2, id);
+      expect(reimported).not.toBeNull();
+      expect(reimported!.quality_notes).toBe("Strong atmosphere — sensory details landed well.");
+    } finally {
+      await rm(dir2, { recursive: true });
+    }
+  });
+});
+
 describe("getRecentComplications", () => {
   it("returns only scenes with complication_theme set", async () => {
     if (!(await ollamaAvailable())) return;

--- a/plugins/ironsworn/scribe/src/rag/scenes.ts
+++ b/plugins/ironsworn/scribe/src/rag/scenes.ts
@@ -18,6 +18,7 @@ export interface Scene {
   timestamp: string;
   kind: string;
   complication_theme?: string;
+  quality_notes?: string;
   beats?: Beat[];
   score?: number;
 }
@@ -97,12 +98,17 @@ async function initDb(campaignPath: string): Promise<DuckDBInstance> {
         embedding          FLOAT[768] NOT NULL,
         timestamp          TEXT NOT NULL,
         kind               TEXT NOT NULL DEFAULT 'scene',
-        complication_theme TEXT
+        complication_theme TEXT,
+        quality_notes      TEXT
       )
     `);
 
     await conn.run(`
       ALTER TABLE scenes ADD COLUMN IF NOT EXISTS complication_theme TEXT
+    `);
+
+    await conn.run(`
+      ALTER TABLE scenes ADD COLUMN IF NOT EXISTS quality_notes TEXT
     `);
 
     await conn.run(`
@@ -249,9 +255,11 @@ export async function recordScene(
   kind?: string,
   complicationTheme?: string,
   beats?: BeatInput[],
+  qualityNotes?: string,
 ): Promise<string> {
+  const embedText = qualityNotes ? `${summary}\n${qualityNotes}` : summary;
   const [embedding, instance] = await Promise.all([
-    getEmbedding(summary),
+    getEmbedding(embedText),
     getDb(campaignPath),
   ]);
 
@@ -264,9 +272,9 @@ export async function recordScene(
   const conn = await openWriteConn(instance);
   try {
     await conn.run(
-      `INSERT INTO scenes (id, text, embedding, timestamp, kind, complication_theme)
-       VALUES (?, ?, ${embeddingLiteral}, ?, ?, ?)`,
-      [id, summary, timestamp, sceneKind, complicationTheme ?? null],
+      `INSERT INTO scenes (id, text, embedding, timestamp, kind, complication_theme, quality_notes)
+       VALUES (?, ?, ${embeddingLiteral}, ?, ?, ?, ?)`,
+      [id, summary, timestamp, sceneKind, complicationTheme ?? null, qualityNotes ?? null],
     );
   } finally {
     conn.closeSync();
@@ -290,7 +298,7 @@ export async function getScene(
   try {
     const rows = (
       await conn.runAndReadAll(
-        `SELECT id, text, timestamp, kind, complication_theme FROM scenes WHERE id = ?`,
+        `SELECT id, text, timestamp, kind, complication_theme, quality_notes FROM scenes WHERE id = ?`,
         [id],
       )
     ).getRowObjectsJS() as Record<string, unknown>[];
@@ -302,6 +310,7 @@ export async function getScene(
       timestamp: String(row["timestamp"]),
       kind: String(row["kind"]),
       complication_theme: row["complication_theme"] != null ? String(row["complication_theme"]) : undefined,
+      quality_notes: row["quality_notes"] != null ? String(row["quality_notes"]) : undefined,
     };
   } finally {
     conn.closeSync();
@@ -317,7 +326,7 @@ export async function getScene(
 export async function updateScene(
   campaignPath: string,
   id: string,
-  fields: { summary?: string; kind?: string; complication_theme?: string },
+  fields: { summary?: string; kind?: string; complication_theme?: string; quality_notes?: string },
 ): Promise<void> {
   const instance = await getDb(campaignPath);
 
@@ -325,12 +334,40 @@ export async function updateScene(
   const setClauses: string[] = [];
   const params: DuckDBValue[] = [];
 
-  if (fields.summary !== undefined) {
-    // Re-embed when summary changes
-    const embedding = await getEmbedding(fields.summary);
+  if (fields.summary !== undefined || fields.quality_notes !== undefined) {
+    // Re-embed when summary or quality_notes changes; need current values for the other field
+    let embedSummary = fields.summary;
+    let embedNotes = fields.quality_notes;
+
+    if (embedSummary === undefined || embedNotes === undefined) {
+      // Fetch current values for whichever field is not being updated
+      const checkConn = await instance.connect();
+      try {
+        const rows = (
+          await checkConn.runAndReadAll(
+            `SELECT text, quality_notes FROM scenes WHERE id = ?`,
+            [id],
+          )
+        ).getRowObjectsJS() as Record<string, unknown>[];
+        if (rows.length > 0) {
+          if (embedSummary === undefined) embedSummary = String(rows[0]!["text"] ?? "");
+          if (embedNotes === undefined) {
+            const n = rows[0]!["quality_notes"];
+            embedNotes = n != null ? String(n) : undefined;
+          }
+        }
+      } finally {
+        checkConn.closeSync();
+      }
+    }
+
+    const embedText = embedNotes ? `${embedSummary}\n${embedNotes}` : embedSummary!;
+    const embedding = await getEmbedding(embedText);
     const embeddingLiteral = `[${embedding.join(",")}]::FLOAT[768]`;
-    setClauses.push(`text = ?`);
-    params.push(fields.summary);
+    if (fields.summary !== undefined) {
+      setClauses.push(`text = ?`);
+      params.push(fields.summary);
+    }
     setClauses.push(`embedding = ${embeddingLiteral}`);
   }
   if (fields.kind !== undefined) {
@@ -340,6 +377,10 @@ export async function updateScene(
   if (fields.complication_theme !== undefined) {
     setClauses.push(`complication_theme = ?`);
     params.push(fields.complication_theme);
+  }
+  if (fields.quality_notes !== undefined) {
+    setClauses.push(`quality_notes = ?`);
+    params.push(fields.quality_notes);
   }
 
   if (setClauses.length === 0) return;
@@ -568,6 +609,7 @@ export interface SceneExport {
   timestamp: string;
   kind: string;
   complication_theme?: string;
+  quality_notes?: string;
   beats?: BeatExport[];
 }
 
@@ -577,7 +619,7 @@ export async function exportScenes(campaignPath: string): Promise<SceneExport[]>
   try {
     const sceneRows = (
       await conn.runAndReadAll(
-        `SELECT id, text, timestamp, kind, complication_theme FROM scenes ORDER BY timestamp`,
+        `SELECT id, text, timestamp, kind, complication_theme, quality_notes FROM scenes ORDER BY timestamp`,
       )
     ).getRowObjectsJS() as Record<string, unknown>[];
 
@@ -621,6 +663,7 @@ export async function exportScenes(campaignPath: string): Promise<SceneExport[]>
         timestamp: String(r["timestamp"]),
         kind: String(r["kind"]),
         complication_theme: r["complication_theme"] != null ? String(r["complication_theme"]) : undefined,
+        quality_notes: r["quality_notes"] != null ? String(r["quality_notes"]) : undefined,
       };
       if (beats && beats.length > 0) entry.beats = beats;
       return entry;
@@ -638,6 +681,7 @@ export async function importScene(
   kind: string,
   complicationTheme?: string,
   beats?: BeatExport[],
+  qualityNotes?: string,
 ): Promise<boolean> {
   const instance = await getDb(campaignPath);
 
@@ -654,7 +698,8 @@ export async function importScene(
   if (exists) return false;
 
   // Fetch scene + all beat embeddings in parallel
-  const allTexts = [text, ...(beats ?? []).map((b) => b.text)];
+  const embedText = qualityNotes ? `${text}\n${qualityNotes}` : text;
+  const allTexts = [embedText, ...(beats ?? []).map((b) => b.text)];
   const allEmbeddings = await Promise.all(allTexts.map(getEmbedding));
   const sceneEmbedding = allEmbeddings[0]!;
   const beatEmbeddings = allEmbeddings.slice(1);
@@ -664,8 +709,8 @@ export async function importScene(
   const conn = await openWriteConn(instance);
   try {
     await conn.run(
-      `INSERT INTO scenes (id, text, embedding, timestamp, kind, complication_theme) VALUES (?, ?, ${embeddingLiteral}, ?, ?, ?)`,
-      [id, text, timestamp, kind, complicationTheme ?? null],
+      `INSERT INTO scenes (id, text, embedding, timestamp, kind, complication_theme, quality_notes) VALUES (?, ?, ${embeddingLiteral}, ?, ?, ?, ?)`,
+      [id, text, timestamp, kind, complicationTheme ?? null, qualityNotes ?? null],
     );
 
     if (beats && beats.length > 0) {
@@ -737,7 +782,7 @@ export async function searchScenes(
   const conn = await instance.connect();
   try {
     const result = await conn.runAndReadAll(
-      `SELECT id, text, timestamp, kind, complication_theme,
+      `SELECT id, text, timestamp, kind, complication_theme, quality_notes,
               array_cosine_similarity(embedding, ${embeddingLiteral}) AS score
        FROM scenes
        ORDER BY score DESC
@@ -753,6 +798,7 @@ export async function searchScenes(
       timestamp: String(row["timestamp"] ?? ""),
       kind: String(row["kind"] ?? "scene"),
       complication_theme: row["complication_theme"] != null ? String(row["complication_theme"]) : undefined,
+      quality_notes: row["quality_notes"] != null ? String(row["quality_notes"]) : undefined,
       score:
         typeof row["score"] === "number"
           ? row["score"]

--- a/plugins/ironsworn/scribe/src/tools/narrative.ts
+++ b/plugins/ironsworn/scribe/src/tools/narrative.ts
@@ -92,10 +92,13 @@ export function register(server: McpServer, campaignPath: string): void {
       beats: z.array(BeatInputSchema).optional().describe(
         "Optional ordered narrative beats for the scene. When omitted, only the summary is stored (backward-compatible)."
       ),
+      quality_notes: z.string().optional().describe(
+        "Optional fiction/RP quality feedback for this scene (e.g. 'Combat felt dangerous — layered pressure worked well', 'Complication theme was repetitive'). Captured for GM improvement and included in semantic search."
+      ),
     },
-    async ({ summary, kind, npcs, lore_ids, complication_theme, beats }) => {
+    async ({ summary, kind, npcs, lore_ids, complication_theme, beats, quality_notes }) => {
       try {
-        const id = await recordScene(campaignPath, summary, kind, complication_theme, beats as BeatInput[] | undefined);
+        const id = await recordScene(campaignPath, summary, kind, complication_theme, beats as BeatInput[] | undefined, quality_notes);
         recordMutation(campaignPath);
         const { warnings, stubbed } = await buildSceneWarnings(campaignPath, npcs, lore_ids);
         return {
@@ -122,8 +125,11 @@ export function register(server: McpServer, campaignPath: string): void {
       append_beats: z.array(BeatInputSchema).optional().describe(
         "New beats to append to the scene's existing beats array (does not replace existing beats)"
       ),
+      quality_notes: z.string().optional().describe(
+        "Fiction/RP quality feedback to set or replace on this scene"
+      ),
     },
-    async ({ id, summary, kind, npcs, lore_ids, append_beats }) => {
+    async ({ id, summary, kind, npcs, lore_ids, append_beats, quality_notes }) => {
       try {
         const existing = await getScene(campaignPath, id);
         if (existing === null) {
@@ -132,7 +138,7 @@ export function register(server: McpServer, campaignPath: string): void {
             isError: true,
           };
         }
-        await updateScene(campaignPath, id, { summary, kind });
+        await updateScene(campaignPath, id, { summary, kind, quality_notes });
         if (append_beats && append_beats.length > 0) {
           await recordBeats(campaignPath, id, append_beats as BeatInput[]);
         }


### PR DESCRIPTION
## Summary

- Adds optional `quality_notes: string` to `record_scene` and `update_scene` for capturing fiction/RP feedback (tone, pacing, what worked/didn't)
- Stored in a new `quality_notes TEXT` column in DuckDB with a backward-compat `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` migration
- Included in the scene embedding (`summary + "\n" + quality_notes`) so the field is semantically searchable via `search_scenes`
- Returned by `getScene`, `searchScenes`, `exportScenes`; round-trips through `importScene`
- `updateScene` re-embeds when either `summary` or `quality_notes` changes (fetching the current value of whichever field isn't being updated)

## Test plan

- [ ] All 36 tests in `scenes.test.ts` pass (`bun test src/rag/scenes.test.ts`)
- [ ] 6 new `quality_notes` tests cover: store/retrieve, absence, search results include the field, `updateScene`, semantic searchability, export/import round-trip

Closes #59

---
_Generated by [Claude Code](https://claude.ai/code/session_018FbrRtuiGKP15tpJ9VCqTM)_