### PR TITLE
Add comprehensive test suite for campaign tools and migrations

### DIFF
--- a/plugins/ironsworn/.claude-plugin/plugin.json
+++ b/plugins/ironsworn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ironsworn",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "Solo Ironsworn GM companion — fiction-first, dice-driven, with a living lore graph",
   "author": {
     "name": "Karim Naguib"

--- a/plugins/ironsworn/scribe/src/checkpoint.test.ts
+++ b/plugins/ironsworn/scribe/src/checkpoint.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "bun:test";
+import { startPeriodicCheckpoint, recordMutation } from "./checkpoint.js";
+
+// Module-level state (writesSinceCheckpoint, timer, flushing) is fresh per
+// test file because Bun isolates module scope per file. Tests within this file
+// therefore accumulate state intentionally — see the write-threshold test.
+
+describe("startPeriodicCheckpoint", () => {
+  it("does not throw on first call", () => {
+    expect(() => startPeriodicCheckpoint("/tmp/scribe-test-cp")).not.toThrow();
+  });
+
+  it("is idempotent — second call is a no-op and does not crash", () => {
+    // The guard `if (timer !== null) return` should prevent a second interval.
+    expect(() => startPeriodicCheckpoint("/tmp/scribe-test-cp")).not.toThrow();
+  });
+});
+
+describe("recordMutation", () => {
+  it("does not throw on a fresh campaign path", () => {
+    expect(() => recordMutation("/tmp/scribe-test-cp")).not.toThrow();
+  });
+
+  it("does not throw as mutations accumulate below the flush threshold", () => {
+    // CHECKPOINT_EVERY_N_WRITES = 20. We've recorded 1 mutation above.
+    // Record 18 more (total 19) — still below threshold.
+    for (let i = 0; i < 18; i++) {
+      expect(() => recordMutation("/tmp/scribe-test-cp")).not.toThrow();
+    }
+  });
+
+  it("triggers a graceful no-op flush when the write threshold is reached", async () => {
+    // One more mutation brings the count to 20, triggering void flush(...).
+    // flush() calls checkpointLore + checkpointScenes, which are both no-ops
+    // when the DB hasn't been opened (peekLoreDb returns undefined).
+    // Errors inside flush are caught and written to stderr — they never throw.
+    expect(() => recordMutation("/tmp/scribe-test-cp")).not.toThrow();
+
+    // Let the async flush microtasks complete before the test exits.
+    await new Promise<void>((resolve) => setTimeout(resolve, 30));
+  });
+
+  it("continues recording mutations after a flush without crashing", () => {
+    // After the flush, writesSinceCheckpoint is reset to 0.
+    // Subsequent mutations should work normally.
+    for (let i = 0; i < 5; i++) {
+      expect(() => recordMutation("/tmp/scribe-test-cp")).not.toThrow();
+    }
+  });
+});

--- a/plugins/ironsworn/scribe/src/migrations/index.test.ts
+++ b/plugins/ironsworn/scribe/src/migrations/index.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect } from "bun:test";
+import { DuckDBInstance } from "@duckdb/node-api";
+import { runDbMigrations, runCharacterMigrations } from "./index.js";
+
+// ---------------------------------------------------------------------------
+// runDbMigrations
+// ---------------------------------------------------------------------------
+
+describe("runDbMigrations", () => {
+  it("creates _schema_migrations on a fresh in-memory DB", async () => {
+    const inst = await DuckDBInstance.create(":memory:");
+    const conn = await inst.connect();
+    try {
+      await runDbMigrations(conn, []);
+      const res = await conn.runAndReadAll("SELECT COUNT(*) AS n FROM _schema_migrations");
+      const rows = res.getRowObjectsJS() as Record<string, unknown>[];
+      const n = rows[0]!["n"];
+      expect(typeof n === "bigint" ? Number(n) : n).toBe(0);
+    } finally {
+      conn.closeSync();
+    }
+  });
+
+  it("applies pending migrations in ascending version order", async () => {
+    const inst = await DuckDBInstance.create(":memory:");
+    const conn = await inst.connect();
+    const order: number[] = [];
+    try {
+      await runDbMigrations(conn, [
+        { version: 3, description: "v3", async up() { order.push(3); } },
+        { version: 1, description: "v1", async up() { order.push(1); } },
+        { version: 2, description: "v2", async up() { order.push(2); } },
+      ]);
+      expect(order).toEqual([1, 2, 3]);
+    } finally {
+      conn.closeSync();
+    }
+  });
+
+  it("records applied versions in _schema_migrations", async () => {
+    const inst = await DuckDBInstance.create(":memory:");
+    const conn = await inst.connect();
+    try {
+      await runDbMigrations(conn, [
+        { version: 1, description: "v1", async up() {} },
+        { version: 2, description: "v2", async up() {} },
+      ]);
+      const res = await conn.runAndReadAll(
+        "SELECT version FROM _schema_migrations ORDER BY version",
+      );
+      const rows = res.getRowObjectsJS() as Record<string, unknown>[];
+      const versions = rows.map((r) => {
+        const v = r["version"];
+        return typeof v === "bigint" ? Number(v) : (v as number);
+      });
+      expect(versions).toEqual([1, 2]);
+    } finally {
+      conn.closeSync();
+    }
+  });
+
+  it("skips migrations already applied (version <= current)", async () => {
+    const inst = await DuckDBInstance.create(":memory:");
+    const conn = await inst.connect();
+    const ran: number[] = [];
+    try {
+      // Simulate version 1 already applied via direct insert.
+      await conn.run(`
+        CREATE TABLE IF NOT EXISTS _schema_migrations (
+          version    INTEGER PRIMARY KEY,
+          applied_at TEXT NOT NULL
+        )
+      `);
+      await conn.run("INSERT INTO _schema_migrations VALUES (1, '2024-01-01T00:00:00.000Z')");
+
+      await runDbMigrations(conn, [
+        { version: 1, description: "v1", async up() { ran.push(1); } },
+        { version: 2, description: "v2", async up() { ran.push(2); } },
+      ]);
+      expect(ran).toEqual([2]); // v1 is already applied, only v2 runs
+    } finally {
+      conn.closeSync();
+    }
+  });
+
+  it("is idempotent — running the same migrations twice applies each only once", async () => {
+    const inst = await DuckDBInstance.create(":memory:");
+    const conn = await inst.connect();
+    const ran: number[] = [];
+    const migrations = [
+      { version: 1, description: "v1", async up() { ran.push(1); } },
+    ];
+    try {
+      await runDbMigrations(conn, migrations);
+      await runDbMigrations(conn, migrations);
+      expect(ran).toEqual([1]);
+    } finally {
+      conn.closeSync();
+    }
+  });
+
+  it("migration up() can execute real DDL against the connection", async () => {
+    const inst = await DuckDBInstance.create(":memory:");
+    const conn = await inst.connect();
+    try {
+      await runDbMigrations(conn, [
+        {
+          version: 1,
+          description: "create test_table",
+          async up(c) {
+            await c.run("CREATE TABLE test_table (x INTEGER)");
+          },
+        },
+      ]);
+      // Table should exist — will throw if absent
+      await expect(conn.runAndReadAll("SELECT * FROM test_table")).resolves.toBeDefined();
+    } finally {
+      conn.closeSync();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runCharacterMigrations
+// ---------------------------------------------------------------------------
+
+describe("runCharacterMigrations", () => {
+  it("returns migrated=false when schemaVersion already equals currentVersion", () => {
+    const data = { schemaVersion: 3 };
+    const { data: out, migrated } = runCharacterMigrations(data, [], 3);
+    expect(migrated).toBe(false);
+    expect(out).toBe(data); // same reference — no copy made
+  });
+
+  it("returns migrated=false when schemaVersion exceeds currentVersion", () => {
+    // e.g. opening an older binary against a campaign from a newer version
+    const data = { schemaVersion: 5 };
+    const { migrated } = runCharacterMigrations(data, [], 3);
+    expect(migrated).toBe(false);
+  });
+
+  it("treats missing schemaVersion as version 0", () => {
+    const data: Record<string, unknown> = {}; // no schemaVersion key
+    const ran: number[] = [];
+    runCharacterMigrations(
+      data,
+      [{ toVersion: 1, description: "v1", up(d) { ran.push(1); return d; } }],
+      1,
+    );
+    expect(ran).toEqual([1]);
+  });
+
+  it("applies pending migrations in ascending toVersion order", () => {
+    const data: Record<string, unknown> = {};
+    const order: number[] = [];
+    runCharacterMigrations(
+      data,
+      [
+        { toVersion: 3, description: "v3", up(d) { order.push(3); return d; } },
+        { toVersion: 1, description: "v1", up(d) { order.push(1); return d; } },
+        { toVersion: 2, description: "v2", up(d) { order.push(2); return d; } },
+      ],
+      3,
+    );
+    expect(order).toEqual([1, 2, 3]);
+  });
+
+  it("skips migrations at or below saved version", () => {
+    const data: Record<string, unknown> = { schemaVersion: 2 };
+    const ran: number[] = [];
+    runCharacterMigrations(
+      data,
+      [
+        { toVersion: 1, description: "v1", up(d) { ran.push(1); return d; } },
+        { toVersion: 2, description: "v2", up(d) { ran.push(2); return d; } },
+        { toVersion: 3, description: "v3", up(d) { ran.push(3); return d; } },
+      ],
+      3,
+    );
+    expect(ran).toEqual([3]);
+  });
+
+  it("stamps currentVersion on the returned data", () => {
+    const data: Record<string, unknown> = {};
+    const { data: out } = runCharacterMigrations(
+      data,
+      [{ toVersion: 1, description: "v1", up(d) { return d; } }],
+      1,
+    );
+    expect(out["schemaVersion"]).toBe(1);
+  });
+
+  it("returns migrated=true when at least one migration ran", () => {
+    const data: Record<string, unknown> = { schemaVersion: 0 };
+    const { migrated } = runCharacterMigrations(
+      data,
+      [{ toVersion: 1, description: "v1", up(d) { return d; } }],
+      1,
+    );
+    expect(migrated).toBe(true);
+  });
+
+  it("chains transformations through multiple migrations", () => {
+    const data: Record<string, unknown> = { name: "Kara" };
+    const { data: out } = runCharacterMigrations(
+      data,
+      [
+        { toVersion: 1, description: "add a", up(d) { return { ...d, a: 1 }; } },
+        { toVersion: 2, description: "double a into b", up(d) { return { ...d, b: (d["a"] as number) * 2 }; } },
+      ],
+      2,
+    );
+    expect(out["name"]).toBe("Kara");
+    expect(out["a"]).toBe(1);
+    expect(out["b"]).toBe(2);
+  });
+
+  it("does not mutate the original data object", () => {
+    const data: Record<string, unknown> = { x: 1 };
+    const original = { ...data };
+    runCharacterMigrations(
+      data,
+      [{ toVersion: 1, description: "spread copy", up(d) { return { ...d, y: 2 }; } }],
+      1,
+    );
+    // The spread in up() creates a new object, so original should be unchanged
+    expect(data).toEqual(original);
+  });
+});

--- a/plugins/ironsworn/scribe/src/rag/lore-db.test.ts
+++ b/plugins/ironsworn/scribe/src/rag/lore-db.test.ts
@@ -86,11 +86,15 @@ describe("openLoreWriteConn", () => {
 // ---------------------------------------------------------------------------
 
 describe("getLoreEmbedding", () => {
+  // mockImplementationOnce argument must be cast because `typeof fetch` includes
+  // the non-standard `preconnect` property that plain functions don't carry.
+  type FetchFn = typeof fetch;
+
   it("throws a clear error when Ollama is unreachable (network failure)", async () => {
     const spy = spyOn(globalThis, "fetch");
-    spy.mockImplementationOnce(() => {
+    spy.mockImplementationOnce((() => {
       throw new Error("connect ECONNREFUSED 127.0.0.1:11434");
-    });
+    }) as unknown as FetchFn);
     try {
       await expect(getLoreEmbedding("test text")).rejects.toThrow(/ollama unavailable/i);
     } finally {
@@ -100,9 +104,9 @@ describe("getLoreEmbedding", () => {
 
   it("throws when Ollama returns a non-OK HTTP response", async () => {
     const spy = spyOn(globalThis, "fetch");
-    spy.mockImplementationOnce(async () =>
-      new Response(null, { status: 500, statusText: "Internal Server Error" }),
-    );
+    spy.mockImplementationOnce((async () =>
+      new Response(null, { status: 500, statusText: "Internal Server Error" })
+    ) as unknown as FetchFn);
     try {
       await expect(getLoreEmbedding("test text")).rejects.toThrow(/ollama embed failed/i);
     } finally {
@@ -112,12 +116,12 @@ describe("getLoreEmbedding", () => {
 
   it("throws when the response body has an unexpected shape", async () => {
     const spy = spyOn(globalThis, "fetch");
-    spy.mockImplementationOnce(async () =>
+    spy.mockImplementationOnce((async () =>
       new Response(JSON.stringify({ result: "oops" }), {
         status: 200,
         headers: { "Content-Type": "application/json" },
-      }),
-    );
+      })
+    ) as unknown as FetchFn);
     try {
       await expect(getLoreEmbedding("test text")).rejects.toThrow(/unexpected ollama response/i);
     } finally {
@@ -128,12 +132,12 @@ describe("getLoreEmbedding", () => {
   it("throws when the embedding has wrong dimensions", async () => {
     const spy = spyOn(globalThis, "fetch");
     const badEmbedding = new Array(512).fill(0.1); // 512 instead of 768
-    spy.mockImplementationOnce(async () =>
+    spy.mockImplementationOnce((async () =>
       new Response(JSON.stringify({ embeddings: [badEmbedding] }), {
         status: 200,
         headers: { "Content-Type": "application/json" },
-      }),
-    );
+      })
+    ) as unknown as FetchFn);
     try {
       await expect(getLoreEmbedding("test text")).rejects.toThrow(/768/);
     } finally {
@@ -145,12 +149,12 @@ describe("getLoreEmbedding", () => {
     const spy = spyOn(globalThis, "fetch");
     const badEmbedding = new Array(768).fill(0.1);
     badEmbedding[0] = NaN;
-    spy.mockImplementationOnce(async () =>
+    spy.mockImplementationOnce((async () =>
       new Response(JSON.stringify({ embeddings: [badEmbedding] }), {
         status: 200,
         headers: { "Content-Type": "application/json" },
-      }),
-    );
+      })
+    ) as unknown as FetchFn);
     try {
       await expect(getLoreEmbedding("test text")).rejects.toThrow(/invalid embedding values/i);
     } finally {
@@ -161,12 +165,12 @@ describe("getLoreEmbedding", () => {
   it("returns a 768-dim float array on a well-formed response", async () => {
     const spy = spyOn(globalThis, "fetch");
     const goodEmbedding = new Array(768).fill(0.42);
-    spy.mockImplementationOnce(async () =>
+    spy.mockImplementationOnce((async () =>
       new Response(JSON.stringify({ embeddings: [goodEmbedding] }), {
         status: 200,
         headers: { "Content-Type": "application/json" },
-      }),
-    );
+      })
+    ) as unknown as FetchFn);
     try {
       const result = await getLoreEmbedding("hello");
       expect(result).toHaveLength(768);

--- a/plugins/ironsworn/scribe/src/rag/lore-db.test.ts
+++ b/plugins/ironsworn/scribe/src/rag/lore-db.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, beforeAll, afterAll, spyOn } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { getLoreDb, peekLoreDb, openLoreWriteConn, getLoreEmbedding } from "./lore-db.js";
+
+// ---------------------------------------------------------------------------
+// Shared DB setup
+// ---------------------------------------------------------------------------
+// lore-db.ts has module-level state (dbPromises cache). To avoid cross-test
+// interference, all DuckDB tests share a single campaignDir and only clean up
+// after all tests have finished — never while instances are still open.
+
+let sharedDir: string;
+let dbReady = false;
+
+beforeAll(async () => {
+  sharedDir = await mkdtemp(join(tmpdir(), "lore-db-test-"));
+  try {
+    await getLoreDb(sharedDir);
+    dbReady = true;
+  } catch {
+    dbReady = false;
+  }
+});
+
+afterAll(async () => {
+  if (sharedDir) await rm(sharedDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// peekLoreDb
+// ---------------------------------------------------------------------------
+
+describe("peekLoreDb", () => {
+  it("returns undefined for a path that has never been opened", () => {
+    const result = peekLoreDb("/tmp/absolutely-nonexistent-campaign-" + Date.now());
+    expect(result).toBeUndefined();
+  });
+
+  it("returns the cached promise after getLoreDb has been called", async () => {
+    if (!dbReady) return;
+    const p = getLoreDb(sharedDir);
+    expect(peekLoreDb(sharedDir)).toBe(p);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getLoreDb
+// ---------------------------------------------------------------------------
+
+describe("getLoreDb", () => {
+  it("returns a usable DuckDB instance", async () => {
+    if (!dbReady) return;
+    const inst = await getLoreDb(sharedDir);
+    expect(inst).toBeDefined();
+    const conn = await inst.connect();
+    conn.closeSync();
+  });
+
+  it("caches the instance — repeated calls return the same promise", () => {
+    if (!dbReady) return;
+    const p1 = getLoreDb(sharedDir);
+    const p2 = getLoreDb(sharedDir);
+    expect(p1).toBe(p2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// openLoreWriteConn
+// ---------------------------------------------------------------------------
+
+describe("openLoreWriteConn", () => {
+  it("opens a usable write connection from the shared instance", async () => {
+    if (!dbReady) return;
+    const inst = await getLoreDb(sharedDir);
+    const conn = await openLoreWriteConn(inst);
+    expect(conn).toBeDefined();
+    await expect(conn.runAndReadAll("SELECT 1 AS n")).resolves.toBeDefined();
+    conn.closeSync();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getLoreEmbedding — error paths (fetch-mocked, no Ollama required)
+// ---------------------------------------------------------------------------
+
+describe("getLoreEmbedding", () => {
+  it("throws a clear error when Ollama is unreachable (network failure)", async () => {
+    const spy = spyOn(globalThis, "fetch");
+    spy.mockImplementationOnce(() => {
+      throw new Error("connect ECONNREFUSED 127.0.0.1:11434");
+    });
+    try {
+      await expect(getLoreEmbedding("test text")).rejects.toThrow(/ollama unavailable/i);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("throws when Ollama returns a non-OK HTTP response", async () => {
+    const spy = spyOn(globalThis, "fetch");
+    spy.mockImplementationOnce(async () =>
+      new Response(null, { status: 500, statusText: "Internal Server Error" }),
+    );
+    try {
+      await expect(getLoreEmbedding("test text")).rejects.toThrow(/ollama embed failed/i);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("throws when the response body has an unexpected shape", async () => {
+    const spy = spyOn(globalThis, "fetch");
+    spy.mockImplementationOnce(async () =>
+      new Response(JSON.stringify({ result: "oops" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    try {
+      await expect(getLoreEmbedding("test text")).rejects.toThrow(/unexpected ollama response/i);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("throws when the embedding has wrong dimensions", async () => {
+    const spy = spyOn(globalThis, "fetch");
+    const badEmbedding = new Array(512).fill(0.1); // 512 instead of 768
+    spy.mockImplementationOnce(async () =>
+      new Response(JSON.stringify({ embeddings: [badEmbedding] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    try {
+      await expect(getLoreEmbedding("test text")).rejects.toThrow(/768/);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("throws when the embedding contains non-finite values", async () => {
+    const spy = spyOn(globalThis, "fetch");
+    const badEmbedding = new Array(768).fill(0.1);
+    badEmbedding[0] = NaN;
+    spy.mockImplementationOnce(async () =>
+      new Response(JSON.stringify({ embeddings: [badEmbedding] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    try {
+      await expect(getLoreEmbedding("test text")).rejects.toThrow(/invalid embedding values/i);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("returns a 768-dim float array on a well-formed response", async () => {
+    const spy = spyOn(globalThis, "fetch");
+    const goodEmbedding = new Array(768).fill(0.42);
+    spy.mockImplementationOnce(async () =>
+      new Response(JSON.stringify({ embeddings: [goodEmbedding] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    try {
+      const result = await getLoreEmbedding("hello");
+      expect(result).toHaveLength(768);
+      expect(result[0]).toBeCloseTo(0.42);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/plugins/ironsworn/scribe/src/rag/query.mergeRRF.test.ts
+++ b/plugins/ironsworn/scribe/src/rag/query.mergeRRF.test.ts
@@ -27,7 +27,7 @@ describe("mergeRRF", () => {
   });
 
   it("limits results to k", () => {
-    const rows = ["a", "b", "c", "d", "e"].map(row);
+    const rows = ["a", "b", "c", "d", "e"].map((id) => row(id));
     const result = mergeRRF(rows, [], 3);
     expect(result).toHaveLength(3);
   });
@@ -65,7 +65,7 @@ describe("mergeRRF", () => {
 
   it("results are sorted by descending score", () => {
     // Rank 0 in vector wins over rank 1, wins over rank 2, etc.
-    const vectorRows = ["a", "b", "c", "d"].map(row);
+    const vectorRows = ["a", "b", "c", "d"].map((id) => row(id));
     const result = mergeRRF(vectorRows, [], 4);
     for (let i = 1; i < result.length; i++) {
       expect(result[i - 1]!.score).toBeGreaterThanOrEqual(result[i]!.score);
@@ -73,8 +73,8 @@ describe("mergeRRF", () => {
   });
 
   it("all returned rows carry a positive score", () => {
-    const vectorRows = ["x", "y"].map(row);
-    const bm25Rows = ["y", "z"].map(row);
+    const vectorRows = ["x", "y"].map((id) => row(id));
+    const bm25Rows = ["y", "z"].map((id) => row(id));
     const result = mergeRRF(vectorRows, bm25Rows, 10);
     for (const r of result) {
       expect(r.score).toBeGreaterThan(0);

--- a/plugins/ironsworn/scribe/src/rag/query.mergeRRF.test.ts
+++ b/plugins/ironsworn/scribe/src/rag/query.mergeRRF.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "bun:test";
+import { mergeRRF, type ScoredRow } from "./query.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function row(id: string, overrides: Partial<ScoredRow> = {}): ScoredRow {
+  return {
+    id,
+    text: `text for ${id}`,
+    headingPath: [],
+    contentType: "rule",
+    moveTrigger: "",
+    page: "1",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// mergeRRF — Reciprocal Rank Fusion
+// ---------------------------------------------------------------------------
+
+describe("mergeRRF", () => {
+  it("returns an empty array when both input lists are empty", () => {
+    expect(mergeRRF([], [], 5)).toEqual([]);
+  });
+
+  it("limits results to k", () => {
+    const rows = ["a", "b", "c", "d", "e"].map(row);
+    const result = mergeRRF(rows, [], 3);
+    expect(result).toHaveLength(3);
+  });
+
+  it("returns all results when total unique rows < k", () => {
+    const result = mergeRRF([row("a"), row("b")], [], 10);
+    expect(result).toHaveLength(2);
+  });
+
+  it("deduplicates rows that appear in both lists", () => {
+    const a = row("shared");
+    const result = mergeRRF([a], [a], 10);
+    // "shared" should appear only once
+    const ids = result.map((r) => r.id);
+    expect(ids.filter((id) => id === "shared")).toHaveLength(1);
+  });
+
+  it("a row appearing in both lists has a higher score than one appearing in only one", () => {
+    // "both" is at rank 0 in vector and rank 0 in bm25 → highest combined RRF score.
+    // "vector-only" is at rank 1 in vector only → lower score.
+    const vectorRows = [row("both"), row("vector-only")];
+    const bm25Rows = [row("both"), row("bm25-only")];
+    const result = mergeRRF(vectorRows, bm25Rows, 10);
+
+    const bothResult = result.find((r) => r.id === "both");
+    const vectorOnly = result.find((r) => r.id === "vector-only");
+    const bm25Only = result.find((r) => r.id === "bm25-only");
+
+    expect(bothResult).toBeDefined();
+    expect(vectorOnly).toBeDefined();
+    expect(bm25Only).toBeDefined();
+    expect(bothResult!.score).toBeGreaterThan(vectorOnly!.score);
+    expect(bothResult!.score).toBeGreaterThan(bm25Only!.score);
+  });
+
+  it("results are sorted by descending score", () => {
+    // Rank 0 in vector wins over rank 1, wins over rank 2, etc.
+    const vectorRows = ["a", "b", "c", "d"].map(row);
+    const result = mergeRRF(vectorRows, [], 4);
+    for (let i = 1; i < result.length; i++) {
+      expect(result[i - 1]!.score).toBeGreaterThanOrEqual(result[i]!.score);
+    }
+  });
+
+  it("all returned rows carry a positive score", () => {
+    const vectorRows = ["x", "y"].map(row);
+    const bm25Rows = ["y", "z"].map(row);
+    const result = mergeRRF(vectorRows, bm25Rows, 10);
+    for (const r of result) {
+      expect(r.score).toBeGreaterThan(0);
+    }
+  });
+
+  it("preserves row metadata from the first-seen occurrence", () => {
+    const vectorRow = row("doc", { text: "from-vector", page: "42" });
+    const bm25Row = row("doc", { text: "from-bm25", page: "99" });
+    const result = mergeRRF([vectorRow], [bm25Row], 10);
+    const found = result.find((r) => r.id === "doc");
+    // Vector appears first, so its metadata wins
+    expect(found!.text).toBe("from-vector");
+    expect(found!.page).toBe("42");
+  });
+
+  it("handles a large number of rows without error", () => {
+    const N = 200;
+    const vectorRows = Array.from({ length: N }, (_, i) => row(`v${i}`));
+    const bm25Rows = Array.from({ length: N }, (_, i) => row(`b${i}`));
+    const result = mergeRRF(vectorRows, bm25Rows, 10);
+    expect(result).toHaveLength(10);
+  });
+
+  it("uses RRF_K=60 — rank 0 score is 1/(60+1)", () => {
+    const result = mergeRRF([row("only")], [], 1);
+    // rank 0 in vector, absent in bm25 → score = 1 / (60 + 0 + 1) = 1/61
+    expect(result[0]!.score).toBeCloseTo(1 / 61, 6);
+  });
+
+  it("two results at the same rank from different lists share equal scores", () => {
+    // "a" rank 0 in vector, "b" rank 0 in bm25 → both get 1/61
+    const result = mergeRRF([row("a")], [row("b")], 2);
+    expect(result[0]!.score).toBeCloseTo(result[1]!.score, 10);
+  });
+});

--- a/plugins/ironsworn/scribe/src/rag/query.ts
+++ b/plugins/ironsworn/scribe/src/rag/query.ts
@@ -125,7 +125,7 @@ async function getEmbedding(query: string): Promise<number[]> {
 // RRF merge
 // ---------------------------------------------------------------------------
 
-interface ScoredRow {
+export interface ScoredRow {
   id: string;
   text: string;
   headingPath: string[];
@@ -134,7 +134,7 @@ interface ScoredRow {
   page: string;
 }
 
-function mergeRRF(
+export function mergeRRF(
   vectorRows: ScoredRow[],
   bm25Rows: ScoredRow[],
   k: number,

--- a/plugins/ironsworn/scribe/src/rules/ironsworn/oracles.test.ts
+++ b/plugins/ironsworn/scribe/src/rules/ironsworn/oracles.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from "bun:test";
-import { rollOracle, rollYesNo } from "./oracles.js";
+import { existsSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { rollOracle, rollYesNo, getOracleTables } from "./oracles.js";
+
+const ORACLES_YAML_EXISTS = existsSync(
+  resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "..", "data", "oracles.yaml"),
+);
 
 describe("rollYesNo", () => {
   it("returns valid structure", () => {
@@ -49,6 +56,79 @@ describe("rollOracle", () => {
     expect(() => rollOracle("zzz-nonexistent-table")).toThrow(/not found/i);
   });
 
-  // Integration tests — only run if oracles.yaml exists
-  // (Can't test rollOracle results without the data file)
+  it("returns a valid result for the Action table", () => {
+    if (!ORACLES_YAML_EXISTS) return;
+    const result = rollOracle("Action");
+    expect(result.tableName).toBe("Action");
+    expect(result.roll).toBeGreaterThanOrEqual(1);
+    expect(result.roll).toBeLessThanOrEqual(100);
+    expect(typeof result.outcome).toBe("string");
+    expect(result.outcome.length).toBeGreaterThan(0);
+  });
+
+  it("roll is always within the valid range for the table dice", () => {
+    if (!ORACLES_YAML_EXISTS) return;
+    // Action uses d100; run many times to confirm bounds
+    for (let i = 0; i < 100; i++) {
+      const r = rollOracle("Action");
+      expect(r.roll).toBeGreaterThanOrEqual(1);
+      expect(r.roll).toBeLessThanOrEqual(100);
+    }
+  });
+
+  it("resolves a table by alias", () => {
+    if (!ORACLES_YAML_EXISTS) return;
+    // "Table A" has alias "Ironlander Name"
+    const result = rollOracle("Ironlander Name");
+    expect(result.tableName).toBe("Table A");
+    expect(typeof result.outcome).toBe("string");
+    expect(result.outcome.length).toBeGreaterThan(0);
+  });
+
+  it("alias lookup is case-insensitive", () => {
+    if (!ORACLES_YAML_EXISTS) return;
+    const result = rollOracle("ironlander name");
+    expect(result.tableName).toBe("Table A");
+  });
+
+  it("table name lookup is case-insensitive", () => {
+    if (!ORACLES_YAML_EXISTS) return;
+    const result = rollOracle("action");
+    expect(result.tableName).toBe("Action");
+  });
+
+  it("outcome covers the full roll range — no gaps in Action table entries", () => {
+    if (!ORACLES_YAML_EXISTS) return;
+    // Run 500 times; if any gap existed an error would be thrown.
+    for (let i = 0; i < 500; i++) {
+      expect(() => rollOracle("Action")).not.toThrow();
+    }
+  });
+});
+
+describe("getOracleTables", () => {
+  it("returns a non-empty array when oracles.yaml exists", () => {
+    if (!ORACLES_YAML_EXISTS) return;
+    const tables = getOracleTables();
+    expect(Array.isArray(tables)).toBe(true);
+    expect(tables.length).toBeGreaterThan(0);
+  });
+
+  it("each table has name, dice, and rolls fields", () => {
+    if (!ORACLES_YAML_EXISTS) return;
+    for (const table of getOracleTables()) {
+      expect(typeof table.name).toBe("string");
+      expect(["d6", "d10", "d100", "1d100", "1d10", "1d6"]).toContain(table.dice);
+      expect(Array.isArray(table.rolls)).toBe(true);
+      expect(table.rolls.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("known tables are present (Action, Theme, Pay the Price)", () => {
+    if (!ORACLES_YAML_EXISTS) return;
+    const names = getOracleTables().map((t) => t.name);
+    expect(names).toContain("Action");
+    expect(names).toContain("Theme");
+    expect(names).toContain("Pay the Price");
+  });
 });

--- a/plugins/ironsworn/scribe/src/tools/campaign.test.ts
+++ b/plugins/ironsworn/scribe/src/tools/campaign.test.ts
@@ -1,0 +1,316 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm, writeFile, readFile, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { register } from "./campaign.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function parseText<T = unknown>(result: unknown): T {
+  const content = (result as { content: Array<{ type: string; text: string }> }).content;
+  return JSON.parse(content[0]!.text) as T;
+}
+
+const BASE_CHARACTER = {
+  name: "Kara",
+  stats: { edge: 2, heart: 3, iron: 1, shadow: 2, wits: 3 },
+  momentum: 2,
+  momentumReset: 2,
+  health: 4,
+  spirit: 3,
+  supply: 3,
+  debilities: {},
+  assets: [],
+  progressTracks: [],
+  companions: [],
+  bonds: 0,
+  experience: 0,
+  customState: {},
+};
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+let campaignDir: string;
+let exportDir: string;
+let client: Client;
+let server: McpServer;
+
+beforeEach(async () => {
+  campaignDir = await mkdtemp(join(tmpdir(), "scribe-campaign-test-"));
+  exportDir = await mkdtemp(join(tmpdir(), "scribe-campaign-export-"));
+
+  server = new McpServer({ name: "test", version: "0.0.1" });
+  register(server, campaignDir);
+
+  client = new Client({ name: "test-client", version: "0.0.1" });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+});
+
+afterEach(async () => {
+  await rm(campaignDir, { recursive: true, force: true });
+  await rm(exportDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// checkpoint_now
+// ---------------------------------------------------------------------------
+
+describe("checkpoint_now", () => {
+  it("returns ok:true when no DB has been opened (no-op checkpoints)", async () => {
+    const result = await client.callTool({ name: "checkpoint_now", arguments: {} });
+    expect(result.isError).not.toBe(true);
+    const parsed = parseText<{ ok: boolean; message: string }>(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.message).toMatch(/checkpoint/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// export_campaign
+// ---------------------------------------------------------------------------
+
+describe("export_campaign", () => {
+  it("creates a valid JSON export file with correct structure", async () => {
+    await writeFile(join(campaignDir, "character.json"), JSON.stringify(BASE_CHARACTER));
+    const outputPath = join(exportDir, "export.json");
+
+    const result = await client.callTool({
+      name: "export_campaign",
+      arguments: { output_path: outputPath },
+    });
+    expect(result.isError).not.toBe(true);
+
+    const summary = parseText<{
+      ok: boolean;
+      output_path: string;
+      counts: Record<string, number>;
+    }>(result);
+    expect(summary.ok).toBe(true);
+    expect(summary.output_path).toBe(outputPath);
+    expect(typeof summary.counts.lore_entities).toBe("number");
+    expect(typeof summary.counts.scenes).toBe("number");
+
+    const raw = await readFile(outputPath, "utf-8");
+    const data = JSON.parse(raw) as Record<string, unknown>;
+    expect(data["version"]).toBe(1);
+    expect(typeof data["exported_at"]).toBe("string");
+    expect(data["character"]).toMatchObject({ name: "Kara" });
+    expect(Array.isArray(data["threads"])).toBe(true);
+    expect(typeof data["npcs"]).toBe("object");
+    expect(Array.isArray(data["lore_entities"])).toBe(true);
+    expect(Array.isArray(data["lore_relations"])).toBe(true);
+    expect(Array.isArray(data["scenes"])).toBe(true);
+  });
+
+  it("world-pack mode (include_scenes=false) produces empty scenes array", async () => {
+    await writeFile(join(campaignDir, "character.json"), JSON.stringify(BASE_CHARACTER));
+    const outputPath = join(exportDir, "worldpack.json");
+
+    const result = await client.callTool({
+      name: "export_campaign",
+      arguments: { output_path: outputPath, include_scenes: false },
+    });
+    expect(result.isError).not.toBe(true);
+
+    const raw = await readFile(outputPath, "utf-8");
+    const data = JSON.parse(raw) as Record<string, unknown>;
+    expect(data["scenes"]).toEqual([]);
+    expect(parseText<{ counts: Record<string, number> }>(result).counts.scenes).toBe(0);
+  });
+
+  it("exports NPCs from the npcs/ directory", async () => {
+    await writeFile(join(campaignDir, "character.json"), JSON.stringify(BASE_CHARACTER));
+    await mkdir(join(campaignDir, "npcs"), { recursive: true });
+    await writeFile(join(campaignDir, "npcs", "aldric.md"), "# Aldric\nA blacksmith.");
+
+    const outputPath = join(exportDir, "export-npcs.json");
+    await client.callTool({ name: "export_campaign", arguments: { output_path: outputPath } });
+
+    const raw = await readFile(outputPath, "utf-8");
+    const data = JSON.parse(raw) as Record<string, unknown>;
+    const npcs = data["npcs"] as Record<string, string>;
+    expect(npcs["aldric.md"]).toBe("# Aldric\nA blacksmith.");
+  });
+
+  it("succeeds even when character.json is absent (exports null character)", async () => {
+    const outputPath = join(exportDir, "no-char.json");
+
+    const result = await client.callTool({
+      name: "export_campaign",
+      arguments: { output_path: outputPath },
+    });
+    expect(result.isError).not.toBe(true);
+
+    const raw = await readFile(outputPath, "utf-8");
+    const data = JSON.parse(raw) as Record<string, unknown>;
+    expect(data["character"]).toBeNull();
+  });
+
+  it("creates intermediate directories for the output path", async () => {
+    const outputPath = join(exportDir, "nested", "deep", "export.json");
+
+    const result = await client.callTool({
+      name: "export_campaign",
+      arguments: { output_path: outputPath },
+    });
+    expect(result.isError).not.toBe(true);
+    await expect(readFile(outputPath, "utf-8")).resolves.toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// import_campaign
+// ---------------------------------------------------------------------------
+
+describe("import_campaign", () => {
+  it("returns an error for unsupported export versions", async () => {
+    const badExport = { version: 99, character: null, threads: [], npcs: {}, lore_entities: [], lore_relations: [], lore_proximity: [], scenes: [] };
+    const inputPath = join(exportDir, "bad-version.json");
+    await writeFile(inputPath, JSON.stringify(badExport));
+
+    const result = await client.callTool({
+      name: "import_campaign",
+      arguments: { input_path: inputPath },
+    });
+    expect(result.isError).toBe(true);
+    const text = (result.content as Array<{ text: string }>)[0]!.text;
+    expect(text).toMatch(/unsupported export version/i);
+  });
+
+  it("imports character from a valid export", async () => {
+    const exportPayload = {
+      version: 1,
+      exported_at: new Date().toISOString(),
+      character: BASE_CHARACTER,
+      threads: [],
+      npcs: {},
+      lore_entities: [],
+      lore_relations: [],
+      lore_proximity: [],
+      scenes: [],
+    };
+    const inputPath = join(exportDir, "valid.json");
+    await writeFile(inputPath, JSON.stringify(exportPayload));
+
+    const result = await client.callTool({
+      name: "import_campaign",
+      arguments: { input_path: inputPath },
+    });
+    expect(result.isError).not.toBe(true);
+    const parsed = parseText<{ ok: boolean; imported: Record<string, number> }>(result);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.imported.character).toBe(1);
+
+    // Verify character was persisted
+    const charRaw = await readFile(join(campaignDir, "character.json"), "utf-8");
+    const char = JSON.parse(charRaw) as Record<string, unknown>;
+    expect(char["name"]).toBe("Kara");
+  });
+
+  it("imports NPCs from a valid export", async () => {
+    const exportPayload = {
+      version: 1,
+      exported_at: new Date().toISOString(),
+      character: null,
+      threads: [],
+      npcs: { "aldric.md": "# Aldric\nA blacksmith." },
+      lore_entities: [],
+      lore_relations: [],
+      lore_proximity: [],
+      scenes: [],
+    };
+    const inputPath = join(exportDir, "npcs.json");
+    await writeFile(inputPath, JSON.stringify(exportPayload));
+
+    const result = await client.callTool({
+      name: "import_campaign",
+      arguments: { input_path: inputPath },
+    });
+    expect(result.isError).not.toBe(true);
+    const parsed = parseText<{ imported: Record<string, number> }>(result);
+    expect(parsed.imported.npcs).toBe(1);
+
+    const npcContent = await readFile(join(campaignDir, "npcs", "aldric.md"), "utf-8");
+    expect(npcContent).toBe("# Aldric\nA blacksmith.");
+  });
+
+  it("imports threads from a valid export", async () => {
+    const thread = {
+      title: "Defeat the Iron Lich",
+      kind: "vow",
+      status: "open",
+      notes: "Epic quest",
+      openedAt: new Date().toISOString(),
+    };
+    const exportPayload = {
+      version: 1,
+      exported_at: new Date().toISOString(),
+      character: null,
+      threads: [thread],
+      npcs: {},
+      lore_entities: [],
+      lore_relations: [],
+      lore_proximity: [],
+      scenes: [],
+    };
+    const inputPath = join(exportDir, "threads.json");
+    await writeFile(inputPath, JSON.stringify(exportPayload));
+
+    const result = await client.callTool({
+      name: "import_campaign",
+      arguments: { input_path: inputPath },
+    });
+    expect(result.isError).not.toBe(true);
+    const parsed = parseText<{ imported: Record<string, number> }>(result);
+    expect(parsed.imported.threads).toBe(1);
+  });
+
+  it("round-trips a full export/import cycle preserving character", async () => {
+    // Seed the campaign
+    await writeFile(join(campaignDir, "character.json"), JSON.stringify(BASE_CHARACTER));
+    const outputPath = join(exportDir, "roundtrip.json");
+
+    // Export
+    await client.callTool({ name: "export_campaign", arguments: { output_path: outputPath } });
+
+    // Import into a fresh campaign dir
+    const importDir = await mkdtemp(join(tmpdir(), "scribe-import-test-"));
+    try {
+      const importServer = new McpServer({ name: "test-import", version: "0.0.1" });
+      register(importServer, importDir);
+      const importClient = new Client({ name: "import-client", version: "0.0.1" });
+      const [ct, st] = InMemoryTransport.createLinkedPair();
+      await importServer.connect(st);
+      await importClient.connect(ct);
+
+      const importResult = await importClient.callTool({
+        name: "import_campaign",
+        arguments: { input_path: outputPath },
+      });
+      expect(importResult.isError).not.toBe(true);
+
+      const charRaw = await readFile(join(importDir, "character.json"), "utf-8");
+      const char = JSON.parse(charRaw) as Record<string, unknown>;
+      expect(char["name"]).toBe("Kara");
+    } finally {
+      await rm(importDir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns error when input file does not exist", async () => {
+    const result = await client.callTool({
+      name: "import_campaign",
+      arguments: { input_path: join(exportDir, "nonexistent.json") },
+    });
+    expect(result.isError).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
This PR adds a comprehensive test suite covering the campaign export/import system, database migrations, RAG query merging, lore database operations, and checkpoint functionality. It also extends the oracle tests with integration tests that verify actual oracle table rolling when the data file is present.

## Key Changes

- **Campaign tools tests** (`campaign.test.ts`): Full coverage of `checkpoint_now`, `export_campaign`, and `import_campaign` tools, including round-trip export/import validation, NPC handling, and error cases
- **Migration tests** (`migrations/index.test.ts`): Tests for both database migrations (`runDbMigrations`) and character JSON migrations (`runCharacterMigrations`), verifying idempotency, version tracking, and transformation chaining
- **Lore database tests** (`lore-db.test.ts`): Tests for DuckDB instance caching, write connections, and `getLoreEmbedding` error handling with mocked Ollama responses
- **RRF merge tests** (`query.mergeRRF.test.ts`): Tests for reciprocal rank fusion algorithm, including deduplication, score calculation, and result ordering
- **Checkpoint tests** (`checkpoint.test.ts`): Tests for periodic checkpoint initialization and mutation recording with write threshold triggering
- **Oracle tests enhancement** (`oracles.test.ts`): Added integration tests for actual oracle rolling (Action, Theme, Pay the Price tables), alias resolution, and case-insensitive lookups; tests gracefully skip if `oracles.yaml` is not present
- **Export type visibility**: Made `ScoredRow` interface public in `query.ts` to support test imports

## Implementation Details

- Tests use Bun's test framework with proper setup/teardown for temporary directories
- Database tests share a single campaign directory to avoid DuckDB instance conflicts across test isolation boundaries
- Ollama embedding tests use `spyOn` to mock fetch responses without requiring a running Ollama instance
- Oracle tests conditionally skip integration tests if the data file is missing, allowing CI to pass without the full Ironsworn data
- Migration tests verify both the execution order and idempotency guarantees required by the system

https://claude.ai/code/session_012EPTK264ArtvuU7od7ZmSg