### PR TITLE
Add roll_epilogue MCP tool for Write Your Epilogue progress roll on bonds

### DIFF
--- a/plugins/ironsworn/.claude-plugin/plugin.json
+++ b/plugins/ironsworn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ironsworn",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Solo Ironsworn GM companion — fiction-first, dice-driven, with a living lore graph",
   "author": {
     "name": "Karim Naguib"

--- a/plugins/ironsworn/scribe/src/rules/ironsworn/progress.ts
+++ b/plugins/ironsworn/scribe/src/rules/ironsworn/progress.ts
@@ -92,3 +92,33 @@ export function rollProgress(track: ProgressTrack): ProgressRollResult {
     match: c1 === c2,
   };
 }
+
+export interface EpilogueRollResult {
+  bonds: number;
+  progressScore: number;
+  challengeDice: [number, number];
+  outcome: "strong" | "weak" | "miss";
+  match: boolean;
+  oraclePrompt: string | null;
+}
+
+export function rollEpilogue(bonds: number): EpilogueRollResult {
+  const progressScore = Math.min(bonds, 10);
+  const c1 = roll("d10").total;
+  const c2 = roll("d10").total;
+  const band = classifyBand(progressScore, c1, c2);
+  const outcome = band === "strong_hit" ? "strong" : band === "weak_hit" ? "weak" : "miss";
+  const oraclePrompt =
+    band === "strong_hit" ? null :
+    band === "weak_hit" ? "Envision an unexpected turn in your new life." :
+    "Envision how your fears are realized.";
+
+  return {
+    bonds,
+    progressScore,
+    challengeDice: [c1, c2],
+    outcome,
+    match: c1 === c2,
+    oraclePrompt,
+  };
+}

--- a/plugins/ironsworn/scribe/src/tools/mechanics.test.ts
+++ b/plugins/ironsworn/scribe/src/tools/mechanics.test.ts
@@ -112,6 +112,63 @@ describe("resolve_move burn_momentum", () => {
   });
 });
 
+describe("roll_epilogue", () => {
+  it("returns outcome, bonds, challengeDice, and match fields", async () => {
+    const result = await client.callTool({ name: "roll_epilogue", arguments: {} });
+    expect(result.isError).not.toBe(true);
+    const parsed = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+    expect(["strong", "weak", "miss"]).toContain(parsed.outcome);
+    expect(parsed.bonds).toBe(0);
+    expect(Array.isArray(parsed.challengeDice)).toBe(true);
+    expect(parsed.challengeDice).toHaveLength(2);
+    expect(typeof parsed.match).toBe("boolean");
+  });
+
+  it("reads bonds from character.json", async () => {
+    const bondsChar = { ...CHARACTER, bonds: 7 };
+    await writeFile(join(campaignDir, "character.json"), JSON.stringify(bondsChar));
+    const result = await client.callTool({ name: "roll_epilogue", arguments: {} });
+    expect(result.isError).not.toBe(true);
+    const parsed = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+    expect(parsed.bonds).toBe(7);
+    expect(parsed.progressScore).toBe(7);
+  });
+
+  it("caps bonds at 10 for progress score", async () => {
+    const bondsChar = { ...CHARACTER, bonds: 15 };
+    await writeFile(join(campaignDir, "character.json"), JSON.stringify(bondsChar));
+    const result = await client.callTool({ name: "roll_epilogue", arguments: {} });
+    expect(result.isError).not.toBe(true);
+    const parsed = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+    expect(parsed.bonds).toBe(15);
+    expect(parsed.progressScore).toBe(10);
+  });
+
+  it("includes oraclePrompt on weak hit or miss, null on strong hit", async () => {
+    // Run many times to cover outcomes; at least verify the field is present and correct type
+    for (let i = 0; i < 30; i++) {
+      const result = await client.callTool({ name: "roll_epilogue", arguments: {} });
+      const parsed = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+      if (parsed.outcome === "strong") {
+        expect(parsed.oraclePrompt).toBeNull();
+      } else {
+        expect(typeof parsed.oraclePrompt).toBe("string");
+        expect(parsed.oraclePrompt.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("writes a writeEpilogue entry to the journal", async () => {
+    const { readFile } = await import("node:fs/promises");
+    await client.callTool({ name: "roll_epilogue", arguments: {} });
+    const journal = await readFile(join(campaignDir, "state-journal.jsonl"), "utf-8");
+    const entries = journal.trim().split("\n").map((l) => JSON.parse(l));
+    const epilogueEntry = entries.find((e) => e.kind === "writeEpilogue");
+    expect(epilogueEntry).toBeDefined();
+    expect(epilogueEntry.kind).toBe("writeEpilogue");
+  });
+});
+
 describe("resolve_move resource stats", () => {
   it("accepts supply as a valid stat", async () => {
     const result = await client.callTool({ name: "resolve_move", arguments: { move_name: "Make Camp", stat: "supply", adds: 0 } });

--- a/plugins/ironsworn/scribe/src/tools/mechanics.ts
+++ b/plugins/ironsworn/scribe/src/tools/mechanics.ts
@@ -2,7 +2,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { roll } from "../rules/dice.js";
 import { resolveMove, applyMomentumBurn } from "../rules/ironsworn/moves.js";
-import { rollProgress } from "../rules/ironsworn/progress.js";
+import { rollProgress, rollEpilogue } from "../rules/ironsworn/progress.js";
 import { rollOracle, rollYesNo } from "../rules/ironsworn/oracles.js";
 import { loadCharacter, saveCharacter, appendJournal } from "../state/character.js";
 import { burnMomentum } from "../rules/ironsworn/momentum.js";
@@ -115,6 +115,33 @@ export function register(server: McpServer, campaignPath: string): void {
           };
         }
         const result = rollProgress(track);
+        return {
+          content: [{ type: "text", text: JSON.stringify(result) }],
+        };
+      } catch (e) {
+        return {
+          content: [{ type: "text", text: `Error: ${e instanceof Error ? e.message : String(e)}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.tool(
+    "roll_epilogue",
+    "Roll Write Your Epilogue — a progress roll against bonds (not a track). " +
+    "Reads bonds from character.json, rolls two challenge d10s, and records the campaign-end event to the journal.",
+    {},
+    async () => {
+      try {
+        const character = await loadCharacter(campaignPath);
+        const result = rollEpilogue(character.bonds);
+        await appendJournal(campaignPath, {
+          timestamp: new Date().toISOString(),
+          kind: "writeEpilogue",
+          before: character,
+          after: character,
+        });
         return {
           content: [{ type: "text", text: JSON.stringify(result) }],
         };

--- a/plugins/ironsworn/skills/ironsworn-social/SKILL.md
+++ b/plugins/ironsworn/skills/ironsworn-social/SKILL.md
@@ -26,7 +26,7 @@ Social moves resolve persuasion, recovery in community, and the relationships th
 | Tool | When |
 |---|---|
 | `resolve_move` | Compel, Sojourn, Forge a Bond, Test Your Bond, Aid Your Ally, Write Your Epilogue (action rolls) |
-| `roll_progress` | Write Your Epilogue (progress roll on bonds) |
+| `roll_epilogue` | Write Your Epilogue (progress roll on bonds — reads bonds directly, no track required) |
 | `override` (path=`bonds`) | Increment / clear `bonds` after Forge a Bond or Test Your Bond outcomes |
 | `get_character_digest` | Read current `bonds` value before mutating |
 | `upsert_npc` | Record a new NPC, or update impression after a beat |
@@ -105,11 +105,11 @@ After choosing, the player may **focus** one chosen *Recover* action: re-roll +h
 **Fiction Notes.** Aid is a fiction frame on an existing move. Decide the supporting action (cover, feint, scout, reassure), pick the stat that matches, and resolve as Secure an Advantage — the result modifies the ally's next roll, not yours.
 
 ### Write Your Epilogue
-**Trigger:** the character retires from the life of the Ironsworn. This is a **progress roll on bonds**, not an action roll: use `roll_progress` (treat each filled bond, up to 10, as a filled progress box).
+**Trigger:** the character retires from the life of the Ironsworn. This is a **progress roll on bonds**, not an action roll: call `roll_epilogue` (reads `bonds` directly from character state, no track required).
 
-- Strong → things come to pass as hoped.
-- Weak → an unexpected turn — narrate the new life (`roll_oracle` if unsure).
-- Miss → fears realized.
+- Strong → things come to pass as hoped. (`oraclePrompt` is null — no oracle needed.)
+- Weak → an unexpected turn — narrate the new life. Call `roll_oracle` using the returned `oraclePrompt`.
+- Miss → fears realized. Call `roll_oracle` using the returned `oraclePrompt`.
 
 After resolution, the campaign closes for that character. **Fiction Notes.** Epilogue is the *cost-benefit ledger of bonds* paying out — few bonds risks isolation, many cashes them in for the life earned. Run it as montage, not scene.
 
@@ -122,7 +122,7 @@ After resolution, the campaign closes for that character. **Fiction Notes.** Epi
 - **A weak-hit promise is a thread.** `open_thread` (debt or vow). Don't trust memory.
 - **Don't conflate Sojourn with Make Camp** — community heart vs wilderness supply.
 - **Aid Your Ally is not a separate roll table** — it's Secure an Advantage with the bonus given to the ally.
-- **Write Your Epilogue uses `roll_progress` on bonds**, not `resolve_move`. It ends the campaign for that character.
+- **Write Your Epilogue uses `roll_epilogue`**, not `resolve_move` or `roll_progress`. It reads `bonds` directly and ends the campaign for that character.
 - **Ground in lore first** — `search_lore_global` / `get_npc` before inventing motives, debts, or community history.
 
 ---


### PR DESCRIPTION
Closes #113. Bonds is a plain integer on character.json, not a ProgressTrack,
so roll_progress("bonds") would fail at runtime. The new roll_epilogue tool
reads bonds directly, rolls two challenge d10s, classifies the outcome, includes
an oraclePrompt string on weak/miss for the follow-up roll_oracle call, and
records the campaign-end event to the journal.

- Add rollEpilogue() domain function and EpilogueRollResult interface to progress.ts
- Register roll_epilogue tool in mechanics.ts
- Add 5 tests covering structure, bonds value, cap-at-10, oraclePrompt, and journal write
- Update ironsworn-social SKILL.md to call roll_epilogue instead of roll_progress
- Bump plugin version 0.16.0 → 0.17.0