### PR TITLE
Support campaign export version 2 and fix lore provenance conflicts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 LocalPreferences.toml
 .worktrees/
+.claude/worktrees/
 campaigns/

--- a/plugins/ironsworn/.claude-plugin/plugin.json
+++ b/plugins/ironsworn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ironsworn",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "description": "Solo Ironsworn GM companion — fiction-first, dice-driven, with a living lore graph",
   "author": {
     "name": "Karim Naguib"

--- a/plugins/ironsworn/scribe/src/rag/lore.ts
+++ b/plugins/ironsworn/scribe/src/rag/lore.ts
@@ -760,7 +760,8 @@ export async function replayProvenance(
     await conn.run(
       `INSERT INTO lore_provenance
          (id, subject_kind, subject_id, source_kind, source_id, excerpt, confidence, created_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT (id) DO NOTHING`,
       [
         entry.id,
         entry.subject_kind,

--- a/plugins/ironsworn/scribe/src/tools/campaign.test.ts
+++ b/plugins/ironsworn/scribe/src/tools/campaign.test.ts
@@ -101,7 +101,7 @@ describe("export_campaign", () => {
 
     const raw = await readFile(outputPath, "utf-8");
     const data = JSON.parse(raw) as Record<string, unknown>;
-    expect(data["version"]).toBe(1);
+    expect(data["version"]).toBe(2);
     expect(typeof data["exported_at"]).toBe("string");
     expect(data["character"]).toMatchObject({ name: "Kara" });
     expect(Array.isArray(data["threads"])).toBe(true);

--- a/plugins/ironsworn/scribe/src/tools/campaign.ts
+++ b/plugins/ironsworn/scribe/src/tools/campaign.ts
@@ -10,7 +10,7 @@ import { exportProximity, linkProximity, type ProximityDimension, type CompassPo
 import { exportScenes, importScene, checkpointScenes, type BeatExport } from "../rag/scenes.js";
 
 interface CampaignExport {
-  version: 1;
+  version: 2;
   exported_at: string;
   character: unknown;
   threads: unknown[];
@@ -75,7 +75,7 @@ export function register(server: McpServer, campaignPath: string): void {
         ]);
 
         const payload: CampaignExport = {
-          version: 1,
+          version: 2,
           exported_at: new Date().toISOString(),
           character,
           threads,
@@ -126,14 +126,17 @@ export function register(server: McpServer, campaignPath: string): void {
     async ({ input_path }) => {
       try {
         const raw = await readFile(input_path, "utf-8");
-        const data = JSON.parse(raw) as CampaignExport;
+        const parsed = JSON.parse(raw) as Record<string, unknown>;
+        const exportVersion = parsed["version"] as number;
 
-        if (data.version !== 1) {
+        if (exportVersion !== 1 && exportVersion !== 2) {
           return {
-            content: [{ type: "text", text: `Unsupported export version: ${data.version}` }],
+            content: [{ type: "text", text: `Unsupported export version: ${exportVersion}` }],
             isError: true,
           };
         }
+
+        const data = parsed as unknown as CampaignExport;
 
         const counts = { character: 0, threads: 0, npcs: 0, lore_entities: 0, lore_relations: 0, lore_proximity: 0, lore_provenance: 0, scenes: 0 };
 


### PR DESCRIPTION
## Summary
This PR bumps the campaign export format to version 2 and adds backward compatibility for importing both v1 and v2 exports. It also fixes a database conflict issue when replaying provenance entries.

## Key Changes
- **Campaign export versioning**: Updated `CampaignExport` interface and export payload to use version 2
- **Import compatibility**: Modified the import handler to accept both v1 and v2 export formats, with explicit version validation before type casting
- **Lore provenance conflicts**: Added `ON CONFLICT (id) DO NOTHING` clause to the provenance insert statement to gracefully handle duplicate entries during replay
- **Test updates**: Updated campaign export test to expect version 2
- **Version bump**: Incremented plugin version to 0.22.2 in `plugin.json`
- **Gitignore**: Added `.claude/worktrees/` to ignore list

## Implementation Details
The import logic now performs a two-stage parse:
1. Parse as generic `Record<string, unknown>` and validate the version field
2. Only cast to `CampaignExport` after version validation succeeds

This defensive approach prevents type-casting errors when handling unexpected export versions while maintaining support for both v1 and v2 formats.

https://claude.ai/code/session_0118QGosATo5A9jTwVV7h7ec