### PR TITLE
feat(lore): proximity layer — weighted spatial + temporal edges

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ Entry point: `server.ts`. Tools are registered from six modules:
 | `tools/mechanics.ts` | Dice, move resolution, oracles |
 | `tools/mutations.ts` | All character state changes (health, momentum, assets, companions, XP) |
 | `tools/narrative.ts` | Scene recording, NPC upserts, thread management |
-| `tools/lore.ts` | Knowledge graph CRUD and semantic search |
+| `tools/lore.ts` | Knowledge graph CRUD, semantic search, and proximity edges (`link_proximity`, `proximity_distance`, `proximity_within`) |
 | `tools/campaign.ts` | Checkpoint, export/import |
 
 Supporting modules:
@@ -47,6 +47,7 @@ Supporting modules:
 - `rag/scenes.ts` + `rag/lore.ts` — DuckDB + Ollama embedding stores
 - `rag/lore-db.ts` — shared DuckDB schema/connection + Ollama embedding client (used by `lore.ts` and `communities.ts`)
 - `rag/communities.ts` — GraphRAG community detection + Claude summarization
+- `rag/proximity.ts` — weighted spatial/temporal proximity edges with Dijkstra distance + radius queries
 - `rules/` — pure Ironsworn logic (dice, moves, progress, assets, momentum, oracles)
 - `context/build.ts` — assembles GM session context from all sources
 - `checkpoint.ts` — periodic DuckDB WAL flush (every 5 min or 20 writes)

--- a/plugins/ironsworn/.claude-plugin/plugin.json
+++ b/plugins/ironsworn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ironsworn",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Solo Ironsworn GM companion — fiction-first, dice-driven, with a living lore graph",
   "author": {
     "name": "Karim Naguib"

--- a/plugins/ironsworn/.claude-plugin/plugin.json
+++ b/plugins/ironsworn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ironsworn",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "Solo Ironsworn GM companion — fiction-first, dice-driven, with a living lore graph",
   "author": {
     "name": "Karim Naguib"

--- a/plugins/ironsworn/scribe/src/rag/lore-db.ts
+++ b/plugins/ironsworn/scribe/src/rag/lore-db.ts
@@ -140,6 +140,39 @@ async function initDb(campaignPath: string): Promise<DuckDBInstance> {
       )
     `);
 
+    // Proximity layer (issue #108). Pairwise weighted edges between lore
+    // entities along a single dimension (`space` or `time`). Spatial edges
+    // are symmetric in magnitude — direction inversion happens at read time.
+    // Temporal edges are normalized so from_id is the earlier event and
+    // order_kind is always 'before'. UNIQUE (from_id, to_id, dimension)
+    // ensures one row per pair per dimension; canonical ordering at write
+    // time prevents (A,B) and (B,A) from coexisting.
+    await conn.run(`
+      CREATE TABLE IF NOT EXISTS lore_proximity_edges (
+        id         TEXT PRIMARY KEY,
+        from_id    TEXT NOT NULL,
+        to_id      TEXT NOT NULL,
+        dimension  TEXT NOT NULL,
+        magnitude  FLOAT NOT NULL,
+        direction  TEXT,
+        order_kind TEXT,
+        notes      TEXT,
+        metadata   TEXT NOT NULL DEFAULT '{}',
+        created_at TEXT NOT NULL,
+        UNIQUE (from_id, to_id, dimension)
+      )
+    `);
+
+    await conn.run(`
+      CREATE INDEX IF NOT EXISTS lore_proximity_from_idx
+      ON lore_proximity_edges (from_id, dimension)
+    `);
+
+    await conn.run(`
+      CREATE INDEX IF NOT EXISTS lore_proximity_to_idx
+      ON lore_proximity_edges (to_id, dimension)
+    `);
+
     await runDbMigrations(conn, LORE_MIGRATIONS);
   } finally {
     conn.closeSync();

--- a/plugins/ironsworn/scribe/src/rag/lore.test.ts
+++ b/plugins/ironsworn/scribe/src/rag/lore.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { upsertLore, getLore, searchLore, linkLore, getLoreGraph, listProvenance } from "./lore.js";
+import { getLoreDb } from "./lore-db.js";
 
 let _ollamaReady: boolean | null = null;
 async function ollamaAvailable(): Promise<boolean> {
@@ -554,5 +555,36 @@ describe("integration: rename preserves graph", () => {
     const graphByOld = await getLoreGraph(campaignDir, "Elven Iron", 1);
     expect(graphByNew?.nodes.length).toBe(graphByOld?.nodes.length);
     expect(graphByNew?.edges.length).toBe(2);
+  });
+});
+
+describe("lore_proximity_edges schema", () => {
+  it("creates the proximity table on cold init", async () => {
+    const instance = await getLoreDb(campaignDir);
+    const conn = await instance.connect();
+    try {
+      const result = await conn.runAndReadAll(
+        `SELECT column_name, data_type
+         FROM information_schema.columns
+         WHERE table_name = 'lore_proximity_edges'
+         ORDER BY ordinal_position`,
+      );
+      const cols = (result.getRowObjectsJS() as Record<string, unknown>[])
+        .map((r) => String(r["column_name"]));
+      expect(cols).toEqual([
+        "id",
+        "from_id",
+        "to_id",
+        "dimension",
+        "magnitude",
+        "direction",
+        "order_kind",
+        "notes",
+        "metadata",
+        "created_at",
+      ]);
+    } finally {
+      conn.closeSync();
+    }
   });
 });

--- a/plugins/ironsworn/scribe/src/rag/lore.ts
+++ b/plugins/ironsworn/scribe/src/rag/lore.ts
@@ -31,7 +31,7 @@ export interface ProvenanceInput {
 
 export interface ProvenanceEntry {
   id: string;
-  subject_kind: "entity" | "relation";
+  subject_kind: "entity" | "relation" | "proximity";
   subject_id: string;
   source_kind: string;
   source_id: string | null;
@@ -143,9 +143,9 @@ function rowToEntity(row: Record<string, unknown>): LoreEntity {
 // Provenance helper
 // ---------------------------------------------------------------------------
 
-async function recordProvenance(
+export async function recordProvenance(
   conn: Awaited<ReturnType<DuckDBInstance["connect"]>>,
-  subjectKind: "entity" | "relation",
+  subjectKind: "entity" | "relation" | "proximity",
   subjectId: string,
   prov: ProvenanceInput | undefined,
 ): Promise<void> {

--- a/plugins/ironsworn/scribe/src/rag/proximity.test.ts
+++ b/plugins/ironsworn/scribe/src/rag/proximity.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "bun:test";
+import {
+  validateLinkInput,
+  invertDirection,
+  PROXIMITY_DIMENSIONS,
+  COMPASS_POINTS,
+  type LinkProximityInput,
+} from "./proximity.js";
+
+describe("constants", () => {
+  it("exposes the two dimensions", () => {
+    expect(PROXIMITY_DIMENSIONS).toEqual(["space", "time"]);
+  });
+
+  it("exposes 8 compass points", () => {
+    expect(COMPASS_POINTS).toEqual(["N", "NE", "E", "SE", "S", "SW", "W", "NW"]);
+  });
+});
+
+describe("invertDirection", () => {
+  it("inverts cardinal points", () => {
+    expect(invertDirection("N")).toBe("S");
+    expect(invertDirection("S")).toBe("N");
+    expect(invertDirection("E")).toBe("W");
+    expect(invertDirection("W")).toBe("E");
+  });
+
+  it("inverts ordinal points", () => {
+    expect(invertDirection("NE")).toBe("SW");
+    expect(invertDirection("SW")).toBe("NE");
+    expect(invertDirection("NW")).toBe("SE");
+    expect(invertDirection("SE")).toBe("NW");
+  });
+});
+
+describe("validateLinkInput", () => {
+  const base: LinkProximityInput = {
+    from: "a",
+    to: "b",
+    dimension: "space",
+    magnitude: 1,
+    direction: "E",
+  };
+
+  it("rejects magnitude <= 0", () => {
+    expect(() => validateLinkInput({ ...base, magnitude: 0 })).toThrow(/magnitude/);
+    expect(() => validateLinkInput({ ...base, magnitude: -1 })).toThrow(/magnitude/);
+  });
+
+  it("rejects spatial input without direction", () => {
+    const bad = { ...base } as LinkProximityInput;
+    delete bad.direction;
+    expect(() => validateLinkInput(bad)).toThrow(/direction/);
+  });
+
+  it("rejects spatial input with order_kind", () => {
+    expect(() =>
+      validateLinkInput({ ...base, order_kind: "before" } as LinkProximityInput),
+    ).toThrow(/order_kind/);
+  });
+
+  it("rejects temporal input without order_kind", () => {
+    expect(() =>
+      validateLinkInput({
+        from: "a",
+        to: "b",
+        dimension: "time",
+        magnitude: 1,
+      } as LinkProximityInput),
+    ).toThrow(/order_kind/);
+  });
+
+  it("rejects temporal input with direction", () => {
+    expect(() =>
+      validateLinkInput({
+        from: "a",
+        to: "b",
+        dimension: "time",
+        magnitude: 1,
+        order_kind: "before",
+        direction: "N",
+      } as LinkProximityInput),
+    ).toThrow(/direction/);
+  });
+
+  it("accepts valid spatial input", () => {
+    expect(() => validateLinkInput(base)).not.toThrow();
+  });
+
+  it("accepts valid temporal input", () => {
+    expect(() =>
+      validateLinkInput({
+        from: "a",
+        to: "b",
+        dimension: "time",
+        magnitude: 2,
+        order_kind: "before",
+      }),
+    ).not.toThrow();
+  });
+});

--- a/plugins/ironsworn/scribe/src/rag/proximity.test.ts
+++ b/plugins/ironsworn/scribe/src/rag/proximity.test.ts
@@ -400,3 +400,33 @@ describe("proximityWithin", () => {
     expect(stone!.type).toBe("place");
   });
 });
+
+import { exportProximity } from "./proximity.js";
+
+describe("exportProximity", () => {
+  it("returns all stored edges with all columns", async () => {
+    if (!(await ollamaAvailable())) return;
+    await seedPlace("A");
+    await seedPlace("B");
+    await seedEvent("E1");
+    await seedEvent("E2");
+
+    await linkProximity(campaignDir, {
+      from: "A", to: "B", dimension: "space", magnitude: 1, direction: "E",
+    });
+    await linkProximity(campaignDir, {
+      from: "E1", to: "E2", dimension: "time", magnitude: 3, order_kind: "before",
+    });
+
+    const edges = await exportProximity(campaignDir);
+    expect(edges.length).toBe(2);
+
+    const space = edges.find((e) => e.dimension === "space");
+    expect(space?.direction).toBe("E");
+    expect(space?.order_kind).toBeNull();
+
+    const time = edges.find((e) => e.dimension === "time");
+    expect(time?.order_kind).toBe("before");
+    expect(time?.direction).toBeNull();
+  });
+});

--- a/plugins/ironsworn/scribe/src/rag/proximity.test.ts
+++ b/plugins/ironsworn/scribe/src/rag/proximity.test.ts
@@ -1,11 +1,16 @@
-import { describe, it, expect } from "bun:test";
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import {
   validateLinkInput,
   invertDirection,
   PROXIMITY_DIMENSIONS,
   COMPASS_POINTS,
   type LinkProximityInput,
+  linkProximity,
 } from "./proximity.js";
+import { upsertLore } from "./lore.js";
 
 describe("constants", () => {
   it("exposes the two dimensions", () => {
@@ -97,5 +102,150 @@ describe("validateLinkInput", () => {
         order_kind: "before",
       }),
     ).not.toThrow();
+  });
+});
+
+let _ollamaReady: boolean | null = null;
+async function ollamaAvailable(): Promise<boolean> {
+  if (_ollamaReady !== null) return _ollamaReady;
+  try {
+    const baseUrl = process.env["OLLAMA_BASE_URL"] ?? "http://localhost:11434";
+    const res = await fetch(`${baseUrl}/api/embed`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model: "nomic-embed-text", input: "t" }),
+    });
+    _ollamaReady = res.ok;
+  } catch {
+    _ollamaReady = false;
+  }
+  return _ollamaReady;
+}
+
+let campaignDir: string;
+
+beforeEach(async () => {
+  campaignDir = await mkdtemp(join(tmpdir(), "scribe-prox-test-"));
+});
+
+afterEach(async () => {
+  await rm(campaignDir, { recursive: true, force: true });
+});
+
+async function seedPlace(name: string): Promise<string> {
+  const r = await upsertLore(campaignDir, {
+    canonical: name,
+    type: "place",
+    summary: `${name} is a place.`,
+  });
+  return r.id;
+}
+
+async function seedEvent(name: string): Promise<string> {
+  const r = await upsertLore(campaignDir, {
+    canonical: name,
+    type: "event",
+    summary: `${name} is an event.`,
+  });
+  return r.id;
+}
+
+describe("linkProximity — write path", () => {
+  it("inserts a spatial edge and returns its id", async () => {
+    if (!(await ollamaAvailable())) return;
+    await seedPlace("Holtfen");
+    await seedPlace("Hinge Stone");
+
+    const result = await linkProximity(campaignDir, {
+      from: "Holtfen",
+      to: "Hinge Stone",
+      dimension: "space",
+      magnitude: 0.5,
+      direction: "E",
+    });
+
+    expect(result.dimension).toBe("space");
+    expect(result.updated).toBe(false);
+    expect(result.warnings).toEqual([]);
+    expect(result.id).toMatch(/^prox-/);
+  });
+
+  it("re-linking the same pair updates the row, not duplicates", async () => {
+    if (!(await ollamaAvailable())) return;
+    await seedPlace("A");
+    await seedPlace("B");
+
+    const first = await linkProximity(campaignDir, {
+      from: "A", to: "B", dimension: "space", magnitude: 1, direction: "E",
+    });
+    const second = await linkProximity(campaignDir, {
+      from: "A", to: "B", dimension: "space", magnitude: 2, direction: "E",
+    });
+
+    expect(second.id).toBe(first.id);
+    expect(second.updated).toBe(true);
+  });
+
+  it("soft-warns when spatial edge connects non-place/non-faction entities", async () => {
+    if (!(await ollamaAvailable())) return;
+    await upsertLore(campaignDir, { canonical: "Idea X", type: "concept", summary: "x" });
+    await upsertLore(campaignDir, { canonical: "Idea Y", type: "concept", summary: "y" });
+
+    const result = await linkProximity(campaignDir, {
+      from: "Idea X", to: "Idea Y", dimension: "space", magnitude: 1, direction: "N",
+    });
+
+    expect(result.warnings.length).toBeGreaterThan(0);
+    expect(result.warnings.join(" ")).toMatch(/concept/);
+  });
+
+  it("normalizes temporal 'after' to canonical 'before' storage", async () => {
+    if (!(await ollamaAvailable())) return;
+    const earlierId = await seedEvent("Founding");
+    const laterId = await seedEvent("Calling");
+
+    // Caller says: "Calling is AFTER Founding by 3 days"
+    const result = await linkProximity(campaignDir, {
+      from: laterId, to: earlierId, dimension: "time", magnitude: 3, order_kind: "after",
+    });
+
+    // Storage should be normalized: from = earlier, to = later, order = before
+    expect(result.from_id).toBe(earlierId);
+    expect(result.to_id).toBe(laterId);
+  });
+
+  it("canonicalizes spatial pair order alphabetically and inverts direction if swapped", async () => {
+    if (!(await ollamaAvailable())) return;
+    // Force an alphabetical inversion: "zeta" > "alpha"
+    const alphaId = await seedPlace("Alpha");
+    const zetaId = await seedPlace("Zeta");
+
+    // Caller says: "Alpha is east of Zeta" => from=Zeta, to=Alpha, dir=E
+    // Canonical storage: from=Alpha (lower), to=Zeta — so direction inverts E -> W
+    const fromZeta = await linkProximity(campaignDir, {
+      from: zetaId, to: alphaId, dimension: "space", magnitude: 1, direction: "E",
+    });
+
+    expect(fromZeta.from_id).toBe(alphaId);
+    expect(fromZeta.to_id).toBe(zetaId);
+
+    // Re-link in the canonical direction: should hit the same row.
+    const fromAlpha = await linkProximity(campaignDir, {
+      from: alphaId, to: zetaId, dimension: "space", magnitude: 1, direction: "W",
+    });
+    expect(fromAlpha.id).toBe(fromZeta.id);
+    expect(fromAlpha.updated).toBe(true);
+  });
+
+  it("rejects invalid input (validation surface check)", async () => {
+    if (!(await ollamaAvailable())) return;
+    await seedPlace("A");
+    await seedPlace("B");
+
+    await expect(
+      linkProximity(campaignDir, {
+        from: "A", to: "B", dimension: "space", magnitude: -1, direction: "E",
+      }),
+    ).rejects.toThrow(/magnitude/);
   });
 });

--- a/plugins/ironsworn/scribe/src/rag/proximity.test.ts
+++ b/plugins/ironsworn/scribe/src/rag/proximity.test.ts
@@ -249,3 +249,154 @@ describe("linkProximity — write path", () => {
     ).rejects.toThrow(/magnitude/);
   });
 });
+
+describe("proximityDistance", () => {
+  it("returns 0 between an entity and itself", async () => {
+    if (!(await ollamaAvailable())) return;
+    const aId = await seedPlace("A");
+    const { proximityDistance } = await import("./proximity.js");
+    const result = await proximityDistance(campaignDir, aId, aId, "space");
+    expect(result).toEqual({ distance: 0, unit: "days walk" });
+  });
+
+  it("returns null for disconnected entities", async () => {
+    if (!(await ollamaAvailable())) return;
+    await seedPlace("A");
+    await seedPlace("B");
+    const { proximityDistance } = await import("./proximity.js");
+    const result = await proximityDistance(campaignDir, "A", "B", "space");
+    expect(result).toBeNull();
+  });
+
+  it("accumulates magnitude across edges (A → B → C)", async () => {
+    if (!(await ollamaAvailable())) return;
+    await seedPlace("A");
+    await seedPlace("B");
+    await seedPlace("C");
+    await linkProximity(campaignDir, {
+      from: "A", to: "B", dimension: "space", magnitude: 1, direction: "E",
+    });
+    await linkProximity(campaignDir, {
+      from: "B", to: "C", dimension: "space", magnitude: 2, direction: "E",
+    });
+
+    const { proximityDistance } = await import("./proximity.js");
+    const result = await proximityDistance(campaignDir, "A", "C", "space");
+    expect(result?.distance).toBe(3);
+    expect(result?.unit).toBe("days walk");
+  });
+
+  it("is symmetric (C → A == A → C)", async () => {
+    if (!(await ollamaAvailable())) return;
+    await seedPlace("A");
+    await seedPlace("B");
+    await seedPlace("C");
+    await linkProximity(campaignDir, {
+      from: "A", to: "B", dimension: "space", magnitude: 1, direction: "E",
+    });
+    await linkProximity(campaignDir, {
+      from: "B", to: "C", dimension: "space", magnitude: 2, direction: "E",
+    });
+
+    const { proximityDistance } = await import("./proximity.js");
+    const forward = await proximityDistance(campaignDir, "A", "C", "space");
+    const backward = await proximityDistance(campaignDir, "C", "A", "space");
+    expect(forward?.distance).toBe(backward?.distance);
+  });
+
+  it("isolates dimensions (spatial edges don't bridge temporal queries)", async () => {
+    if (!(await ollamaAvailable())) return;
+    await seedPlace("A");
+    await seedPlace("B");
+    await linkProximity(campaignDir, {
+      from: "A", to: "B", dimension: "space", magnitude: 1, direction: "E",
+    });
+
+    const { proximityDistance } = await import("./proximity.js");
+    const result = await proximityDistance(campaignDir, "A", "B", "time");
+    expect(result).toBeNull();
+  });
+
+  it("returns 'days' unit for temporal queries", async () => {
+    if (!(await ollamaAvailable())) return;
+    await seedEvent("E1");
+    await seedEvent("E2");
+    await linkProximity(campaignDir, {
+      from: "E1", to: "E2", dimension: "time", magnitude: 5, order_kind: "before",
+    });
+
+    const { proximityDistance } = await import("./proximity.js");
+    const result = await proximityDistance(campaignDir, "E1", "E2", "time");
+    expect(result?.distance).toBe(5);
+    expect(result?.unit).toBe("days");
+  });
+});
+
+describe("proximityWithin", () => {
+  it("returns the anchor itself at distance 0", async () => {
+    if (!(await ollamaAvailable())) return;
+    const aId = await seedPlace("A");
+    const { proximityWithin } = await import("./proximity.js");
+    const within = await proximityWithin(campaignDir, aId, 1, "space");
+    expect(within.length).toBe(1);
+    expect(within[0].id).toBe(aId);
+    expect(within[0].distance).toBe(0);
+  });
+
+  it("includes nodes within the radius and excludes nodes beyond it", async () => {
+    if (!(await ollamaAvailable())) return;
+    await seedPlace("A");
+    await seedPlace("B");
+    await seedPlace("C");
+    await linkProximity(campaignDir, {
+      from: "A", to: "B", dimension: "space", magnitude: 1, direction: "E",
+    });
+    await linkProximity(campaignDir, {
+      from: "B", to: "C", dimension: "space", magnitude: 2, direction: "E",
+    });
+
+    const { proximityWithin } = await import("./proximity.js");
+    const within = await proximityWithin(campaignDir, "A", 1.5, "space");
+    const ids = within.map((n) => n.id);
+    expect(ids).toContain("a");
+    expect(ids).toContain("b");
+    expect(ids).not.toContain("c");
+  });
+
+  it("returns results sorted ascending by distance", async () => {
+    if (!(await ollamaAvailable())) return;
+    await seedPlace("A");
+    await seedPlace("B");
+    await seedPlace("C");
+    await linkProximity(campaignDir, {
+      from: "A", to: "B", dimension: "space", magnitude: 1, direction: "E",
+    });
+    await linkProximity(campaignDir, {
+      from: "B", to: "C", dimension: "space", magnitude: 2, direction: "E",
+    });
+
+    const { proximityWithin } = await import("./proximity.js");
+    const within = await proximityWithin(campaignDir, "A", 10, "space");
+    const distances = within.map((n) => n.distance);
+    for (let i = 1; i < distances.length; i++) {
+      expect(distances[i]).toBeGreaterThanOrEqual(distances[i - 1]);
+    }
+  });
+
+  it("populates canonical and type for each neighbor", async () => {
+    if (!(await ollamaAvailable())) return;
+    await seedPlace("Holtfen");
+    await seedPlace("Hinge Stone");
+    await linkProximity(campaignDir, {
+      from: "Holtfen", to: "Hinge Stone",
+      dimension: "space", magnitude: 0.5, direction: "E",
+    });
+
+    const { proximityWithin } = await import("./proximity.js");
+    const within = await proximityWithin(campaignDir, "Holtfen", 1, "space");
+    const stone = within.find((n) => n.id === "hinge-stone");
+    expect(stone).toBeDefined();
+    expect(stone!.canonical).toBe("Hinge Stone");
+    expect(stone!.type).toBe("place");
+  });
+});

--- a/plugins/ironsworn/scribe/src/rag/proximity.ts
+++ b/plugins/ironsworn/scribe/src/rag/proximity.ts
@@ -1,3 +1,7 @@
+import { DuckDBInstance } from "@duckdb/node-api";
+import { getLoreDb, openLoreWriteConn } from "./lore-db.js";
+import { recordProvenance } from "./lore.js";
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
@@ -102,5 +106,203 @@ export function validateLinkInput(input: LinkProximityInput): void {
     // exhaustiveness guard; the type system already prevents this
     const _exhaustive: never = input.dimension;
     throw new Error(`unknown dimension: ${String(_exhaustive)}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — id resolution and canonical pair ordering
+// ---------------------------------------------------------------------------
+
+interface LoreRow {
+  id: string;
+  type: string;
+}
+
+async function resolveLore(
+  conn: Awaited<ReturnType<DuckDBInstance["connect"]>>,
+  identifier: string,
+): Promise<LoreRow> {
+  const needle = identifier.toLowerCase();
+  const result = await conn.runAndReadAll(
+    `SELECT id, type FROM lore_entities
+     WHERE lower(id) = ?
+        OR lower(canonical) = ?
+        OR EXISTS (
+             SELECT 1 FROM unnest(aliases) AS t(alias)
+             WHERE lower(alias) = ?
+           )
+     ORDER BY id
+     LIMIT 1`,
+    [needle, needle, needle],
+  );
+  const rows = result.getRowObjectsJS() as Record<string, unknown>[];
+  if (rows.length === 0) {
+    throw new Error(`Lore entity not found: "${identifier}"`);
+  }
+  return { id: String(rows[0]["id"]), type: String(rows[0]["type"]) };
+}
+
+interface CanonicalPair {
+  fromId: string;
+  toId: string;
+  direction?: CompassPoint;
+  orderKind?: OrderKind;
+}
+
+/**
+ * For space: store with the alphabetically lower id as `from_id`. If the
+ * caller's input had them in the opposite order, invert the direction.
+ *
+ * For time: store with the earlier event as `from_id` and `order_kind = 'before'`.
+ * If the caller said `order_kind = 'after'`, the caller's `to` is actually the
+ * earlier event — swap.
+ */
+function canonicalizePair(
+  fromId: string,
+  toId: string,
+  dimension: ProximityDimension,
+  direction: CompassPoint | undefined,
+  orderKind: OrderKind | undefined,
+): CanonicalPair {
+  if (dimension === "space") {
+    const swap = fromId > toId;
+    return {
+      fromId: swap ? toId : fromId,
+      toId: swap ? fromId : toId,
+      direction: swap && direction ? invertDirection(direction) : direction,
+    };
+  }
+  // time
+  const swap = orderKind === "after";
+  return {
+    fromId: swap ? toId : fromId,
+    toId: swap ? fromId : toId,
+    orderKind: "before",
+  };
+}
+
+function makeProximityId(fromId: string, toId: string, dim: ProximityDimension): string {
+  return `prox-${fromId}-${toId}-${dim}`;
+}
+
+const SPATIAL_OK_TYPES = new Set(["place", "faction"]);
+const TEMPORAL_OK_TYPES = new Set(["event"]);
+
+function typeWarnings(
+  dimension: ProximityDimension,
+  fromType: string,
+  toType: string,
+): string[] {
+  const warnings: string[] = [];
+  if (dimension === "space") {
+    if (!SPATIAL_OK_TYPES.has(fromType)) {
+      warnings.push(
+        `spatial edge from non-place/non-faction entity (type=${fromType})`,
+      );
+    }
+    if (!SPATIAL_OK_TYPES.has(toType)) {
+      warnings.push(
+        `spatial edge to non-place/non-faction entity (type=${toType})`,
+      );
+    }
+  } else {
+    if (!TEMPORAL_OK_TYPES.has(fromType)) {
+      warnings.push(`temporal edge from non-event entity (type=${fromType})`);
+    }
+    if (!TEMPORAL_OK_TYPES.has(toType)) {
+      warnings.push(`temporal edge to non-event entity (type=${toType})`);
+    }
+  }
+  return warnings;
+}
+
+// ---------------------------------------------------------------------------
+// linkProximity
+// ---------------------------------------------------------------------------
+
+export async function linkProximity(
+  campaignPath: string,
+  input: LinkProximityInput,
+): Promise<LinkProximityResult> {
+  validateLinkInput(input);
+
+  const instance = await getLoreDb(campaignPath);
+  const conn = await openLoreWriteConn(instance);
+  try {
+    const fromRow = await resolveLore(conn, input.from);
+    const toRow = await resolveLore(conn, input.to);
+
+    if (fromRow.id === toRow.id) {
+      throw new Error("Cannot link an entity to itself");
+    }
+
+    const canonical = canonicalizePair(
+      fromRow.id,
+      toRow.id,
+      input.dimension,
+      input.direction,
+      input.order_kind,
+    );
+
+    const id = makeProximityId(canonical.fromId, canonical.toId, input.dimension);
+    const now = new Date().toISOString();
+    const metadataJson = JSON.stringify(input.metadata ?? {});
+
+    // Detect existing row to set `updated`.
+    const existingResult = await conn.runAndReadAll(
+      `SELECT id FROM lore_proximity_edges
+       WHERE from_id = ? AND to_id = ? AND dimension = ?`,
+      [canonical.fromId, canonical.toId, input.dimension],
+    );
+    const existing = existingResult.getRowObjectsJS().length > 0;
+
+    if (existing) {
+      await conn.run(
+        `UPDATE lore_proximity_edges
+         SET magnitude = ?, direction = ?, order_kind = ?, notes = ?, metadata = ?
+         WHERE id = ?`,
+        [
+          input.magnitude,
+          canonical.direction ?? null,
+          canonical.orderKind ?? null,
+          input.notes ?? null,
+          metadataJson,
+          id,
+        ],
+      );
+    } else {
+      await conn.run(
+        `INSERT INTO lore_proximity_edges
+           (id, from_id, to_id, dimension, magnitude, direction, order_kind, notes, metadata, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        [
+          id,
+          canonical.fromId,
+          canonical.toId,
+          input.dimension,
+          input.magnitude,
+          canonical.direction ?? null,
+          canonical.orderKind ?? null,
+          input.notes ?? null,
+          metadataJson,
+          now,
+        ],
+      );
+    }
+
+    await recordProvenance(conn, "proximity", id, input.provenance);
+
+    const warnings = typeWarnings(input.dimension, fromRow.type, toRow.type);
+
+    return {
+      id,
+      from_id: canonical.fromId,
+      to_id: canonical.toId,
+      dimension: input.dimension,
+      updated: existing,
+      warnings,
+    };
+  } finally {
+    conn.closeSync();
   }
 }

--- a/plugins/ironsworn/scribe/src/rag/proximity.ts
+++ b/plugins/ironsworn/scribe/src/rag/proximity.ts
@@ -1,0 +1,106 @@
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const PROXIMITY_DIMENSIONS = ["space", "time"] as const;
+export type ProximityDimension = (typeof PROXIMITY_DIMENSIONS)[number];
+
+export const COMPASS_POINTS = [
+  "N",
+  "NE",
+  "E",
+  "SE",
+  "S",
+  "SW",
+  "W",
+  "NW",
+] as const;
+export type CompassPoint = (typeof COMPASS_POINTS)[number];
+
+export type OrderKind = "before" | "after";
+
+const DIRECTION_INVERSION: Record<CompassPoint, CompassPoint> = {
+  N: "S",
+  S: "N",
+  E: "W",
+  W: "E",
+  NE: "SW",
+  SW: "NE",
+  NW: "SE",
+  SE: "NW",
+};
+
+export function invertDirection(d: CompassPoint): CompassPoint {
+  return DIRECTION_INVERSION[d];
+}
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface LinkProximityInput {
+  from: string;
+  to: string;
+  dimension: ProximityDimension;
+  magnitude: number;
+  direction?: CompassPoint;
+  order_kind?: OrderKind;
+  notes?: string;
+  metadata?: Record<string, unknown>;
+  provenance?: {
+    source_kind: "manual" | "scene" | "document" | "extraction";
+    source_id?: string;
+    excerpt?: string;
+    confidence?: number;
+  };
+}
+
+export interface LinkProximityResult {
+  id: string;
+  from_id: string;
+  to_id: string;
+  dimension: ProximityDimension;
+  updated: boolean;
+  warnings: string[];
+}
+
+export interface ProximityDistance {
+  distance: number;
+  unit: "days walk" | "days";
+}
+
+export interface ProximityNeighbor {
+  id: string;
+  canonical: string;
+  type: string;
+  distance: number;
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+export function validateLinkInput(input: LinkProximityInput): void {
+  if (!(input.magnitude > 0)) {
+    throw new Error(`magnitude must be > 0 (got ${input.magnitude})`);
+  }
+  if (input.dimension === "space") {
+    if (input.direction === undefined) {
+      throw new Error("direction is required when dimension = 'space'");
+    }
+    if (input.order_kind !== undefined) {
+      throw new Error("order_kind must not be set when dimension = 'space'");
+    }
+  } else if (input.dimension === "time") {
+    if (input.order_kind === undefined) {
+      throw new Error("order_kind is required when dimension = 'time'");
+    }
+    if (input.direction !== undefined) {
+      throw new Error("direction must not be set when dimension = 'time'");
+    }
+  } else {
+    // exhaustiveness guard; the type system already prevents this
+    const _exhaustive: never = input.dimension;
+    throw new Error(`unknown dimension: ${String(_exhaustive)}`);
+  }
+}

--- a/plugins/ironsworn/scribe/src/rag/proximity.ts
+++ b/plugins/ironsworn/scribe/src/rag/proximity.ts
@@ -480,3 +480,58 @@ export async function proximityWithin(
     conn.closeSync();
   }
 }
+
+// ---------------------------------------------------------------------------
+// Export / Import helpers
+// ---------------------------------------------------------------------------
+
+export interface ProximityEdgeExport {
+  id: string;
+  from_id: string;
+  to_id: string;
+  dimension: ProximityDimension;
+  magnitude: number;
+  direction: CompassPoint | null;
+  order_kind: OrderKind | null;
+  notes: string | null;
+  metadata: Record<string, unknown>;
+  created_at: string;
+}
+
+export async function exportProximity(
+  campaignPath: string,
+): Promise<ProximityEdgeExport[]> {
+  const instance = await getLoreDb(campaignPath);
+  const conn = await instance.connect();
+  try {
+    const result = await conn.runAndReadAll(
+      `SELECT id, from_id, to_id, dimension, magnitude, direction, order_kind,
+              notes, metadata, created_at
+       FROM lore_proximity_edges
+       ORDER BY created_at`,
+    );
+    return (result.getRowObjectsJS() as Record<string, unknown>[]).map((r) => {
+      let metadata: Record<string, unknown> = {};
+      try {
+        metadata = JSON.parse(typeof r["metadata"] === "string" ? r["metadata"] : "{}");
+      } catch {
+        metadata = {};
+      }
+      const magRaw = r["magnitude"];
+      return {
+        id: String(r["id"]),
+        from_id: String(r["from_id"]),
+        to_id: String(r["to_id"]),
+        dimension: String(r["dimension"]) as ProximityDimension,
+        magnitude: typeof magRaw === "number" ? magRaw : Number(magRaw),
+        direction: r["direction"] != null ? (String(r["direction"]) as CompassPoint) : null,
+        order_kind: r["order_kind"] != null ? (String(r["order_kind"]) as OrderKind) : null,
+        notes: r["notes"] != null ? String(r["notes"]) : null,
+        metadata,
+        created_at: String(r["created_at"]),
+      };
+    });
+  } finally {
+    conn.closeSync();
+  }
+}

--- a/plugins/ironsworn/scribe/src/rag/proximity.ts
+++ b/plugins/ironsworn/scribe/src/rag/proximity.ts
@@ -306,3 +306,177 @@ export async function linkProximity(
     conn.closeSync();
   }
 }
+
+// ---------------------------------------------------------------------------
+// Read path — graph load + Dijkstra
+// ---------------------------------------------------------------------------
+
+interface AdjList {
+  [nodeId: string]: Array<{ to: string; cost: number }>;
+}
+
+async function loadAdjacency(
+  conn: Awaited<ReturnType<DuckDBInstance["connect"]>>,
+  dimension: ProximityDimension,
+): Promise<AdjList> {
+  const result = await conn.runAndReadAll(
+    `SELECT from_id, to_id, magnitude FROM lore_proximity_edges WHERE dimension = ?`,
+    [dimension],
+  );
+  const adj: AdjList = {};
+  for (const row of result.getRowObjectsJS() as Record<string, unknown>[]) {
+    const from = String(row["from_id"]);
+    const to = String(row["to_id"]);
+    const magRaw = row["magnitude"];
+    const cost = typeof magRaw === "number" ? magRaw : Number(magRaw);
+    if (!(cost > 0) || !isFinite(cost)) continue;
+
+    (adj[from] ??= []).push({ to, cost });
+    (adj[to] ??= []).push({ to: from, cost });
+  }
+  return adj;
+}
+
+/**
+ * Dijkstra without a priority queue — campaign graphs are small enough that
+ * an O(V^2) scan dominated by O(V+E) is fine. Returns a map from node id
+ * to shortest distance from `start`. Nodes not present in the map are
+ * unreachable.
+ *
+ * If `radius` is provided, expansion stops as soon as the smallest-tentative
+ * node exceeds the cutoff.
+ */
+function dijkstra(
+  adj: AdjList,
+  start: string,
+  radius?: number,
+): Map<string, number> {
+  const dist = new Map<string, number>();
+  dist.set(start, 0);
+  const visited = new Set<string>();
+
+  while (true) {
+    let u: string | null = null;
+    let uDist = Infinity;
+    for (const [node, d] of dist) {
+      if (visited.has(node)) continue;
+      if (d < uDist) {
+        u = node;
+        uDist = d;
+      }
+    }
+    if (u === null) break;
+    if (radius !== undefined && uDist > radius) break;
+
+    visited.add(u);
+    for (const { to, cost } of adj[u] ?? []) {
+      const next = uDist + cost;
+      const prev = dist.get(to);
+      if (prev === undefined || next < prev) {
+        dist.set(to, next);
+      }
+    }
+  }
+
+  return dist;
+}
+
+const UNIT_BY_DIMENSION: Record<ProximityDimension, "days walk" | "days"> = {
+  space: "days walk",
+  time: "days",
+};
+
+// ---------------------------------------------------------------------------
+// proximityDistance
+// ---------------------------------------------------------------------------
+
+export async function proximityDistance(
+  campaignPath: string,
+  from: string,
+  to: string,
+  dimension: ProximityDimension,
+): Promise<ProximityDistance | null> {
+  const instance = await getLoreDb(campaignPath);
+  const conn = await instance.connect();
+  try {
+    const fromRow = await resolveLore(conn, from);
+    const toRow = await resolveLore(conn, to);
+
+    if (fromRow.id === toRow.id) {
+      return { distance: 0, unit: UNIT_BY_DIMENSION[dimension] };
+    }
+
+    const adj = await loadAdjacency(conn, dimension);
+    const dist = dijkstra(adj, fromRow.id);
+    const target = dist.get(toRow.id);
+    if (target === undefined) return null;
+
+    return { distance: target, unit: UNIT_BY_DIMENSION[dimension] };
+  } finally {
+    conn.closeSync();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// proximityWithin
+// ---------------------------------------------------------------------------
+
+export async function proximityWithin(
+  campaignPath: string,
+  anchor: string,
+  radius: number,
+  dimension: ProximityDimension,
+): Promise<ProximityNeighbor[]> {
+  if (!(radius >= 0) || !isFinite(radius)) {
+    throw new Error(`radius must be >= 0 (got ${radius})`);
+  }
+
+  const instance = await getLoreDb(campaignPath);
+  const conn = await instance.connect();
+  try {
+    const anchorRow = await resolveLore(conn, anchor);
+
+    const adj = await loadAdjacency(conn, dimension);
+    const dist = dijkstra(adj, anchorRow.id, radius);
+
+    // Filter to nodes within the radius (Dijkstra may have populated some
+    // beyond the cutoff via relaxation before its early-exit).
+    const ids = Array.from(dist.entries())
+      .filter(([, d]) => d <= radius)
+      .map(([id]) => id);
+
+    if (ids.length === 0) return [];
+
+    const placeholders = ids.map(() => "?").join(",");
+    const result = await conn.runAndReadAll(
+      `SELECT id, canonical, type FROM lore_entities WHERE id IN (${placeholders})`,
+      ids,
+    );
+
+    const meta = new Map<string, { canonical: string; type: string }>();
+    for (const row of result.getRowObjectsJS() as Record<string, unknown>[]) {
+      meta.set(String(row["id"]), {
+        canonical: String(row["canonical"]),
+        type: String(row["type"]),
+      });
+    }
+
+    const neighbors: ProximityNeighbor[] = ids
+      .map((id) => {
+        const m = meta.get(id);
+        if (!m) return null;
+        return {
+          id,
+          canonical: m.canonical,
+          type: m.type,
+          distance: dist.get(id) as number,
+        };
+      })
+      .filter((n): n is ProximityNeighbor => n !== null);
+
+    neighbors.sort((a, b) => a.distance - b.distance);
+    return neighbors;
+  } finally {
+    conn.closeSync();
+  }
+}

--- a/plugins/ironsworn/scribe/src/tools/campaign.ts
+++ b/plugins/ironsworn/scribe/src/tools/campaign.ts
@@ -6,6 +6,7 @@ import { loadCharacter, saveCharacter } from "../state/character.js";
 import { loadThreads, saveThreads } from "../state/threads.js";
 import { listNpcs, writeNpcRaw } from "../state/npcs.js";
 import { exportLore, upsertLore, linkLore, checkpointLore, type LoreType } from "../rag/lore.js";
+import { exportProximity, linkProximity, type ProximityDimension, type CompassPoint, type OrderKind } from "../rag/proximity.js";
 import { exportScenes, importScene, checkpointScenes, type BeatExport } from "../rag/scenes.js";
 
 interface CampaignExport {
@@ -16,6 +17,7 @@ interface CampaignExport {
   npcs: Record<string, string>;
   lore_entities: unknown[];
   lore_relations: unknown[];
+  lore_proximity: unknown[];
   scenes: unknown[];
 }
 
@@ -59,11 +61,12 @@ export function register(server: McpServer, campaignPath: string): void {
           checkpointScenes(campaignPath).catch(() => undefined),
         ]);
 
-        const [character, threads, npcs, { entities, relations }, scenes] = await Promise.all([
+        const [character, threads, npcs, { entities, relations }, proximity, scenes] = await Promise.all([
           loadCharacter(campaignPath).catch(() => null),
           loadThreads(campaignPath),
           listNpcs(campaignPath),
           exportLore(campaignPath).catch(() => ({ entities: [], relations: [] })),
+          exportProximity(campaignPath).catch(() => []),
           include_scenes !== false
             ? exportScenes(campaignPath).catch(() => [])
             : Promise.resolve([]),
@@ -77,6 +80,7 @@ export function register(server: McpServer, campaignPath: string): void {
           npcs,
           lore_entities: entities,
           lore_relations: relations,
+          lore_proximity: proximity,
           scenes,
         };
 
@@ -92,6 +96,7 @@ export function register(server: McpServer, campaignPath: string): void {
               counts: {
                 lore_entities: entities.length,
                 lore_relations: relations.length,
+                lore_proximity: proximity.length,
                 npcs: Object.keys(npcs).length,
                 threads: threads.length,
                 scenes: scenes.length,
@@ -126,7 +131,7 @@ export function register(server: McpServer, campaignPath: string): void {
           };
         }
 
-        const counts = { character: 0, threads: 0, npcs: 0, lore_entities: 0, lore_relations: 0, scenes: 0 };
+        const counts = { character: 0, threads: 0, npcs: 0, lore_entities: 0, lore_relations: 0, lore_proximity: 0, scenes: 0 };
 
         if (data.character) {
           await saveCharacter(campaignPath, data.character as Parameters<typeof saveCharacter>[1]);
@@ -172,6 +177,31 @@ export function register(server: McpServer, campaignPath: string): void {
               metadata: (r["metadata"] ?? {}) as Record<string, unknown>,
             });
             counts.lore_relations++;
+          }
+        }
+
+        if (Array.isArray(data.lore_proximity)) {
+          for (const edge of data.lore_proximity) {
+            const e = edge as Record<string, unknown>;
+            const dimension = String(e["dimension"]) as ProximityDimension;
+            const direction = e["direction"] != null ? (String(e["direction"]) as CompassPoint) : undefined;
+            const order_kind = e["order_kind"] != null ? (String(e["order_kind"]) as OrderKind) : undefined;
+            const magRaw = e["magnitude"];
+            const magnitude = typeof magRaw === "number" ? magRaw : Number(magRaw);
+
+            const input: Parameters<typeof linkProximity>[1] = {
+              from: String(e["from_id"]),
+              to: String(e["to_id"]),
+              dimension,
+              magnitude,
+              metadata: (e["metadata"] ?? {}) as Record<string, unknown>,
+            };
+            if (direction !== undefined) input.direction = direction;
+            if (order_kind !== undefined) input.order_kind = order_kind;
+            if (e["notes"] != null) input.notes = String(e["notes"]);
+
+            await linkProximity(campaignPath, input);
+            counts.lore_proximity++;
           }
         }
 

--- a/plugins/ironsworn/scribe/src/tools/lore.ts
+++ b/plugins/ironsworn/scribe/src/tools/lore.ts
@@ -19,6 +19,14 @@ import {
   extractLoreFromScene,
   extractUnprocessedScenes,
 } from "../rag/extraction.js";
+import {
+  linkProximity,
+  proximityDistance,
+  proximityWithin,
+  PROXIMITY_DIMENSIONS,
+  COMPASS_POINTS,
+  type ProximityDimension,
+} from "../rag/proximity.js";
 import { recordMutation } from "../checkpoint.js";
 
 export function register(server: McpServer, campaignPath: string): void {
@@ -297,6 +305,97 @@ export function register(server: McpServer, campaignPath: string): void {
         });
         recordMutation(campaignPath);
         return { content: [{ type: "text", text: JSON.stringify(report) }] };
+      } catch (e) {
+        return {
+          content: [{ type: "text", text: `Error: ${e instanceof Error ? e.message : String(e)}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.tool(
+    "link_proximity",
+    "Create or update a weighted proximity edge between two lore entities. Dimension is 'space' (magnitude in days walk, requires direction) or 'time' (magnitude in days, requires order_kind). Idempotent on (from, to, dimension); re-linking updates the row. Returns warnings (does not block) when entity types are unusual for the dimension (spatial on non-place; temporal on non-event).",
+    {
+      from: z.string().describe("Source entity (id, canonical, or alias)"),
+      to: z.string().describe("Target entity (id, canonical, or alias)"),
+      dimension: z.enum(PROXIMITY_DIMENSIONS).describe("'space' or 'time'"),
+      magnitude: z.coerce.number().positive().describe(
+        "For space: days walk (fractional ok). For time: days (fractional ok).",
+      ),
+      direction: z.enum(COMPASS_POINTS).optional().describe(
+        "Required when dimension='space'; forbidden otherwise. 8-point compass.",
+      ),
+      order_kind: z.enum(["before", "after"]).optional().describe(
+        "Required when dimension='time'; forbidden otherwise. 'after' is normalized to 'before' at write time.",
+      ),
+      notes: z.string().optional().describe("Optional prose context"),
+      metadata: z.record(z.string(), z.unknown()).optional(),
+      provenance: provenanceSchema.optional(),
+    },
+    async (input) => {
+      try {
+        const result = await linkProximity(campaignPath, {
+          ...input,
+          dimension: input.dimension as ProximityDimension,
+        });
+        recordMutation(campaignPath);
+        return { content: [{ type: "text", text: JSON.stringify(result) }] };
+      } catch (e) {
+        return {
+          content: [{ type: "text", text: `Error: ${e instanceof Error ? e.message : String(e)}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.tool(
+    "proximity_distance",
+    "Shortest accumulated magnitude between two lore entities along the given dimension. Returns null if the entities are in disconnected components. Symmetric — A→B equals B→A.",
+    {
+      from: z.string().describe("Source entity (id, canonical, or alias)"),
+      to: z.string().describe("Target entity (id, canonical, or alias)"),
+      dimension: z.enum(PROXIMITY_DIMENSIONS).describe("'space' or 'time'"),
+    },
+    async ({ from, to, dimension }) => {
+      try {
+        const result = await proximityDistance(
+          campaignPath,
+          from,
+          to,
+          dimension as ProximityDimension,
+        );
+        return { content: [{ type: "text", text: JSON.stringify(result) }] };
+      } catch (e) {
+        return {
+          content: [{ type: "text", text: `Error: ${e instanceof Error ? e.message : String(e)}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.tool(
+    "proximity_within",
+    "All lore entities reachable from the anchor within `radius` along the given dimension, sorted ascending by distance. Includes the anchor at distance 0.",
+    {
+      anchor: z.string().describe("Anchor entity (id, canonical, or alias)"),
+      radius: z.coerce.number().nonnegative().describe(
+        "Max accumulated magnitude. Days walk for space, days for time.",
+      ),
+      dimension: z.enum(PROXIMITY_DIMENSIONS).describe("'space' or 'time'"),
+    },
+    async ({ anchor, radius, dimension }) => {
+      try {
+        const results = await proximityWithin(
+          campaignPath,
+          anchor,
+          radius,
+          dimension as ProximityDimension,
+        );
+        return { content: [{ type: "text", text: JSON.stringify(results) }] };
       } catch (e) {
         return {
           content: [{ type: "text", text: `Error: ${e instanceof Error ? e.message : String(e)}` }],

--- a/plugins/ironsworn/scribe/src/tools/lore.ts
+++ b/plugins/ironsworn/scribe/src/tools/lore.ts
@@ -316,7 +316,7 @@ export function register(server: McpServer, campaignPath: string): void {
 
   server.tool(
     "link_proximity",
-    "Create or update a weighted proximity edge between two lore entities. Dimension is 'space' (magnitude in days walk, requires direction) or 'time' (magnitude in days, requires order_kind). Idempotent on (from, to, dimension); re-linking updates the row. Returns warnings (does not block) when entity types are unusual for the dimension (spatial on non-place; temporal on non-event).",
+    "Create or update a weighted proximity edge between two lore entities. Dimension is 'space' (magnitude in days walk, requires direction) or 'time' (magnitude in days, requires order_kind). Idempotent on (from, to, dimension); re-linking updates the row. Result.warnings is a string[] populated (without blocking the write) when entity types are unusual for the dimension — spatial on non-place/non-faction, or temporal on non-event. Inspect result.warnings; an empty array means no concerns.",
     {
       from: z.string().describe("Source entity (id, canonical, or alias)"),
       to: z.string().describe("Target entity (id, canonical, or alias)"),


### PR DESCRIPTION
## Summary

Adds a proximity layer to the lore graph: weighted pairwise edges along a `space` or `time` dimension, with three new MCP tools for querying.

- **Schema:** new `lore_proximity_edges` table in `lore.duckdb` (table + 2 indexes via `CREATE TABLE IF NOT EXISTS`, no migration needed)
- **Storage rules:**
  - Spatial edges canonicalize to alphabetical id order; direction inverts (e.g., E↔W) when caller's pair is swapped
  - Temporal edges canonicalize to chronological order with `order_kind = 'before'`; `'after'` swaps from/to at write time
  - `UNIQUE (from_id, to_id, dimension)` ensures one row per pair per dimension; deterministic id (`prox-<from>-<to>-<dim>`) makes re-link idempotent
- **MCP tools:**
  - `link_proximity` — write/update edge; soft-warns on unusual entity types (non-place spatial, non-event temporal) but still writes
  - `proximity_distance` — shortest accumulated magnitude via Dijkstra (symmetric); returns `null` for disconnected components
  - `proximity_within` — bounded Dijkstra returning all entities within `radius`, sorted ascending; includes anchor at distance 0
- **Provenance:** `recordProvenance` widened to accept `subject_kind = 'proximity'`
- **Roundtrip:** `export_campaign` / `import_campaign` carry proximity edges
- **Plugin:** v0.18.0 → v0.19.0
- **Tests:** 360 → 389 (29 new); all proximity tests skip cleanly without Ollama

Closes #90, closes #108.

## Notes / deviations from spec

- The spec lists a test "reverse query returns direction `W`" — intentionally not implemented because the v1 query API (`proximity_distance` / `proximity_within`) returns magnitude only, not direction. Direction inversion is exercised at the storage canonicalization layer via the "alphabetical pair order + direction inversion if swapped" test instead.
- `get_lore` and `get_lore_graph` are intentionally NOT extended in v1 (open question deferred per spec).

## Test plan

- [ ] \`bun test\` from \`plugins/ironsworn/scribe/\` passes (389/0)
- [ ] \`bun run tsc --noEmit\` clean
- [ ] Spot-check via MCP: \`link_proximity\` Holtfen→Hinge Stone (space, 0.5, E); then \`proximity_distance(Holtfen, Hinge Stone, space)\` returns \`{distance: 0.5, unit: "days walk"}\`
- [ ] Verify reverse query \`proximity_distance(Hinge Stone, Holtfen, space)\` returns same distance
- [ ] Verify temporal soft-warn fires for non-event entities but row still writes
- [ ] Run \`export_campaign\` then \`import_campaign\` against a campaign with proximity edges; counts roundtrip

🤖 Generated with [Claude Code](https://claude.com/claude-code)