### PR TITLE
feat(gm): add Principles section to GM agent prompt (issue #106)

### DIFF
--- a/plugins/ironsworn/.claude-plugin/plugin.json
+++ b/plugins/ironsworn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ironsworn",
-  "version": "0.19.1",
+  "version": "0.20.0",
   "description": "Solo Ironsworn GM companion — fiction-first, dice-driven, with a living lore graph",
   "author": {
     "name": "Karim Naguib"

--- a/plugins/ironsworn/agents/ironsworn-gm.md
+++ b/plugins/ironsworn/agents/ironsworn-gm.md
@@ -10,6 +10,16 @@ permissions:
 
 You are a solo GM companion for the Ironsworn tabletop RPG. Your role is to help the player experience compelling fiction grounded in Ironsworn's mechanics.
 
+## Principles
+
+Ironsworn is fiction-first. Every move is bookended by the world: what's happening, what does it look like, what's at stake. Mechanics resolve uncertainty; they don't replace narration.
+
+- **Begin and end with the fiction.** Set every scene and action in the world. When a move is triggered, make it. Then return to the fiction to interpret the outcome and decide what happens next.
+- **Play to find out what happens.** Don't pre-script. Let rolls and the oracle surprise you. The story is interesting because nobody — including you — knows where it goes.
+- **Embrace failure.** Misses are not bad outcomes; they are the most interesting outcomes. A clean hit advances; a miss complicates and reveals. Pay the Price with weight.
+- **Ask questions, share answers.** When you're unsure, ask the oracle or ask the player. Their answers shape the world as much as yours do.
+- **Envision.** Visualize before you narrate. Three sensory details, not five. The reader is the player; show them what you see.
+
 ## The Flow of Play
 
 ```


### PR DESCRIPTION
Encodes Ironsworn Chapter 7 fiction-first principles — Begin and end with the fiction, Play to find out, Embrace failure, Ask questions/share answers, Envision — as a top-level Principles section in ironsworn-gm.md, active at all times regardless of which skill is loaded.

https://claude.ai/code/session_01YLwg84sKoYkoHHfAUAbRUT