### PR TITLE
feat(gm): add Fiction Grounding Protocol and cross-reference all fiction-touching skills

### DIFF
--- a/plugins/ironsworn/.claude-plugin/plugin.json
+++ b/plugins/ironsworn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ironsworn",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "description": "Solo Ironsworn GM companion — fiction-first, dice-driven, with a living lore graph",
   "author": {
     "name": "Karim Naguib"

--- a/plugins/ironsworn/agents/ironsworn-gm.md
+++ b/plugins/ironsworn/agents/ironsworn-gm.md
@@ -149,6 +149,17 @@ When you call `roll_yes_no` or `roll_oracle`, the result is a constraint, not a 
 
 Complication and opportunity should feel inevitable in retrospect, like they were always going to happen this way.
 
+### Fiction Grounding Protocol
+
+Before narrating any fiction that introduces or invokes a place, NPC, faction, or past event:
+
+1. **Search first** — Call `search_lore_global` (or `search_lore` if the scope is specific) for the subject.
+2. **If results exist** — Weave them in. Honor what's already established: voice, faction ties, past beats.
+3. **If no results** — You are inventing something new. Narrate it, then call `upsert_lore` after the beat to record it.
+4. **Never contradict** — If a roll or oracle says something that conflicts with established lore, treat the conflict itself as the complication.
+
+Every fiction-touching skill invokes this protocol. See each skill's SKILL.md for the reminder.
+
 ### Complication Diversity Protocol
 
 Before narrating ANY miss or Pay the Price outcome, follow this protocol:

--- a/plugins/ironsworn/skills/ironsworn-combat/SKILL.md
+++ b/plugins/ironsworn/skills/ironsworn-combat/SKILL.md
@@ -18,6 +18,8 @@ Combat is a distinct mode of play. The clock runs faster, the fiction is sharper
 
 For all progress-track mechanics (ticks, glyphs, fulfill flow), defer to `ironsworn-progress-tracks`. For Endure Harm / Endure Stress / Face Death triggered by a Pay the Price, defer to `ironsworn-suffer`. For oracle prompts during combat, defer to `ironsworn-oracle`.
 
+**Fiction Grounding Protocol:** Must invoke before narrating foe descriptions, fight texture, or any fiction beat that introduces a place, NPC, or faction — see `agents/ironsworn-gm.md`.
+
 ---
 
 ## Tools This Skill Governs

--- a/plugins/ironsworn/skills/ironsworn-complications/SKILL.md
+++ b/plugins/ironsworn/skills/ironsworn-complications/SKILL.md
@@ -22,6 +22,8 @@ description: >
 
 A miss without a cost is a lie. A complication without texture is paperwork. This skill owns *texture* — how a cost lands in the senses, in the lore, in the campaign's weight. It does not own diversity-protocol enforcement (`agents/ironsworn-gm.md` does, via `get_recent_complications`) or the Pay the Price *decision* (`ironsworn-oracle` does).
 
+**Fiction Grounding Protocol:** Must invoke before narrating complication beats that introduce a place, NPC, faction, or past event — see `agents/ironsworn-gm.md`.
+
 ---
 
 ## Tools This Skill Governs

--- a/plugins/ironsworn/skills/ironsworn-npc-voice/SKILL.md
+++ b/plugins/ironsworn/skills/ironsworn-npc-voice/SKILL.md
@@ -17,6 +17,8 @@ description: >
 
 NPCs in Ironsworn have no stats — they exist entirely in fiction (rulebook p. 24, 133). This skill is the craft layer for keeping them **distinctive, motivated, and continuous** across sessions. Every line and reaction must be grounded in the lore record.
 
+**Fiction Grounding Protocol:** Must invoke before writing any NPC dialogue or reaction that introduces or invokes a place, faction, or past event — see `agents/ironsworn-gm.md`.
+
 ---
 
 ## Tools This Skill Governs

--- a/plugins/ironsworn/skills/ironsworn-oracle/SKILL.md
+++ b/plugins/ironsworn/skills/ironsworn-oracle/SKILL.md
@@ -19,6 +19,8 @@ description: >
 
 The oracle is the engine of surprise. Anything you don't already know, the dice can tell you. This skill is the single source of truth for the two Fate moves — **Ask the Oracle** and **Pay the Price** — and for how every other skill should reach for `roll_yes_no` and `roll_oracle`.
 
+**Fiction Grounding Protocol:** Must invoke before narrating oracle answer interpretations that introduce a place, NPC, faction, or past event — see `agents/ironsworn-gm.md`.
+
 ---
 
 ## Tools This Skill Governs

--- a/plugins/ironsworn/skills/ironsworn-pacing/SKILL.md
+++ b/plugins/ironsworn/skills/ironsworn-pacing/SKILL.md
@@ -18,6 +18,8 @@ description: >
 
 Pacing is the GM's decision about **where the camera lives**: zoomed out across days, or zoomed into a single breath. Ironsworn breathes in and out; this skill keeps the rhythm honest.
 
+**Fiction Grounding Protocol:** Must invoke before narrating any scene framing or transition beat that introduces a place, NPC, faction, or past event — see `agents/ironsworn-gm.md`.
+
 ---
 
 ## Tools This Skill Governs

--- a/plugins/ironsworn/skills/ironsworn-progress-tracks/SKILL.md
+++ b/plugins/ironsworn/skills/ironsworn-progress-tracks/SKILL.md
@@ -16,6 +16,8 @@ description: >
 
 Progress tracks are the spine of Ironsworn. Vows, journeys, combats, bonds, and scene challenges all use them. This skill is the single source of truth for how they work, how they are advanced, how they resolve, and how they are displayed.
 
+**Fiction Grounding Protocol:** Must invoke before narrating vow fiction, journey arrivals, or milestone beats that introduce a place, NPC, faction, or past event — see `agents/ironsworn-gm.md`.
+
 ---
 
 ## Tools This Skill Governs

--- a/plugins/ironsworn/skills/ironsworn-scene-craft/SKILL.md
+++ b/plugins/ironsworn/skills/ironsworn-scene-craft/SKILL.md
@@ -19,6 +19,8 @@ description: >
 
 # Ironsworn Scene Craft
 
+**Fiction Grounding Protocol:** Must invoke before framing any scene that introduces or invokes a place, NPC, faction, or past event — see `agents/ironsworn-gm.md`.
+
 A scene has a place, a moment, a stake, and an exit. This skill is the operational form of the rulebook's *Begin and End with the Fiction* principle (Ch. 7, p. 226). It loads alongside any mechanics skill when the texture of a moment matters more than the dice.
 
 ---

--- a/plugins/ironsworn/skills/ironsworn-social/SKILL.md
+++ b/plugins/ironsworn/skills/ironsworn-social/SKILL.md
@@ -17,6 +17,8 @@ description: >
 
 Social moves resolve persuasion, recovery in community, and the relationships that anchor the character to the Ironlands. This skill is the single source of truth for **how** these moves resolve, what tool calls follow each outcome, and where social play hands off to other skills.
 
+**Fiction Grounding Protocol:** Must invoke before narrating NPC voice, bond stakes, or any fiction beat that introduces a place, NPC, faction, or past event — see `agents/ironsworn-gm.md`.
+
 ---
 
 ## Tools This Skill Governs

--- a/plugins/ironsworn/skills/ironsworn-suffer/SKILL.md
+++ b/plugins/ironsworn/skills/ironsworn-suffer/SKILL.md
@@ -17,6 +17,8 @@ description: >
 
 Suffer moves apply costs when the world pushes back. This skill is the single source of truth for **applying** consequences. Choosing *which* consequence belongs to `ironsworn-oracle` Pay the Price; this skill takes it from there.
 
+**Fiction Grounding Protocol:** Must invoke before narrating consequence beats that introduce a place, NPC, faction, or past event — see `agents/ironsworn-gm.md`.
+
 **The discipline:** *A hit that costs nothing isn't a hit.* Never narrate "you take a wound" without `suffer_harm`; never narrate "you're rattled" without `suffer_stress`. The journal is how the campaign remembers wounds.
 
 ---


### PR DESCRIPTION
Adds a named Fiction Grounding Protocol section to ironsworn-gm.md near
the Complication Diversity Protocol. Every fiction-touching skill now carries
a one-line callout citing the protocol so the GM agent never narrates a place,
NPC, faction, or past event without searching lore first.

Closes #103