### PR TITLE
Improve plugin root resolution and scribe dependency handling

### DIFF
--- a/plugins/ironsworn/.claude-plugin/plugin.json
+++ b/plugins/ironsworn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ironsworn",
-  "version": "0.22.2",
+  "version": "0.22.3",
   "description": "Solo Ironsworn GM companion — fiction-first, dice-driven, with a living lore graph",
   "author": {
     "name": "Karim Naguib"

--- a/plugins/ironsworn/commands/ironsworn-init.sh
+++ b/plugins/ironsworn/commands/ironsworn-init.sh
@@ -6,6 +6,11 @@ set -euo pipefail
 CWD="$(pwd)"
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-}"
 
+# Resolve plugin root from installed_plugins.json if CLAUDE_PLUGIN_ROOT is unset
+if [ -z "$PLUGIN_ROOT" ]; then
+  PLUGIN_ROOT=$(jq -r '(.plugins | to_entries[] | select(.key | startswith("ironsworn@")) | .value[0].installPath) // ""' ~/.claude/plugins/installed_plugins.json 2>/dev/null || true)
+fi
+
 created=()
 skipped=()
 
@@ -41,7 +46,7 @@ echo "────────────────────────�
 # The statusLine command uses \\033 (double-escaped) so ANSI codes survive JSON embedding.
 STATUS_LINE_JSON='{
     "type": "command",
-    "command": "input=$(cat); cwd=$(echo \"$input\" | jq -r '"'"'.workspace.project_dir'"'"'); char=\"$cwd/campaigns/default/character.json\"; if [ ! -f \"$char\" ]; then exit 0; fi; name=$(jq -r '"'"'.name // \"Hero\"'"'"' \"$char\"); fe=$(jq -r '"'"'.stats.iron // \"?\"'"'"' \"$char\"); ed=$(jq -r '"'"'.stats.edge // \"?\"'"'"' \"$char\"); sh=$(jq -r '"'"'.stats.shadow // \"?\"'"'"' \"$char\"); ht=$(jq -r '"'"'.stats.heart // \"?\"'"'"' \"$char\"); wt=$(jq -r '"'"'.stats.wits // \"?\"'"'"' \"$char\"); hp=$(jq -r '"'"'.health'"'"' \"$char\"); sp=$(jq -r '"'"'.spirit'"'"' \"$char\"); su=$(jq -r '"'"'.supply'"'"' \"$char\"); mo=$(jq -r '"'"'.momentum'"'"' \"$char\"); xp=$(jq -r '"'"'.experience // 0'"'"' \"$char\"); pv=$(jq -r '"'"'.plugins[\"ironsworn@agentic-ironsworn\"][0].version // \"?\"'"'"' ~/.claude/plugins/installed_plugins.json 2>/dev/null || echo '"'"'?'"'"'); colorval(){ v=$1; if [ \"$v\" -le 1 ] 2>/dev/null; then printf '"'"'\\033[31m%s\\033[0m'"'"' \"$v\"; elif [ \"$v\" -le 3 ] 2>/dev/null; then printf '"'"'\\033[38;5;208m%s\\033[0m'"'"' \"$v\"; else printf '"'"'\\033[32m%s\\033[0m'"'"' \"$v\"; fi; }; echo \"$name | Fe:$fe Ed:$ed Sh:$sh Ht:$ht Wt:$wt | HP:$(colorval $hp) Sp:$(colorval $sp) Su:$(colorval $su) Mo:$mo XP:$xp | is:$pv\""
+    "command": "input=$(cat); cwd=$(echo \"$input\" | jq -r '"'"'.workspace.project_dir'"'"'); char=\"$cwd/campaigns/default/character.json\"; if [ ! -f \"$char\" ]; then exit 0; fi; name=$(jq -r '"'"'.name // \"Hero\"'"'"' \"$char\"); fe=$(jq -r '"'"'.stats.iron // \"?\"'"'"' \"$char\"); ed=$(jq -r '"'"'.stats.edge // \"?\"'"'"' \"$char\"); sh=$(jq -r '"'"'.stats.shadow // \"?\"'"'"' \"$char\"); ht=$(jq -r '"'"'.stats.heart // \"?\"'"'"' \"$char\"); wt=$(jq -r '"'"'.stats.wits // \"?\"'"'"' \"$char\"); hp=$(jq -r '"'"'.health'"'"' \"$char\"); sp=$(jq -r '"'"'.spirit'"'"' \"$char\"); su=$(jq -r '"'"'.supply'"'"' \"$char\"); mo=$(jq -r '"'"'.momentum'"'"' \"$char\"); xp=$(jq -r '"'"'.experience // 0'"'"' \"$char\"); pv=$(jq -r '"'"'(.plugins | to_entries[] | select(.key | startswith("ironsworn@")) | .value[0].version) // "?"'"'"' ~/.claude/plugins/installed_plugins.json 2>/dev/null || echo '"'"'?'"'"'); colorval(){ v=$1; if [ \"$v\" -le 1 ] 2>/dev/null; then printf '"'"'\\033[31m%s\\033[0m'"'"' \"$v\"; elif [ \"$v\" -le 3 ] 2>/dev/null; then printf '"'"'\\033[38;5;208m%s\\033[0m'"'"' \"$v\"; else printf '"'"'\\033[32m%s\\033[0m'"'"' \"$v\"; fi; }; echo \"$name | Fe:$fe Ed:$ed Sh:$sh Ht:$ht Wt:$wt | HP:$(colorval $hp) Sp:$(colorval $sp) Su:$(colorval $su) Mo:$mo XP:$xp | is:$pv\""
   }'
 # The old default (stats, no XP/version) — used to detect an un-customized statusLine on upsert.
 OLD_STATUS_LINE_JSON='{
@@ -142,10 +147,17 @@ fi
 # scribe node_modules
 if [ -n "$PLUGIN_ROOT" ] && [ -d "$PLUGIN_ROOT/scribe/node_modules" ]; then
   echo "✓ scribe dependencies installed"
+elif [ -n "$PLUGIN_ROOT" ] && [ -d "$PLUGIN_ROOT/scribe" ]; then
+  echo "  → running bun install in scribe..."
+  if bun install --cwd "$PLUGIN_ROOT/scribe" 2>&1; then
+    echo "✓ scribe dependencies installed"
+  else
+    echo "✗ bun install failed — run manually: cd \"$PLUGIN_ROOT/scribe\" && bun install"
+  fi
 elif [ -n "$PLUGIN_ROOT" ]; then
-  echo "✗ scribe dependencies missing — run: cd \"$PLUGIN_ROOT/scribe\" && bun install"
+  echo "✗ scribe directory not found at $PLUGIN_ROOT/scribe"
 else
-  echo "? scribe path unknown (CLAUDE_PLUGIN_ROOT not set)"
+  echo "? scribe path unknown (CLAUDE_PLUGIN_ROOT not set and plugin not found in installed_plugins.json)"
 fi
 
 # Ollama reachable


### PR DESCRIPTION
## Summary
Enhance the ironsworn-init script to automatically resolve the plugin root from `installed_plugins.json` when `CLAUDE_PLUGIN_ROOT` is unset, and improve scribe dependency installation with automatic `bun install` fallback and better error messaging.

## Key Changes
- **Plugin root auto-discovery**: Added fallback logic to resolve `PLUGIN_ROOT` from `~/.claude/plugins/installed_plugins.json` using jq to find any installed plugin matching `ironsworn@*` pattern
- **Scribe dependency auto-install**: When `scribe/node_modules` is missing but `scribe/` directory exists, automatically attempt `bun install` instead of just reporting an error
- **Improved error messages**: Updated status messages to be more informative:
  - Distinguish between missing scribe directory vs. missing dependencies
  - Clarify when plugin root cannot be determined
  - Provide actionable fallback instructions if `bun install` fails
- **Version bump**: Updated plugin version from 0.22.2 to 0.22.3
- **Status line query fix**: Updated the hardcoded jq query in the status line JSON to use the same dynamic plugin key matching pattern (selecting any `ironsworn@*` plugin) instead of the hardcoded `ironsworn@agentic-ironsworn` key

## Implementation Details
The plugin root resolution uses the same jq pattern in two places:
1. At script initialization to set `PLUGIN_ROOT`
2. In the status line command to fetch the plugin version

Both now dynamically match any installed plugin starting with `ironsworn@`, making the script more resilient to plugin naming variations and installation paths.

https://claude.ai/code/session_01BXECpZNfrCjkohLixHodGe