### PR TITLE
feat(scribe): async beat queue — non-blocking record_beat (#145)

### DIFF
--- a/plugins/ironsworn/.claude-plugin/plugin.json
+++ b/plugins/ironsworn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ironsworn",
-  "version": "0.22.3",
+  "version": "0.23.0",
   "description": "Solo Ironsworn GM companion — fiction-first, dice-driven, with a living lore graph",
   "author": {
     "name": "Karim Naguib"

--- a/plugins/ironsworn/scribe/src/rag/beat-queue.test.ts
+++ b/plugins/ironsworn/scribe/src/rag/beat-queue.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, beforeEach, afterEach, afterAll, mock } from "bun:test";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+import { pushBeat, drainNotices, replayFailures, shutdown, _setRecordBeatFn, _resetRecordBeatFn } from "./beat-queue.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "beat-queue-test-"));
+}
+
+function cleanupTmpDir(dir: string): void {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("BeatQueue", () => {
+  let campaignPath: string;
+  let mockRecordBeat: ReturnType<typeof mock<(cp: string, sid: string, beat: unknown) => Promise<number>>>;
+
+  beforeEach(async () => {
+    campaignPath = makeTmpDir();
+    mockRecordBeat = mock(async () => 0);
+    _setRecordBeatFn(mockRecordBeat as unknown as (cp: string, sid: string, beat: import("./scenes.js").BeatInput) => Promise<number>);
+    await shutdown(campaignPath);
+  });
+
+  afterEach(() => {
+    cleanupTmpDir(campaignPath);
+  });
+
+  afterAll(() => {
+    _resetRecordBeatFn();
+  });
+
+  describe("pushBeat", () => {
+    it("returns an entry with a settled promise immediately", async () => {
+      const entry = await pushBeat(campaignPath, "scene-1", { kind: "narration", text: "The fire crackles." });
+      expect(entry).toHaveProperty("settled");
+      expect(entry.settled).toBeInstanceOf(Promise);
+    });
+
+    it("resolves settled promise after worker processes the beat", async () => {
+      const entry = await pushBeat(campaignPath, "scene-1", { kind: "narration", text: "The fire crackles." });
+      await entry.settled;
+      expect(mockRecordBeat).toHaveBeenCalledTimes(1);
+      expect(mockRecordBeat).toHaveBeenCalledWith(campaignPath, "scene-1", { kind: "narration", text: "The fire crackles." });
+    });
+
+    it("processes multiple beats in the order they were pushed", async () => {
+      const calls: string[] = [];
+      mockRecordBeat.mockImplementation(async (_cp, _sid, beat) => {
+        calls.push((beat as { text: string }).text);
+        return calls.length - 1;
+      });
+
+      const e1 = await pushBeat(campaignPath, "scene-1", { kind: "narration", text: "first" });
+      const e2 = await pushBeat(campaignPath, "scene-1", { kind: "narration", text: "second" });
+      const e3 = await pushBeat(campaignPath, "scene-1", { kind: "narration", text: "third" });
+
+      await Promise.all([e1.settled, e2.settled, e3.settled]);
+
+      expect(calls).toEqual(["first", "second", "third"]);
+    });
+
+    it("queues beats from different scenes serially (one worker per campaign)", async () => {
+      const order: string[] = [];
+      mockRecordBeat.mockImplementation(async (_cp, sceneId) => {
+        order.push(sceneId);
+        return 0;
+      });
+
+      const e1 = await pushBeat(campaignPath, "scene-A", { kind: "narration", text: "a" });
+      const e2 = await pushBeat(campaignPath, "scene-B", { kind: "narration", text: "b" });
+      await Promise.all([e1.settled, e2.settled]);
+
+      expect(order).toEqual(["scene-A", "scene-B"]);
+    });
+  });
+
+  describe("wait semantics", () => {
+    it("settled resolves only after recordBeat completes", async () => {
+      const order: string[] = [];
+      mockRecordBeat.mockImplementation(async () => {
+        order.push("recordBeat");
+        return 0;
+      });
+
+      const entry = await pushBeat(campaignPath, "scene-1", { kind: "narration", text: "x" });
+      await entry.settled;
+      order.push("settled");
+
+      // recordBeat must have run before settled resolved
+      expect(order[0]).toBe("recordBeat");
+      expect(order[1]).toBe("settled");
+    });
+
+    it("not awaiting settled does not block caller", async () => {
+      // pushBeat itself should resolve quickly even if worker is still running
+      let resolveRecord!: () => void;
+      mockRecordBeat.mockImplementation(
+        () => new Promise<number>((res) => { resolveRecord = () => res(0); }),
+      );
+
+      const before = Date.now();
+      const entry = await pushBeat(campaignPath, "scene-1", { kind: "narration", text: "x" });
+      const elapsed = Date.now() - before;
+
+      // pushBeat returned without waiting for the slow recordBeat
+      expect(elapsed).toBeLessThan(200);
+      expect(entry.settled).toBeInstanceOf(Promise);
+
+      // Clean up — resolve the pending worker so the queue drains
+      resolveRecord();
+      await entry.settled;
+    });
+  });
+
+  describe("failure handling", () => {
+    it("rejects settled promise when recordBeat throws", async () => {
+      mockRecordBeat.mockImplementation(async () => { throw new Error("Ollama unavailable"); });
+
+      const entry = await pushBeat(campaignPath, "scene-1", { kind: "narration", text: "x" });
+      await expect(entry.settled).rejects.toThrow("Ollama unavailable");
+    });
+
+    it("writes failed beat to beat-failures.jsonl sidecar", async () => {
+      mockRecordBeat.mockImplementation(async () => { throw new Error("Ollama unavailable"); });
+
+      const entry = await pushBeat(campaignPath, "scene-1", { kind: "narration", text: "lost beat" });
+      await entry.settled.catch(() => {});
+
+      const sidecar = path.join(campaignPath, "beat-failures.jsonl");
+      expect(fs.existsSync(sidecar)).toBe(true);
+
+      const lines = fs.readFileSync(sidecar, "utf8").trim().split("\n");
+      expect(lines).toHaveLength(1);
+      const record = JSON.parse(lines[0]!);
+      expect(record.sceneId).toBe("scene-1");
+      expect(record.beat.text).toBe("lost beat");
+      expect(record).toHaveProperty("failedAt");
+    });
+
+    it("queues a notice when recordBeat fails", async () => {
+      mockRecordBeat.mockImplementation(async () => { throw new Error("embed failed"); });
+
+      const entry = await pushBeat(campaignPath, "scene-1", { kind: "narration", text: "x" });
+      await entry.settled.catch(() => {});
+
+      const notices = drainNotices(campaignPath);
+      expect(notices.length).toBeGreaterThan(0);
+      expect(notices[0]).toContain("beat");
+    });
+
+    it("drainNotices clears the notice queue", async () => {
+      mockRecordBeat.mockImplementation(async () => { throw new Error("fail"); });
+      const entry = await pushBeat(campaignPath, "scene-1", { kind: "narration", text: "x" });
+      await entry.settled.catch(() => {});
+
+      drainNotices(campaignPath); // first drain
+      const second = drainNotices(campaignPath);
+      expect(second).toHaveLength(0);
+    });
+  });
+
+  describe("replayFailures", () => {
+    it("re-enqueues beats from beat-failures.jsonl on startup", async () => {
+      // Pre-populate a sidecar file
+      const sidecar = path.join(campaignPath, "beat-failures.jsonl");
+      const record = JSON.stringify({
+        sceneId: "scene-1",
+        beat: { kind: "narration", text: "replayed beat" },
+        failedAt: new Date().toISOString(),
+      });
+      fs.writeFileSync(sidecar, record + "\n");
+
+      await replayFailures(campaignPath);
+
+      // Give the worker time to run
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(mockRecordBeat).toHaveBeenCalledWith(
+        campaignPath,
+        "scene-1",
+        { kind: "narration", text: "replayed beat" },
+      );
+    });
+
+    it("removes the sidecar file after successful replay", async () => {
+      const sidecar = path.join(campaignPath, "beat-failures.jsonl");
+      const record = JSON.stringify({
+        sceneId: "scene-1",
+        beat: { kind: "narration", text: "replayed" },
+        failedAt: new Date().toISOString(),
+      });
+      fs.writeFileSync(sidecar, record + "\n");
+
+      await replayFailures(campaignPath);
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(fs.existsSync(sidecar)).toBe(false);
+    });
+
+    it("does nothing when no sidecar file exists", async () => {
+      await replayFailures(campaignPath); // should not throw
+      expect(mockRecordBeat).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/plugins/ironsworn/scribe/src/rag/beat-queue.test.ts
+++ b/plugins/ironsworn/scribe/src/rag/beat-queue.test.ts
@@ -39,6 +39,29 @@ describe("BeatQueue", () => {
     _resetRecordBeatFn();
   });
 
+  describe("worker error recovery", () => {
+    it("can process new beats after a prior catastrophic worker crash", async () => {
+      // Simulate a worker that throws *outside* the per-beat try/catch by
+      // making the first call throw synchronously before returning a number.
+      let callCount = 0;
+      mockRecordBeat.mockImplementation(async () => {
+        callCount++;
+        if (callCount === 1) throw new Error("catastrophic-crash");
+        return callCount - 2; // beat index for subsequent calls
+      });
+
+      // First beat — will fail; worker catches it and moves on
+      const e1 = await pushBeat(campaignPath, "scene-1", { kind: "narration", text: "bad" });
+      await e1.settled.catch(() => {}); // swallow the expected rejection
+
+      // Queue should still function — a second push must complete successfully
+      const e2 = await pushBeat(campaignPath, "scene-1", { kind: "narration", text: "good" });
+      await e2.settled;
+
+      expect(mockRecordBeat).toHaveBeenCalledTimes(2);
+    });
+  });
+
   describe("pushBeat", () => {
     it("returns an entry with a settled promise immediately", async () => {
       const entry = await pushBeat(campaignPath, "scene-1", { kind: "narration", text: "The fire crackles." });
@@ -158,6 +181,23 @@ describe("BeatQueue", () => {
       expect(notices[0]).toContain("beat");
     });
 
+    it("notice indicates permanent loss when sidecar write also fails", async () => {
+      // Make the recordBeat fail AND the sidecar write fail (read-only campaign dir)
+      mockRecordBeat.mockImplementation(async () => { throw new Error("db error"); });
+
+      // Use a campaign path that is a file (not a dir) so mkdirSync fails
+      const filePath = path.join(campaignPath, "not-a-dir");
+      fs.writeFileSync(filePath, "i am a file");
+
+      const entry = await pushBeat(filePath, "scene-1", { kind: "narration", text: "x" });
+      await entry.settled.catch(() => {});
+
+      const notices = drainNotices(filePath);
+      expect(notices.length).toBeGreaterThan(0);
+      // When the sidecar can't be written, the notice must warn the beat is permanently lost
+      expect(notices[0]).toContain("permanently lost");
+    });
+
     it("drainNotices clears the notice queue", async () => {
       mockRecordBeat.mockImplementation(async () => { throw new Error("fail"); });
       const entry = await pushBeat(campaignPath, "scene-1", { kind: "narration", text: "x" });
@@ -166,6 +206,36 @@ describe("BeatQueue", () => {
       drainNotices(campaignPath); // first drain
       const second = drainNotices(campaignPath);
       expect(second).toHaveLength(0);
+    });
+  });
+
+  describe("fire-and-forget response shape", () => {
+    it("beat_index is null before the worker processes the beat", async () => {
+      let resolveRecord!: (n: number) => void;
+      mockRecordBeat.mockImplementation(
+        () => new Promise<number>((res) => { resolveRecord = res; }),
+      );
+
+      const entry = await pushBeat(campaignPath, "scene-1", { kind: "narration", text: "pending" });
+      // beatIndex must be null before the worker completes (fire-and-forget semantics)
+      expect(entry.beatIndex).toBeNull();
+
+      // Resolve and wait — beatIndex is now set
+      resolveRecord(7);
+      await entry.settled;
+      expect(entry.beatIndex).toBe(7);
+    });
+
+    it("notices from prior failed beats surface on the next push call", async () => {
+      // First push fails, queuing a notice
+      mockRecordBeat.mockImplementationOnce(async () => { throw new Error("fail"); });
+      const e1 = await pushBeat(campaignPath, "scene-1", { kind: "narration", text: "a" });
+      await e1.settled.catch(() => {});
+
+      // drainNotices now returns the notice from the failed beat
+      const notices = drainNotices(campaignPath);
+      expect(notices.length).toBeGreaterThan(0);
+      expect(notices[0]).toContain("beat write failed");
     });
   });
 
@@ -180,10 +250,8 @@ describe("BeatQueue", () => {
       });
       fs.writeFileSync(sidecar, record + "\n");
 
-      await replayFailures(campaignPath);
-
-      // Give the worker time to run
-      await new Promise((r) => setTimeout(r, 50));
+      const entries = await replayFailures(campaignPath);
+      await Promise.allSettled(entries.map((e) => e.settled));
 
       expect(mockRecordBeat).toHaveBeenCalledWith(
         campaignPath,
@@ -201,15 +269,48 @@ describe("BeatQueue", () => {
       });
       fs.writeFileSync(sidecar, record + "\n");
 
-      await replayFailures(campaignPath);
-      await new Promise((r) => setTimeout(r, 50));
+      const entries = await replayFailures(campaignPath);
+      await Promise.allSettled(entries.map((e) => e.settled));
 
       expect(fs.existsSync(sidecar)).toBe(false);
     });
 
     it("does nothing when no sidecar file exists", async () => {
-      await replayFailures(campaignPath); // should not throw
+      const entries = await replayFailures(campaignPath); // should not throw
+      expect(entries).toHaveLength(0);
       expect(mockRecordBeat).not.toHaveBeenCalled();
+    });
+
+    it("returns entries that settle without relying on a timer", async () => {
+      // This test replaces the flaky setTimeout(50) pattern — replay entries must
+      // be directly awaitable so tests are deterministic on slow CI.
+      const sidecar = path.join(campaignPath, "beat-failures.jsonl");
+      const lines = [
+        JSON.stringify({ sceneId: "s1", beat: { kind: "narration", text: "beat-A" }, failedAt: new Date().toISOString() }),
+        JSON.stringify({ sceneId: "s2", beat: { kind: "narration", text: "beat-B" }, failedAt: new Date().toISOString() }),
+      ];
+      fs.writeFileSync(sidecar, lines.join("\n") + "\n");
+
+      const entries = await replayFailures(campaignPath);
+      expect(entries).toHaveLength(2);
+
+      // Await all settled promises — no timer needed
+      await Promise.allSettled(entries.map((e) => e.settled));
+
+      expect(mockRecordBeat).toHaveBeenCalledTimes(2);
+    });
+
+    it("skips malformed JSONL lines and still replays valid ones", async () => {
+      const sidecar = path.join(campaignPath, "beat-failures.jsonl");
+      const valid = JSON.stringify({ sceneId: "s1", beat: { kind: "narration", text: "good" }, failedAt: new Date().toISOString() });
+      fs.writeFileSync(sidecar, `not-valid-json\n${valid}\n{truncated`);
+
+      const entries = await replayFailures(campaignPath);
+      await Promise.allSettled(entries.map((e) => e.settled));
+
+      // Only the valid record was replayed
+      expect(mockRecordBeat).toHaveBeenCalledTimes(1);
+      expect(mockRecordBeat).toHaveBeenCalledWith(campaignPath, "s1", { kind: "narration", text: "good" });
     });
   });
 });

--- a/plugins/ironsworn/scribe/src/rag/beat-queue.ts
+++ b/plugins/ironsworn/scribe/src/rag/beat-queue.ts
@@ -1,0 +1,254 @@
+/**
+ * BeatQueue — async fire-and-forget beat persistence.
+ *
+ * The MCP `record_beat` tool pushes entries here and returns immediately.
+ * A serial worker per campaign path drains the queue in the background,
+ * calling `recordBeat` from scenes.ts for each entry.
+ *
+ * On failure:
+ *  - The failed beat is appended to `<campaignPath>/beat-failures.jsonl`
+ *  - An error notice is queued for the agent to see on its next tool response
+ *  - `entry.settled` rejects so callers using `wait: true` learn immediately
+ *
+ * On server startup, call `replayFailures(campaignPath)` to re-enqueue any
+ * beats that failed in a previous session.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import { recordBeat as _defaultRecordBeat } from "./scenes.js";
+import type { BeatInput } from "./scenes.js";
+
+// ---------------------------------------------------------------------------
+// Pluggable recordBeat — injectable for testing without module-level mocking
+// ---------------------------------------------------------------------------
+
+type RecordBeatFn = (campaignPath: string, sceneId: string, beat: BeatInput) => Promise<number>;
+
+let _recordBeat: RecordBeatFn = _defaultRecordBeat;
+
+/**
+ * Override the `recordBeat` implementation used by the queue worker.
+ * Intended for unit tests only — not part of the public production API.
+ */
+export function _setRecordBeatFn(fn: RecordBeatFn): void {
+  _recordBeat = fn;
+}
+
+/** Restore the default implementation (call in afterAll/afterEach in tests). */
+export function _resetRecordBeatFn(): void {
+  _recordBeat = _defaultRecordBeat;
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface BeatQueueEntry {
+  campaignPath: string;
+  sceneId: string;
+  beat: BeatInput;
+  /**
+   * The 0-based index of the beat in its scene, set by the worker after
+   * `recordBeat` completes. `null` until then (i.e. before `settled` resolves).
+   */
+  beatIndex: number | null;
+  /** Resolves when the worker persists the beat; rejects on failure. */
+  settled: Promise<void>;
+  /** @internal */
+  _resolve: () => void;
+  /** @internal */
+  _reject: (e: unknown) => void;
+}
+
+interface FailureRecord {
+  sceneId: string;
+  beat: BeatInput;
+  failedAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// Module state — one queue + worker flag per campaign path
+// ---------------------------------------------------------------------------
+
+const _queues = new Map<string, BeatQueueEntry[]>();
+const _workerRunning = new Map<string, boolean>();
+const _notices = new Map<string, string[]>();
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Push a beat onto the async queue and return an entry whose `settled` promise
+ * resolves when the worker has persisted it (or rejects on failure).
+ *
+ * Returns immediately — the caller does NOT need to await this function, but
+ * can await `entry.settled` if it needs to block (e.g. before export).
+ */
+export async function pushBeat(
+  campaignPath: string,
+  sceneId: string,
+  beat: BeatInput,
+): Promise<BeatQueueEntry> {
+  let _resolve!: () => void;
+  let _reject!: (e: unknown) => void;
+  const settled = new Promise<void>((res, rej) => {
+    _resolve = res;
+    _reject = rej;
+  });
+
+  const entry: BeatQueueEntry = { campaignPath, sceneId, beat, beatIndex: null, settled, _resolve, _reject };
+
+  if (!_queues.has(campaignPath)) {
+    _queues.set(campaignPath, []);
+  }
+  _queues.get(campaignPath)!.push(entry);
+
+  void _ensureWorker(campaignPath);
+
+  return entry;
+}
+
+/**
+ * Drain and return any pending error notices for this campaign.
+ * Call this in every MCP tool handler before returning to the agent so
+ * failures surface naturally on the next interaction.
+ */
+export function drainNotices(campaignPath: string): string[] {
+  const notices = _notices.get(campaignPath) ?? [];
+  _notices.set(campaignPath, []);
+  return notices;
+}
+
+/**
+ * Re-enqueue any beats recorded in `beat-failures.jsonl` from a previous
+ * session. Call once on server startup before registering tools.
+ */
+export async function replayFailures(campaignPath: string): Promise<void> {
+  const sidecar = _sidecarPath(campaignPath);
+  if (!fs.existsSync(sidecar)) return;
+
+  let lines: string[];
+  try {
+    lines = fs.readFileSync(sidecar, "utf8").trim().split("\n").filter(Boolean);
+  } catch {
+    return;
+  }
+
+  const records: FailureRecord[] = [];
+  for (const line of lines) {
+    try {
+      records.push(JSON.parse(line) as FailureRecord);
+    } catch {
+      // malformed line — skip
+    }
+  }
+
+  if (records.length === 0) {
+    _removeSidecar(campaignPath);
+    return;
+  }
+
+  // Re-enqueue; remove the sidecar optimistically — if replay fails again,
+  // the worker will write a fresh sidecar entry.
+  _removeSidecar(campaignPath);
+
+  for (const record of records) {
+    await pushBeat(campaignPath, record.sceneId, record.beat);
+  }
+}
+
+/**
+ * Drain the queue for a campaign path and wait for the worker to finish.
+ * Useful in tests and graceful-shutdown paths.
+ */
+export async function shutdown(campaignPath: string): Promise<void> {
+  const queue = _queues.get(campaignPath);
+  if (!queue || queue.length === 0) {
+    _queues.delete(campaignPath);
+    _workerRunning.delete(campaignPath);
+    return;
+  }
+  // Wait for all settled promises (ignoring rejections — callers handle those)
+  const entries = [...queue];
+  await Promise.allSettled(entries.map((e) => e.settled));
+  _queues.delete(campaignPath);
+  _workerRunning.delete(campaignPath);
+}
+
+// ---------------------------------------------------------------------------
+// Worker
+// ---------------------------------------------------------------------------
+
+function _ensureWorker(campaignPath: string): void {
+  if (_workerRunning.get(campaignPath)) return;
+  _workerRunning.set(campaignPath, true);
+  void _runWorker(campaignPath);
+}
+
+async function _runWorker(campaignPath: string): Promise<void> {
+  const queue = _queues.get(campaignPath);
+  if (!queue) {
+    _workerRunning.set(campaignPath, false);
+    return;
+  }
+
+  while (queue.length > 0) {
+    const entry = queue[0]!;
+    try {
+      entry.beatIndex = await _recordBeat(campaignPath, entry.sceneId, entry.beat);
+      entry._resolve();
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      _appendSidecar(campaignPath, entry);
+      _queueNotice(campaignPath, `[scribe] beat write failed for scene ${entry.sceneId}: ${msg}. Beat saved to beat-failures.jsonl for replay on next startup.`);
+      process.stderr.write(`[scribe] beat-queue: failed to persist beat for scene ${entry.sceneId}: ${msg}\n`);
+      entry._reject(e);
+    }
+    queue.shift();
+  }
+
+  _workerRunning.set(campaignPath, false);
+}
+
+// ---------------------------------------------------------------------------
+// Notices
+// ---------------------------------------------------------------------------
+
+function _queueNotice(campaignPath: string, notice: string): void {
+  if (!_notices.has(campaignPath)) {
+    _notices.set(campaignPath, []);
+  }
+  _notices.get(campaignPath)!.push(notice);
+}
+
+// ---------------------------------------------------------------------------
+// Sidecar helpers
+// ---------------------------------------------------------------------------
+
+function _sidecarPath(campaignPath: string): string {
+  return path.join(campaignPath, "beat-failures.jsonl");
+}
+
+function _appendSidecar(campaignPath: string, entry: BeatQueueEntry): void {
+  const record: FailureRecord = {
+    sceneId: entry.sceneId,
+    beat: entry.beat,
+    failedAt: new Date().toISOString(),
+  };
+  try {
+    fs.mkdirSync(campaignPath, { recursive: true });
+    fs.appendFileSync(_sidecarPath(campaignPath), JSON.stringify(record) + "\n", "utf8");
+  } catch (e) {
+    process.stderr.write(`[scribe] beat-queue: could not write sidecar: ${e}\n`);
+  }
+}
+
+function _removeSidecar(campaignPath: string): void {
+  try {
+    fs.unlinkSync(_sidecarPath(campaignPath));
+  } catch {
+    // Already gone — fine
+  }
+}

--- a/plugins/ironsworn/scribe/src/rag/beat-queue.ts
+++ b/plugins/ironsworn/scribe/src/rag/beat-queue.ts
@@ -124,16 +124,20 @@ export function drainNotices(campaignPath: string): string[] {
 /**
  * Re-enqueue any beats recorded in `beat-failures.jsonl` from a previous
  * session. Call once on server startup before registering tools.
+ *
+ * Returns the enqueued entries so callers can await their settled promises
+ * deterministically (no setTimeout needed in tests or shutdown paths).
  */
-export async function replayFailures(campaignPath: string): Promise<void> {
+export async function replayFailures(campaignPath: string): Promise<BeatQueueEntry[]> {
   const sidecar = _sidecarPath(campaignPath);
-  if (!fs.existsSync(sidecar)) return;
+  if (!fs.existsSync(sidecar)) return [];
 
   let lines: string[];
   try {
     lines = fs.readFileSync(sidecar, "utf8").trim().split("\n").filter(Boolean);
-  } catch {
-    return;
+  } catch (e) {
+    process.stderr.write(`[scribe] beat-queue: could not read sidecar ${sidecar}: ${e}\n`);
+    return [];
   }
 
   const records: FailureRecord[] = [];
@@ -141,22 +145,24 @@ export async function replayFailures(campaignPath: string): Promise<void> {
     try {
       records.push(JSON.parse(line) as FailureRecord);
     } catch {
-      // malformed line — skip
+      process.stderr.write(`[scribe] beat-queue: skipping malformed failure record: ${JSON.stringify(line.slice(0, 200))}\n`);
     }
   }
 
   if (records.length === 0) {
     _removeSidecar(campaignPath);
-    return;
+    return [];
   }
 
   // Re-enqueue; remove the sidecar optimistically — if replay fails again,
   // the worker will write a fresh sidecar entry.
   _removeSidecar(campaignPath);
 
+  const entries: BeatQueueEntry[] = [];
   for (const record of records) {
-    await pushBeat(campaignPath, record.sceneId, record.beat);
+    entries.push(await pushBeat(campaignPath, record.sceneId, record.beat));
   }
+  return entries;
 }
 
 /**
@@ -184,7 +190,12 @@ export async function shutdown(campaignPath: string): Promise<void> {
 function _ensureWorker(campaignPath: string): void {
   if (_workerRunning.get(campaignPath)) return;
   _workerRunning.set(campaignPath, true);
-  void _runWorker(campaignPath);
+  _runWorker(campaignPath).catch((err: unknown) => {
+    // Defensive guard — _runWorker's while-loop already catches per-beat errors,
+    // so this only fires on truly unexpected failures (programming errors, OOM, etc.)
+    process.stderr.write(`[scribe] beat-queue: worker crashed unexpectedly for ${campaignPath}: ${err}\n`);
+    _workerRunning.set(campaignPath, false);
+  });
 }
 
 async function _runWorker(campaignPath: string): Promise<void> {
@@ -201,8 +212,11 @@ async function _runWorker(campaignPath: string): Promise<void> {
       entry._resolve();
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
-      _appendSidecar(campaignPath, entry);
-      _queueNotice(campaignPath, `[scribe] beat write failed for scene ${entry.sceneId}: ${msg}. Beat saved to beat-failures.jsonl for replay on next startup.`);
+      const sidecarOk = _appendSidecar(campaignPath, entry);
+      const noticeDetail = sidecarOk
+        ? "Beat saved to beat-failures.jsonl for replay on next startup."
+        : "Sidecar write also failed — beat is permanently lost and will NOT be replayed.";
+      _queueNotice(campaignPath, `[scribe] beat write failed for scene ${entry.sceneId}: ${msg}. ${noticeDetail}`);
       process.stderr.write(`[scribe] beat-queue: failed to persist beat for scene ${entry.sceneId}: ${msg}\n`);
       entry._reject(e);
     }
@@ -231,7 +245,8 @@ function _sidecarPath(campaignPath: string): string {
   return path.join(campaignPath, "beat-failures.jsonl");
 }
 
-function _appendSidecar(campaignPath: string, entry: BeatQueueEntry): void {
+/** Returns true if the sidecar was written successfully, false on failure. */
+function _appendSidecar(campaignPath: string, entry: BeatQueueEntry): boolean {
   const record: FailureRecord = {
     sceneId: entry.sceneId,
     beat: entry.beat,
@@ -240,8 +255,10 @@ function _appendSidecar(campaignPath: string, entry: BeatQueueEntry): void {
   try {
     fs.mkdirSync(campaignPath, { recursive: true });
     fs.appendFileSync(_sidecarPath(campaignPath), JSON.stringify(record) + "\n", "utf8");
+    return true;
   } catch (e) {
-    process.stderr.write(`[scribe] beat-queue: could not write sidecar: ${e}\n`);
+    process.stderr.write(`[scribe] beat-queue: could not write sidecar — beat permanently lost: ${e}\n`);
+    return false;
   }
 }
 

--- a/plugins/ironsworn/scribe/src/server.ts
+++ b/plugins/ironsworn/scribe/src/server.ts
@@ -10,6 +10,7 @@ import { loadExpansions } from "./expansions/loader.js";
 import { checkpointLore } from "./rag/lore.js";
 import { checkpointScenes } from "./rag/scenes.js";
 import { startPeriodicCheckpoint } from "./checkpoint.js";
+import { replayFailures, shutdown as drainBeatQueue } from "./rag/beat-queue.js";
 
 const CAMPAIGN_PATH = process.env.SCRIBE_CAMPAIGN ?? "campaigns/default";
 
@@ -27,6 +28,11 @@ campaignTools.register(server, CAMPAIGN_PATH);
 
 await loadExpansions(server, CAMPAIGN_PATH);
 
+// Replay any beats that failed to persist in a previous session
+await replayFailures(CAMPAIGN_PATH).catch((e: unknown) => {
+  process.stderr.write(`[scribe] beat replay failed: ${e}\n`);
+});
+
 // ---------------------------------------------------------------------------
 // Graceful shutdown — flush WAL before the process exits
 // ---------------------------------------------------------------------------
@@ -38,7 +44,10 @@ await loadExpansions(server, CAMPAIGN_PATH);
 // loses all campaign data.
 
 async function shutdown(signal: string): Promise<void> {
-  process.stderr.write(`[scribe] ${signal} received — checkpointing DuckDB…\n`);
+  process.stderr.write(`[scribe] ${signal} received — draining beat queue and checkpointing DuckDB…\n`);
+  await drainBeatQueue(CAMPAIGN_PATH).catch((e: unknown) => {
+    process.stderr.write(`[scribe] beat queue drain failed: ${e}\n`);
+  });
   await Promise.all([
     checkpointLore(CAMPAIGN_PATH).catch((e: unknown) => {
       process.stderr.write(`[scribe] lore checkpoint failed: ${e}\n`);

--- a/plugins/ironsworn/scribe/src/tools/campaign.ts
+++ b/plugins/ironsworn/scribe/src/tools/campaign.ts
@@ -8,6 +8,7 @@ import { listNpcs, writeNpcRaw } from "../state/npcs.js";
 import { exportLore, exportProvenance, upsertLore, linkLore, checkpointLore, replayProvenance, type LoreType } from "../rag/lore.js";
 import { exportProximity, linkProximity, type ProximityDimension, type CompassPoint, type OrderKind } from "../rag/proximity.js";
 import { exportScenes, importScene, checkpointScenes, type BeatExport } from "../rag/scenes.js";
+import { shutdown as drainBeatQueue } from "../rag/beat-queue.js";
 
 interface CampaignExport {
   version: 2;
@@ -29,6 +30,8 @@ export function register(server: McpServer, campaignPath: string): void {
     {},
     async () => {
       try {
+        // Drain any queued beats before checkpointing so they're included
+        await drainBeatQueue(campaignPath);
         await Promise.all([
           checkpointLore(campaignPath),
           checkpointScenes(campaignPath),
@@ -54,6 +57,9 @@ export function register(server: McpServer, campaignPath: string): void {
     },
     async ({ output_path, include_scenes }) => {
       try {
+        // Drain any queued beats before checkpointing so the export reflects
+        // all beats pushed during this session, regardless of wait=true/false.
+        await drainBeatQueue(campaignPath);
         // Flush WAL to the .duckdb files before reading so the export reflects
         // all in-memory writes. Without CHECKPOINT the tracked binaries stay
         // frozen and a clone / crash loses all session data.

--- a/plugins/ironsworn/scribe/src/tools/narrative.test.ts
+++ b/plugins/ironsworn/scribe/src/tools/narrative.test.ts
@@ -161,7 +161,7 @@ describe("record_beat tool", () => {
     await client.connect(clientTransport);
   });
 
-  it("happy path: appends a beat and returns correct beat_index", async () => {
+  it("happy path: queues a beat and returns queued:true (fire-and-forget)", async () => {
     if (!(await ollamaAvailable())) return;
     const sceneId = await recordScene(campaignDir, "An ambush at the forest edge.", "combat");
 
@@ -171,15 +171,28 @@ describe("record_beat tool", () => {
     });
     expect(result.isError).not.toBe(true);
     const parsed = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+    expect(parsed.queued).toBe(true);
+  });
+
+  it("wait=true blocks until beat is persisted and returns the real beat_index", async () => {
+    if (!(await ollamaAvailable())) return;
+    const sceneId = await recordScene(campaignDir, "An ambush at the forest edge.", "combat");
+
+    const result = await client.callTool({
+      name: "record_beat",
+      arguments: { scene_id: sceneId, kind: "narration", text: "Arrows fly from the shadows.", wait: true },
+    });
+    expect(result.isError).not.toBe(true);
+    const parsed = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
     expect(parsed.beat_index).toBe(0);
   });
 
-  it("sequential calls return incrementing indices", async () => {
+  it("sequential wait=true calls return incrementing indices", async () => {
     if (!(await ollamaAvailable())) return;
     const sceneId = await recordScene(campaignDir, "A social encounter.", "social");
 
-    const r1 = await client.callTool({ name: "record_beat", arguments: { scene_id: sceneId, kind: "narration", text: "The fire crackles." } });
-    const r2 = await client.callTool({ name: "record_beat", arguments: { scene_id: sceneId, kind: "dialogue", speaker: "Kira", text: "You came back." } });
+    const r1 = await client.callTool({ name: "record_beat", arguments: { scene_id: sceneId, kind: "narration", text: "The fire crackles.", wait: true } });
+    const r2 = await client.callTool({ name: "record_beat", arguments: { scene_id: sceneId, kind: "dialogue", speaker: "Kira", text: "You came back.", wait: true } });
 
     expect(r1.isError).not.toBe(true);
     expect(r2.isError).not.toBe(true);
@@ -189,13 +202,13 @@ describe("record_beat tool", () => {
     expect(p2.beat_index).toBe(1);
   });
 
-  it("beat is persisted — subsequent getScene shows the beat", async () => {
+  it("beat is persisted — wait=true then getScene shows the beat", async () => {
     if (!(await ollamaAvailable())) return;
     const sceneId = await recordScene(campaignDir, "A brief exploration.", "exploration");
 
     await client.callTool({
       name: "record_beat",
-      arguments: { scene_id: sceneId, kind: "oracle", text: "The oracle whispers: fire and shadow." },
+      arguments: { scene_id: sceneId, kind: "oracle", text: "The oracle whispers: fire and shadow.", wait: true },
     });
 
     const scene = await getScene(campaignDir, sceneId, { include_beats: true });

--- a/plugins/ironsworn/scribe/src/tools/narrative.ts
+++ b/plugins/ironsworn/scribe/src/tools/narrative.ts
@@ -192,11 +192,16 @@ export function register(server: McpServer, campaignPath: string): void {
         try {
           await entry.settled;
         } catch (e) {
+          // Drain notices accumulated from prior beats before returning error —
+          // include them in the response body so the agent sees them even on failure.
           const notices = drainNotices(campaignPath);
+          const body: Record<string, unknown> = {
+            error: e instanceof Error ? e.message : String(e),
+          };
+          if (notices.length > 0) body.notices = notices;
           return {
-            content: [{ type: "text", text: `Error: beat write failed: ${e instanceof Error ? e.message : String(e)}` }],
+            content: [{ type: "text", text: JSON.stringify(body) }],
             isError: true,
-            ...(notices.length > 0 ? { _notices: notices } : {}),
           };
         }
       }
@@ -210,8 +215,13 @@ export function register(server: McpServer, campaignPath: string): void {
         void server.sendLoggingMessage({ level: "warning", data: notice });
       }
 
+      // Omit beat_index when null (fire-and-forget path — worker hasn't run yet)
+      const responseBody: Record<string, unknown> = { queued: true };
+      if (entry.beatIndex !== null) responseBody.beat_index = entry.beatIndex;
+      if (notices.length > 0) responseBody.notices = notices;
+
       return {
-        content: [{ type: "text", text: JSON.stringify({ queued: true, beat_index: entry.beatIndex, ...(notices.length > 0 ? { notices } : {}) }) }],
+        content: [{ type: "text", text: JSON.stringify(responseBody) }],
       };
     },
   );

--- a/plugins/ironsworn/scribe/src/tools/narrative.ts
+++ b/plugins/ironsworn/scribe/src/tools/narrative.ts
@@ -6,6 +6,7 @@ import { upsertNpc, getNpc } from "../state/npcs.js";
 import { getLore, upsertLore } from "../rag/lore.js";
 import { loadCharacter, saveCharacter, ProgressTrack } from "../state/character.js";
 import { recordMutation } from "../checkpoint.js";
+import { pushBeat, drainNotices } from "../rag/beat-queue.js";
 
 const BeatInputSchema = z.object({
   kind: z.enum(["narration", "dialogue", "move", "choice", "oracle"]).describe(
@@ -158,7 +159,9 @@ export function register(server: McpServer, campaignPath: string): void {
 
   server.tool(
     "record_beat",
-    "Append a single beat to an existing scene in real time, as events happen during play. Returns the 0-based index of the appended beat.",
+    "Append a single beat to an existing scene in real time, as events happen during play. " +
+    "Returns immediately by default (fire-and-forget); the embedding and DB write happen in the background. " +
+    "Pass wait=true only when you need the beat fully persisted before continuing (e.g. before export_campaign or close_scene).",
     {
       scene_id: z.string().describe("ID of the scene to append the beat to"),
       kind: z.enum(["dialogue", "narration", "move", "choice", "oracle"]).describe(
@@ -169,20 +172,47 @@ export function register(server: McpServer, campaignPath: string): void {
       metadata: z.record(z.string(), z.unknown()).optional().describe(
         "Structured data for move beats (e.g. {move: 'Face Danger', stat: 'edge', outcome: 'weak_hit'})"
       ),
+      wait: z.boolean().optional().describe(
+        "If true, block until the beat is fully persisted before returning. Default: false (fire-and-forget)."
+      ),
     },
-    async ({ scene_id, kind, text, speaker, metadata }) => {
-      try {
-        const beatIndex = await recordBeat(campaignPath, scene_id, { kind, text, speaker, metadata });
-        recordMutation(campaignPath);
+    async ({ scene_id, kind, text, speaker, metadata, wait }) => {
+      // Validate scene exists synchronously — cheap read, surfaces errors immediately
+      const existing = await getScene(campaignPath, scene_id);
+      if (existing === null) {
         return {
-          content: [{ type: "text", text: JSON.stringify({ beat_index: beatIndex }) }],
-        };
-      } catch (e) {
-        return {
-          content: [{ type: "text", text: `Error: ${e instanceof Error ? e.message : String(e)}` }],
+          content: [{ type: "text", text: `Error: Scene not found: ${scene_id}` }],
           isError: true,
         };
       }
+
+      const entry = await pushBeat(campaignPath, scene_id, { kind, text, speaker, metadata });
+
+      if (wait) {
+        try {
+          await entry.settled;
+        } catch (e) {
+          const notices = drainNotices(campaignPath);
+          return {
+            content: [{ type: "text", text: `Error: beat write failed: ${e instanceof Error ? e.message : String(e)}` }],
+            isError: true,
+            ...(notices.length > 0 ? { _notices: notices } : {}),
+          };
+        }
+      }
+
+      recordMutation(campaignPath);
+
+      // Drain any notices from prior failed beats and surface them to the agent
+      const notices = drainNotices(campaignPath);
+      // Best-effort MCP log notification (may or may not surface in agent context)
+      for (const notice of notices) {
+        void server.sendLoggingMessage({ level: "warning", data: notice });
+      }
+
+      return {
+        content: [{ type: "text", text: JSON.stringify({ queued: true, beat_index: entry.beatIndex, ...(notices.length > 0 ? { notices } : {}) }) }],
+      };
     },
   );
 


### PR DESCRIPTION
Closes #145

## What changed

`record_beat` no longer blocks the player while Ollama computes the embedding. The tool returns immediately; a serial background worker per campaign path handles embedding + DuckDB write.

## New module: `rag/beat-queue.ts`

- `pushBeat(campaignPath, sceneId, beat)` — queues the beat, returns an entry with a `settled: Promise<void>` the caller can optionally await
- `drainNotices(campaignPath)` — returns any error notices from failed background writes (called by the tool handler on every response)
- `replayFailures(campaignPath)` — re-enqueues beats from `beat-failures.jsonl` on server startup
- `_setRecordBeatFn` / `_resetRecordBeatFn` — DI seam for tests (avoids `mock.module` leakage across test files)

## Changes to `record_beat` tool

- Returns `{ queued: true, beat_index: null }` by default (fire-and-forget)
- New optional `wait?: boolean` — pass `true` to block until the beat is persisted (e.g. before `export_campaign` or `close_scene`); returns the real `beat_index` in that case
- Scene existence is validated synchronously before queuing (cheap read, surfaces errors immediately)
- Error notices from prior failed beats are piggybacked on the response
- `server.sendLoggingMessage()` fires a best-effort MCP warning notification on failure

## Failure path

1. Worker catches the error → appends to `<campaignPath>/beat-failures.jsonl`
2. Notice queued for agent's next tool response
3. `settled` promise rejects (callers using `wait: true` learn immediately)
4. On next server start, `replayFailures()` re-enqueues from the sidecar

## Tests

- 13 new tests in `beat-queue.test.ts` covering ordering, wait semantics, failure → sidecar, notice drain, and sidecar replay
- Updated `narrative.test.ts` to reflect async semantics; added `wait=true` coverage

## Plugin version

`0.22.3` → `0.23.0` (minor — new feature)

🤖 Generated with [Claude Code](https://claude.com/claude-code)