### PR TITLE
Switch embedding provider from Ollama to Nomic Atlas

### DIFF
--- a/plugins/ironsworn/.claude-plugin/plugin.json
+++ b/plugins/ironsworn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ironsworn",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "Solo Ironsworn GM companion — fiction-first, dice-driven, with a living lore graph",
   "author": {
     "name": "Karim Naguib"

--- a/plugins/ironsworn/scribe/src/rag/query.test.ts
+++ b/plugins/ironsworn/scribe/src/rag/query.test.ts
@@ -26,27 +26,28 @@ async function ftsAvailable(): Promise<boolean> {
   return _ftsAvailable;
 }
 
-let _ollamaReady: boolean | null = null;
-async function ollamaAvailable(): Promise<boolean> {
-  if (_ollamaReady !== null) return _ollamaReady;
+let _nomicReady: boolean | null = null;
+async function nomicAvailable(): Promise<boolean> {
+  if (_nomicReady !== null) return _nomicReady;
   try {
-    const baseUrl = process.env["OLLAMA_BASE_URL"] ?? "http://localhost:11434";
-    const res = await fetch(`${baseUrl}/api/embed`, {
+    const apiKey = process.env["NOMIC_API_KEY"] ?? "";
+    if (!apiKey) { _nomicReady = false; return false; }
+    const res = await fetch("https://api-atlas.nomic.ai/v1/embedding/text", {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ model: "nomic-embed-text", input: "t" }),
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
+      body: JSON.stringify({ model: "nomic-embed-text-v1.5", texts: ["t"] }),
     });
-    _ollamaReady = res.ok;
+    _nomicReady = res.ok;
   } catch {
-    _ollamaReady = false;
+    _nomicReady = false;
   }
-  return _ollamaReady;
+  return _nomicReady;
 }
 
 describe("searchRules", () => {
   it("returns results for a rules query", async () => {
     if (!DB_EXISTS) return; // skip gracefully
-    if (!(await ollamaAvailable())) return; // skip when Ollama not running
+    if (!(await nomicAvailable())) return; // skip when Nomic Atlas not available
     if (!(await ftsAvailable())) return; // skip when fts extension unavailable
     const results = await searchRules("face danger move", { k: 3 });
     expect(results.length).toBeGreaterThan(0);

--- a/plugins/ironsworn/scribe/src/rag/query.ts
+++ b/plugins/ironsworn/scribe/src/rag/query.ts
@@ -7,8 +7,8 @@ import { getMoves } from "../rules/ironsworn/moves.js";
 // Config
 // ---------------------------------------------------------------------------
 
-const OLLAMA_BASE_URL =
-  process.env["OLLAMA_BASE_URL"] ?? "http://localhost:11434";
+const NOMIC_API_KEY = process.env["NOMIC_API_KEY"] ?? "";
+const NOMIC_ENDPOINT = "https://api-atlas.nomic.ai/v1/embedding/text";
 
 export function resolveDbPath(): string {
   const explicit = process.env["DB_PATH"];
@@ -90,24 +90,27 @@ function toNum(value: unknown): number {
 async function getEmbedding(query: string): Promise<number[]> {
   let response: Response;
   try {
-    response = await fetch(`${OLLAMA_BASE_URL}/api/embed`, {
+    response = await fetch(NOMIC_ENDPOINT, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ model: "nomic-embed-text", input: query }),
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${NOMIC_API_KEY}`,
+      },
+      body: JSON.stringify({ model: "nomic-embed-text-v1.5", texts: [query] }),
     });
   } catch (e) {
     const err = e as Error;
-    throw new Error(`Ollama unavailable at ${OLLAMA_BASE_URL}: ${err.message}`);
+    throw new Error(`Nomic Atlas unavailable: ${err.message}`);
   }
 
   if (!response.ok) {
-    throw new Error(`Ollama embed failed: ${response.status} ${response.statusText}`);
+    throw new Error(`Nomic Atlas embed failed: ${response.status} ${response.statusText}`);
   }
 
   const data = (await response.json()) as { embeddings: number[][] };
 
   if (!data.embeddings || !Array.isArray(data.embeddings[0])) {
-    throw new Error("Unexpected Ollama response shape");
+    throw new Error("Unexpected Nomic Atlas response shape");
   }
 
   if (data.embeddings[0].length !== 768) {
@@ -115,7 +118,7 @@ async function getEmbedding(query: string): Promise<number[]> {
   }
 
   if (!data.embeddings[0].every((v) => typeof v === "number" && isFinite(v))) {
-    throw new Error("Invalid embedding values from Ollama");
+    throw new Error("Invalid embedding values from Nomic Atlas");
   }
 
   return data.embeddings[0];


### PR DESCRIPTION
## Summary
Migrates the RAG embedding pipeline from a local Ollama instance to Nomic Atlas cloud API, eliminating the need for local infrastructure while maintaining the same embedding model (`nomic-embed-text`).

## Changes
- **Configuration**: Replace `OLLAMA_BASE_URL` environment variable with `NOMIC_API_KEY` for cloud authentication
- **Embedding endpoint**: Update from local Ollama (`http://localhost:11434/api/embed`) to Nomic Atlas (`https://api-atlas.nomic.ai/v1/embedding/text`)
- **Request format**: Adjust payload structure to match Nomic API:
  - Model: `nomic-embed-text` → `nomic-embed-text-v1.5`
  - Input field: `input: query` → `texts: [query]`
  - Add Bearer token authorization header
- **Error messages**: Update all error messages to reference "Nomic Atlas" instead of "Ollama"
- **Tests**: Update availability check function from `ollamaAvailable()` to `nomicAvailable()` with API key validation
- **Version bump**: Increment plugin version to 0.22.1

## Implementation Details
The embedding dimension remains 768, matching Nomic's output. The API key is required and checked early in the availability function to fail gracefully when not configured. All error handling and response validation logic is preserved, only the endpoint and request/response shapes change.

https://claude.ai/code/session_01AnErdGMnq4UMgaU5rn4MDM