### PR TITLE
Add campaign-level expansion enablement via expansions.json

### DIFF
--- a/plugins/ironsworn/.claude-plugin/plugin.json
+++ b/plugins/ironsworn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ironsworn",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "description": "Solo Ironsworn GM companion — fiction-first, dice-driven, with a living lore graph",
   "author": {
     "name": "Karim Naguib"

--- a/plugins/ironsworn/scribe/src/expansions/loader.test.ts
+++ b/plugins/ironsworn/scribe/src/expansions/loader.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
 import { mkdtemp, rm, writeFile, mkdir, readFile } from "node:fs/promises";
 import { join, resolve, dirname } from "node:path";
 import { tmpdir } from "node:os";
@@ -9,12 +9,16 @@ const STUB_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "stub");
 
 describe("discoverExpansions", () => {
   let tmpDir: string;
+  let campaignDir: string;
   const savedEnv: Record<string, string | undefined> = {};
 
   beforeEach(async () => {
     tmpDir = await mkdtemp(join(tmpdir(), "scribe-loader-"));
+    campaignDir = join(tmpDir, "campaign");
+    await mkdir(campaignDir, { recursive: true });
     savedEnv["SCRIBE_PLUGINS_JSON"] = process.env["SCRIBE_PLUGINS_JSON"];
     savedEnv["SCRIBE_EXPANSIONS"] = process.env["SCRIBE_EXPANSIONS"];
+    savedEnv["SCRIBE_CAMPAIGN"] = process.env["SCRIBE_CAMPAIGN"];
   });
 
   afterEach(async () => {
@@ -25,11 +29,19 @@ describe("discoverExpansions", () => {
     await rm(tmpDir, { recursive: true, force: true });
   });
 
+  async function makePluginsJson(plugins: Record<string, unknown> = {}) {
+    const pluginsJson = join(tmpDir, "plugins.json");
+    await writeFile(pluginsJson, JSON.stringify({ version: 2, plugins }));
+    process.env["SCRIBE_PLUGINS_JSON"] = pluginsJson;
+    return pluginsJson;
+  }
+
+  // --- Original tests (regression) ---
+
   it("returns empty when SCRIBE_EXPANSIONS is unset", async () => {
     delete process.env["SCRIBE_EXPANSIONS"];
-    const pluginsJson = join(tmpDir, "plugins.json");
-    await writeFile(pluginsJson, JSON.stringify({ version: 2, plugins: {} }));
-    process.env["SCRIBE_PLUGINS_JSON"] = pluginsJson;
+    delete process.env["SCRIBE_CAMPAIGN"];
+    await makePluginsJson();
     const { discoverExpansions } = await import(`./loader.ts?t=${Date.now()}`);
     const result = await discoverExpansions();
     expect(result).toEqual([]);
@@ -45,14 +57,9 @@ describe("discoverExpansions", () => {
 
   it("discovers a valid expansion by installPath", async () => {
     process.env["SCRIBE_EXPANSIONS"] = "stub";
-    const pluginsJson = join(tmpDir, "plugins.json");
-    await writeFile(pluginsJson, JSON.stringify({
-      version: 2,
-      plugins: {
-        "ironsworn-stub@test-repo": [{ installPath: STUB_DIR, version: "1.0.0", scope: "user" }],
-      },
-    }));
-    process.env["SCRIBE_PLUGINS_JSON"] = pluginsJson;
+    await makePluginsJson({
+      "ironsworn-stub@test-repo": [{ installPath: STUB_DIR, version: "1.0.0", scope: "user" }],
+    });
     const { discoverExpansions } = await import(`./loader.ts?t=${Date.now()}`);
     const result = await discoverExpansions();
     expect(result).toHaveLength(1);
@@ -62,14 +69,9 @@ describe("discoverExpansions", () => {
 
   it("skips expansions not in SCRIBE_EXPANSIONS allow-list", async () => {
     process.env["SCRIBE_EXPANSIONS"] = "other";
-    const pluginsJson = join(tmpDir, "plugins.json");
-    await writeFile(pluginsJson, JSON.stringify({
-      version: 2,
-      plugins: {
-        "ironsworn-stub@test-repo": [{ installPath: STUB_DIR, version: "1.0.0", scope: "user" }],
-      },
-    }));
-    process.env["SCRIBE_PLUGINS_JSON"] = pluginsJson;
+    await makePluginsJson({
+      "ironsworn-stub@test-repo": [{ installPath: STUB_DIR, version: "1.0.0", scope: "user" }],
+    });
     const { discoverExpansions } = await import(`./loader.ts?t=${Date.now()}`);
     const result = await discoverExpansions();
     expect(result).toEqual([]);
@@ -77,17 +79,133 @@ describe("discoverExpansions", () => {
 
   it("skips expansion with no expansion.json", async () => {
     process.env["SCRIBE_EXPANSIONS"] = "missing";
-    const pluginsJson = join(tmpDir, "plugins.json");
-    await writeFile(pluginsJson, JSON.stringify({
-      version: 2,
-      plugins: {
-        "ironsworn-missing@test-repo": [{ installPath: join(tmpDir, "no-such-dir"), version: "1.0.0", scope: "user" }],
-      },
-    }));
-    process.env["SCRIBE_PLUGINS_JSON"] = pluginsJson;
+    await makePluginsJson({
+      "ironsworn-missing@test-repo": [{ installPath: join(tmpDir, "no-such-dir"), version: "1.0.0", scope: "user" }],
+    });
     const { discoverExpansions } = await import(`./loader.ts?t=${Date.now()}`);
     const result = await discoverExpansions();
     expect(result).toEqual([]);
+  });
+
+  // --- New tests: campaign expansions.json ---
+
+  it("enables expansion from file when env is unset (file-only enablement)", async () => {
+    delete process.env["SCRIBE_EXPANSIONS"];
+    await makePluginsJson({
+      "ironsworn-stub@test-repo": [{ installPath: STUB_DIR, version: "1.0.0", scope: "user" }],
+    });
+    await writeFile(
+      join(campaignDir, "expansions.json"),
+      JSON.stringify({ enabled: ["stub"] }),
+    );
+    const { discoverExpansions } = await import(`./loader.ts?t=${Date.now()}`);
+    const result = await discoverExpansions(campaignDir);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("stub");
+  });
+
+  it("env-only enablement still works when no expansions.json (regression)", async () => {
+    process.env["SCRIBE_EXPANSIONS"] = "stub";
+    await makePluginsJson({
+      "ironsworn-stub@test-repo": [{ installPath: STUB_DIR, version: "1.0.0", scope: "user" }],
+    });
+    // no expansions.json written
+    const { discoverExpansions } = await import(`./loader.ts?t=${Date.now()}`);
+    const result = await discoverExpansions(campaignDir);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("stub");
+  });
+
+  it("unions env and file enabled lists", async () => {
+    // env enables "stub", file enables "extra" — both should be present
+    // We only have "stub" installed, so result has 1 item (extra not installed)
+    process.env["SCRIBE_EXPANSIONS"] = "stub";
+    await makePluginsJson({
+      "ironsworn-stub@test-repo": [{ installPath: STUB_DIR, version: "1.0.0", scope: "user" }],
+    });
+    await writeFile(
+      join(campaignDir, "expansions.json"),
+      JSON.stringify({ enabled: ["extra"] }),
+    );
+    const { discoverExpansions } = await import(`./loader.ts?t=${Date.now()}`);
+    const result = await discoverExpansions(campaignDir);
+    // "stub" is installed; "extra" is not — but "stub" must still be discovered
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("stub");
+  });
+
+  it("file disabled list removes expansion that env would otherwise enable", async () => {
+    process.env["SCRIBE_EXPANSIONS"] = "stub";
+    await makePluginsJson({
+      "ironsworn-stub@test-repo": [{ installPath: STUB_DIR, version: "1.0.0", scope: "user" }],
+    });
+    await writeFile(
+      join(campaignDir, "expansions.json"),
+      JSON.stringify({ disabled: ["stub"] }),
+    );
+    const { discoverExpansions } = await import(`./loader.ts?t=${Date.now()}`);
+    const result = await discoverExpansions(campaignDir);
+    expect(result).toEqual([]);
+  });
+
+  it("missing expansions.json falls back gracefully to env-only", async () => {
+    process.env["SCRIBE_EXPANSIONS"] = "stub";
+    await makePluginsJson({
+      "ironsworn-stub@test-repo": [{ installPath: STUB_DIR, version: "1.0.0", scope: "user" }],
+    });
+    // campaignDir exists but has no expansions.json
+    const { discoverExpansions } = await import(`./loader.ts?t=${Date.now()}`);
+    const result = await discoverExpansions(campaignDir);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("stub");
+  });
+
+  it("malformed expansions.json falls back to env-only and logs to stderr", async () => {
+    process.env["SCRIBE_EXPANSIONS"] = "stub";
+    await makePluginsJson({
+      "ironsworn-stub@test-repo": [{ installPath: STUB_DIR, version: "1.0.0", scope: "user" }],
+    });
+    await writeFile(join(campaignDir, "expansions.json"), "{ not valid json !!!");
+    const stderrWrites: string[] = [];
+    const spy = spyOn(process.stderr, "write").mockImplementation((msg: string | Uint8Array) => {
+      stderrWrites.push(typeof msg === "string" ? msg : "");
+      return true;
+    });
+    try {
+      const { discoverExpansions } = await import(`./loader.ts?t=${Date.now()}`);
+      const result = await discoverExpansions(campaignDir);
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe("stub");
+      expect(stderrWrites.some((m) => m.includes("malformed JSON"))).toBe(true);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("enabled not an array logs to stderr and treats as empty", async () => {
+    process.env["SCRIBE_EXPANSIONS"] = "stub";
+    await makePluginsJson({
+      "ironsworn-stub@test-repo": [{ installPath: STUB_DIR, version: "1.0.0", scope: "user" }],
+    });
+    await writeFile(
+      join(campaignDir, "expansions.json"),
+      JSON.stringify({ enabled: "stub" }),
+    );
+    const stderrWrites: string[] = [];
+    const spy = spyOn(process.stderr, "write").mockImplementation((msg: string | Uint8Array) => {
+      stderrWrites.push(typeof msg === "string" ? msg : "");
+      return true;
+    });
+    try {
+      const { discoverExpansions } = await import(`./loader.ts?t=${Date.now()}`);
+      // env still enables "stub", so it should still be found
+      const result = await discoverExpansions(campaignDir);
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe("stub");
+      expect(stderrWrites.some((m) => m.includes('"enabled" is not an array'))).toBe(true);
+    } finally {
+      spy.mockRestore();
+    }
   });
 });
 

--- a/plugins/ironsworn/scribe/src/expansions/loader.ts
+++ b/plugins/ironsworn/scribe/src/expansions/loader.ts
@@ -96,13 +96,79 @@ function satisfiesCompat(running: string, range: string | undefined): boolean {
   return cmp >= 0;
 }
 
-export async function discoverExpansions(): Promise<LoadedExpansion[]> {
-  const enabled = new Set(
+function readCampaignExpansionsFile(campaignPath: string | undefined): {
+  fileEnabled: Set<string>;
+  fileDisabled: Set<string>;
+} {
+  const empty = { fileEnabled: new Set<string>(), fileDisabled: new Set<string>() };
+  if (!campaignPath) return empty;
+
+  const filePath = join(campaignPath, "expansions.json");
+  if (!existsSync(filePath)) return empty;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(filePath, "utf-8"));
+  } catch {
+    process.stderr.write(`[scribe] expansions.json at ${filePath} is malformed JSON — falling back to env-only\n`);
+    return empty;
+  }
+
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    process.stderr.write(`[scribe] expansions.json at ${filePath} is not an object — falling back to env-only\n`);
+    return empty;
+  }
+
+  const record = parsed as Record<string, unknown>;
+
+  let fileEnabled = new Set<string>();
+  if ("enabled" in record) {
+    if (!Array.isArray(record["enabled"])) {
+      process.stderr.write(`[scribe] expansions.json "enabled" is not an array — treating as empty\n`);
+    } else {
+      fileEnabled = new Set(
+        (record["enabled"] as unknown[])
+          .filter((x): x is string => typeof x === "string")
+          .map((s) => s.trim())
+          .filter(Boolean),
+      );
+    }
+  }
+
+  let fileDisabled = new Set<string>();
+  if ("disabled" in record) {
+    if (!Array.isArray(record["disabled"])) {
+      process.stderr.write(`[scribe] expansions.json "disabled" is not an array — treating as empty\n`);
+    } else {
+      fileDisabled = new Set(
+        (record["disabled"] as unknown[])
+          .filter((x): x is string => typeof x === "string")
+          .map((s) => s.trim())
+          .filter(Boolean),
+      );
+    }
+  }
+
+  return { fileEnabled, fileDisabled };
+}
+
+export async function discoverExpansions(campaignPath?: string): Promise<LoadedExpansion[]> {
+  const envEnabled = new Set(
     (process.env["SCRIBE_EXPANSIONS"] ?? "")
       .split(",")
       .map((s) => s.trim())
       .filter(Boolean),
   );
+
+  const resolvedCampaignPath = campaignPath ?? process.env["SCRIBE_CAMPAIGN"];
+  const { fileEnabled, fileDisabled } = readCampaignExpansionsFile(resolvedCampaignPath);
+
+  // union of env + file enabled, minus file disabled
+  const enabled = new Set([...envEnabled, ...fileEnabled]);
+  for (const name of fileDisabled) {
+    enabled.delete(name);
+  }
+
   if (enabled.size === 0) return [];
 
   const jsonPath = installedPluginsPath();
@@ -166,7 +232,7 @@ export async function loadExpansions(
   server: McpServer,
   campaignPath: string,
 ): Promise<LoadedExpansion[]> {
-  const expansions = await discoverExpansions();
+  const expansions = await discoverExpansions(campaignPath);
   _active = expansions;
 
   for (const expansion of expansions) {


### PR DESCRIPTION
## Summary
Extends the expansion discovery system to support per-campaign expansion configuration via an `expansions.json` file, while maintaining backward compatibility with environment variable-only enablement.

## Key Changes
- **New `readCampaignExpansionsFile()` function** in `loader.ts` that reads and parses `{campaignPath}/expansions.json` with graceful error handling:
  - Validates JSON structure and array fields
  - Logs validation errors to stderr without crashing
  - Falls back to empty sets if file is missing or malformed
  
- **Updated `discoverExpansions()` signature** to accept optional `campaignPath` parameter (also reads from `SCRIBE_CAMPAIGN` env var if not provided)

- **Union-based enablement logic**: expansions are enabled if listed in either `SCRIBE_EXPANSIONS` env var OR the file's `enabled` array

- **Disable override**: expansions listed in the file's `disabled` array are removed from the final enabled set, allowing campaigns to opt-out of globally-enabled expansions

- **Updated `loadExpansions()` call** to pass `campaignPath` to `discoverExpansions()`

- **Comprehensive test suite** covering:
  - File-only enablement (env unset)
  - Env-only enablement (no file, regression test)
  - Union of env + file enabled lists
  - File disabled list overriding env enablement
  - Graceful fallback when file is missing
  - Malformed JSON handling with stderr logging
  - Invalid field types with stderr logging

- **Version bump** to 0.23.1 in `plugin.json`

## Implementation Details
- The `expansions.json` schema supports `{ enabled?: string[], disabled?: string[] }` at the root level
- All string values are trimmed and empty strings filtered out
- Non-string array elements are silently skipped (type-safe filtering)
- Errors are logged to `process.stderr` with `[scribe]` prefix for visibility without disrupting discovery
- Tests use `spyOn()` to verify stderr messages for error cases

https://claude.ai/code/session_01QCkvSugYYpXP3EYQvDzY7c