### PR TITLE
Add DB migration system for schema versioning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,36 @@ A campaign lives in its own directory (default: `campaigns/default/`):
 - `npcs/`, `threads/` — per-entity markdown/JSON files
 - `state-journal.jsonl` — append-only mutation audit log
 
+## Schema migrations
+
+The scribe server has a lightweight migration system in `scribe/src/migrations/`.
+
+**DuckDB (lore + scenes):** Each DB gets a `_schema_migrations` table tracking applied version numbers. `runDbMigrations` is called at the end of each `initDb` in `rag/lore-db.ts` and `rag/scenes.ts` — migrations run automatically on first DB access after server start. Add new entries to `migrations/lore.ts` or `migrations/scenes.ts`:
+
+```ts
+{
+  version: 1,
+  description: "add source_url column to lore_entities",
+  async up(conn) {
+    await conn.run("ALTER TABLE lore_entities ADD COLUMN IF NOT EXISTS source_url TEXT");
+  },
+}
+```
+
+Also update the corresponding `CREATE TABLE` statement in `initDb` so fresh installs get the column without running the migration.
+
+**Character JSON:** `character.json` carries a `schemaVersion` field. `runCharacterMigrations` is called in `loadCharacter`; if migrations run, the file is saved immediately. `saveCharacter` always stamps the current version. Add entries to `CHARACTER_MIGRATIONS` in `state/character.ts` and bump `CURRENT_CHARACTER_VERSION`:
+
+```ts
+{
+  toVersion: 1,
+  description: "rename bonds to bondCount",
+  up(data) { data["bondCount"] = data["bonds"]; delete data["bonds"]; return data; },
+}
+```
+
+**Rules:** migrations are append-only — never edit or reorder existing entries. Version 0 is the implicit baseline (existing campaigns get the tracking table created but no migrations applied). To squash old migrations: update `initDb` / `CHARACTER_MIGRATIONS` to reflect the current schema, delete the old entries, and bump a baseline version constant in the runner so it skips past them.
+
 ## Plugin versioning
 
 **Every PR must bump `plugins/ironsworn/.claude-plugin/plugin.json`** — the Stop hook blocks completion otherwise. Use semver: bump minor for new tools/features, patch for fixes. The hook compares against `origin/main` and also verifies the version actually increased.

--- a/plugins/ironsworn/.claude-plugin/plugin.json
+++ b/plugins/ironsworn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ironsworn",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Solo Ironsworn GM companion — fiction-first, dice-driven, with a living lore graph",
   "author": {
     "name": "Karim Naguib"

--- a/plugins/ironsworn/scribe/src/migrations/index.ts
+++ b/plugins/ironsworn/scribe/src/migrations/index.ts
@@ -1,0 +1,92 @@
+import type { DuckDBInstance } from "@duckdb/node-api";
+
+type DuckDBConn = Awaited<ReturnType<DuckDBInstance["connect"]>>;
+
+// ---------------------------------------------------------------------------
+// DuckDB schema migrations
+// ---------------------------------------------------------------------------
+
+export interface DbMigration {
+  version: number;
+  description: string;
+  up: (conn: DuckDBConn) => Promise<void>;
+}
+
+/**
+ * Creates a `_schema_migrations` table (if absent), determines the current
+ * schema version, and applies any pending migrations in order. Safe to call
+ * on both fresh and existing databases — version 0 is the implicit baseline
+ * established by the `CREATE TABLE IF NOT EXISTS` calls in each initDb.
+ */
+export async function runDbMigrations(
+  conn: DuckDBConn,
+  migrations: DbMigration[],
+): Promise<void> {
+  await conn.run(`
+    CREATE TABLE IF NOT EXISTS _schema_migrations (
+      version    INTEGER PRIMARY KEY,
+      applied_at TEXT NOT NULL
+    )
+  `);
+
+  const result = await conn.runAndReadAll(
+    "SELECT COALESCE(MAX(version), 0) AS v FROM _schema_migrations",
+  );
+  const rows = result.getRowObjectsJS() as Record<string, unknown>[];
+  const raw = rows[0]?.["v"] ?? 0;
+  const current = typeof raw === "bigint" ? Number(raw) : (raw as number);
+
+  const pending = migrations
+    .filter((m) => m.version > current)
+    .sort((a, b) => a.version - b.version);
+
+  for (const migration of pending) {
+    await migration.up(conn);
+    await conn.run("INSERT INTO _schema_migrations VALUES (?, ?)", [
+      migration.version,
+      new Date().toISOString(),
+    ]);
+    console.error(
+      `[scribe] db migration v${migration.version}: ${migration.description}`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Character JSON migrations
+// ---------------------------------------------------------------------------
+
+export interface CharacterMigration {
+  toVersion: number;
+  description: string;
+  /** Pure transform: takes raw parsed JSON, returns updated raw JSON. */
+  up: (data: Record<string, unknown>) => Record<string, unknown>;
+}
+
+/**
+ * Applies any pending character migrations and stamps the current version.
+ * Returns `{ data, migrated }` — caller saves to disk only when `migrated`
+ * is true.
+ */
+export function runCharacterMigrations(
+  data: Record<string, unknown>,
+  migrations: CharacterMigration[],
+  currentVersion: number,
+): { data: Record<string, unknown>; migrated: boolean } {
+  const savedVersion = (data["schemaVersion"] as number | undefined) ?? 0;
+  if (savedVersion >= currentVersion) return { data, migrated: false };
+
+  const pending = migrations
+    .filter((m) => m.toVersion > savedVersion)
+    .sort((a, b) => a.toVersion - b.toVersion);
+
+  let result = data;
+  for (const migration of pending) {
+    result = migration.up(result);
+    console.error(
+      `[scribe] character migration v${migration.toVersion}: ${migration.description}`,
+    );
+  }
+  result["schemaVersion"] = currentVersion;
+  return { data: result, migrated: true };
+}

--- a/plugins/ironsworn/scribe/src/migrations/lore.ts
+++ b/plugins/ironsworn/scribe/src/migrations/lore.ts
@@ -1,0 +1,15 @@
+import type { DbMigration } from "./index.js";
+
+// Lore DB migrations. The baseline schema (tables created by initDb in
+// rag/lore-db.ts) is version 0. Append new entries here when the schema
+// changes; never edit or reorder existing entries.
+//
+// Example:
+//   {
+//     version: 1,
+//     description: "add source_url column to lore_entities",
+//     async up(conn) {
+//       await conn.run("ALTER TABLE lore_entities ADD COLUMN IF NOT EXISTS source_url TEXT");
+//     },
+//   },
+export const LORE_MIGRATIONS: DbMigration[] = [];

--- a/plugins/ironsworn/scribe/src/migrations/scenes.ts
+++ b/plugins/ironsworn/scribe/src/migrations/scenes.ts
@@ -1,0 +1,15 @@
+import type { DbMigration } from "./index.js";
+
+// Scenes DB migrations. The baseline schema (tables created by initDb in
+// rag/scenes.ts) is version 0. Append new entries here when the schema
+// changes; never edit or reorder existing entries.
+//
+// Example:
+//   {
+//     version: 1,
+//     description: "add arc column to scenes",
+//     async up(conn) {
+//       await conn.run("ALTER TABLE scenes ADD COLUMN IF NOT EXISTS arc TEXT");
+//     },
+//   },
+export const SCENES_MIGRATIONS: DbMigration[] = [];

--- a/plugins/ironsworn/scribe/src/rag/lore-db.ts
+++ b/plugins/ironsworn/scribe/src/rag/lore-db.ts
@@ -4,6 +4,8 @@
 
 import { DuckDBInstance } from "@duckdb/node-api";
 import { mkdir } from "node:fs/promises";
+import { runDbMigrations } from "../migrations/index.js";
+import { LORE_MIGRATIONS } from "../migrations/lore.js";
 
 const OLLAMA_BASE_URL =
   process.env["OLLAMA_BASE_URL"] ?? "http://localhost:11434";
@@ -137,6 +139,8 @@ async function initDb(campaignPath: string): Promise<DuckDBInstance> {
         skipped           INTEGER NOT NULL DEFAULT 0
       )
     `);
+
+    await runDbMigrations(conn, LORE_MIGRATIONS);
   } finally {
     conn.closeSync();
   }

--- a/plugins/ironsworn/scribe/src/rag/scenes.ts
+++ b/plugins/ironsworn/scribe/src/rag/scenes.ts
@@ -1,5 +1,7 @@
 import { DuckDBInstance, type DuckDBValue } from "@duckdb/node-api";
 import { mkdir } from "node:fs/promises";
+import { runDbMigrations } from "../migrations/index.js";
+import { SCENES_MIGRATIONS } from "../migrations/scenes.js";
 
 // ---------------------------------------------------------------------------
 // Config
@@ -144,6 +146,8 @@ async function initDb(campaignPath: string): Promise<DuckDBInstance> {
         WITH (metric = 'cosine')
       `);
     }
+
+    await runDbMigrations(conn, SCENES_MIGRATIONS);
   } finally {
     conn.closeSync();
   }

--- a/plugins/ironsworn/scribe/src/state/character.ts
+++ b/plugins/ironsworn/scribe/src/state/character.ts
@@ -1,5 +1,6 @@
 import { readFile, writeFile, appendFile } from "node:fs/promises";
 import { join } from "node:path";
+import { runCharacterMigrations, type CharacterMigration } from "../migrations/index.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -24,7 +25,23 @@ export interface ProgressTrack {
   status: "active" | "fulfilled" | "forsaken";
 }
 
+// Current character JSON schema version. Increment when a migration is added.
+export const CURRENT_CHARACTER_VERSION = 0;
+
+// Character JSON migrations. The baseline schema is version 0. Append new
+// entries here when fields are added, removed, or restructured; never edit or
+// reorder existing entries.
+//
+// Example:
+//   {
+//     toVersion: 1,
+//     description: "rename 'bonds' to 'bondCount'",
+//     up(data) { data["bondCount"] = data["bonds"]; delete data["bonds"]; return data; },
+//   },
+const CHARACTER_MIGRATIONS: CharacterMigration[] = [];
+
 export interface Character {
+  schemaVersion?: number;
   name: string;
   stats: {
     edge: number;
@@ -107,7 +124,19 @@ function journalPath(campaignPath: string): string {
 
 export async function loadCharacter(campaignPath: string): Promise<Character> {
   const raw = await readFile(characterPath(campaignPath), "utf-8");
-  const char = JSON.parse(raw) as Character;
+  let data = JSON.parse(raw) as Record<string, unknown>;
+
+  const { data: migrated, migrated: didMigrate } = runCharacterMigrations(
+    data,
+    CHARACTER_MIGRATIONS,
+    CURRENT_CHARACTER_VERSION,
+  );
+  if (didMigrate) {
+    await writeFile(characterPath(campaignPath), JSON.stringify(migrated, null, 2), "utf-8");
+  }
+  data = migrated;
+
+  const char = data as unknown as Character;
   char.companions ??= [];
   char.experience ??= 0;
   for (const track of char.progressTracks) {
@@ -125,6 +154,7 @@ export async function saveCharacter(
   campaignPath: string,
   char: Character,
 ): Promise<void> {
+  char.schemaVersion = CURRENT_CHARACTER_VERSION;
   await writeFile(characterPath(campaignPath), JSON.stringify(char, null, 2), "utf-8");
 }
 


### PR DESCRIPTION
Introduces a lightweight migration system so schema changes are applied
automatically when the plugin starts, without manual intervention.

- src/migrations/index.ts: shared runDbMigrations (DuckDB) and
  runCharacterMigrations (JSON) runners. DuckDB runner tracks applied
  versions in a _schema_migrations table; character runner stamps
  schemaVersion on the saved JSON. Both runners are no-ops if nothing
  is pending — safe on fresh installs and existing campaigns.
- src/migrations/lore.ts / scenes.ts: empty baseline arrays for
  lore and scenes DB migrations respectively; append here for future
  schema changes.
- rag/lore-db.ts / rag/scenes.ts: call runDbMigrations at the end of
  each initDb so every campaign DB is migrated on first use.
- state/character.ts: adds schemaVersion field, calls
  runCharacterMigrations in loadCharacter (auto-saves if migrated),
  and stamps the version in saveCharacter.

Version 0 is the implicit baseline — no migrations run on existing
campaigns, just the tracking table is created.