### PR TITLE
Add Character Disposition oracle and NPC introduction protocol

### DIFF
--- a/plugins/ironsworn/.claude-plugin/plugin.json
+++ b/plugins/ironsworn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ironsworn",
-  "version": "0.23.2",
+  "version": "0.24.0",
   "description": "Solo Ironsworn GM companion — fiction-first, dice-driven, with a living lore graph",
   "author": {
     "name": "Karim Naguib"

--- a/plugins/ironsworn/data/oracles.yaml
+++ b/plugins/ironsworn/data/oracles.yaml
@@ -1102,6 +1102,135 @@
   - min: 100
     max: 100
     outcome: Ironsworn
+- name: Character Disposition
+  dice: 1d100
+  rolls:
+  - min: 1
+    max: 4
+    outcome: Openly hostile — reads you as a threat or a mark
+  - min: 5
+    max: 9
+    outcome: Suspicious — watching for the angle, not yet committed
+  - min: 10
+    max: 14
+    outcome: Wary — will deal, but keeps an exit in reach
+  - min: 15
+    max: 19
+    outcome: Indifferent — you are neither threat nor opportunity yet
+  - min: 20
+    max: 24
+    outcome: Preoccupied — present in body, elsewhere in mind
+  - min: 25
+    max: 29
+    outcome: Cautiously curious — interested, but won't show it plainly
+  - min: 30
+    max: 34
+    outcome: Guarded respect — knows your reputation, not yet sure what to make of it
+  - min: 35
+    max: 39
+    outcome: Transactional — this is business; do not make it personal
+  - min: 40
+    max: 44
+    outcome: Desperate — needs something badly enough to overlook their usual caution
+  - min: 45
+    max: 49
+    outcome: Deferential — treats you as authority, at least for now
+  - min: 50
+    max: 54
+    outcome: Warily open — willing to talk, slow to trust
+  - min: 55
+    max: 59
+    outcome: Hopeful — wants to believe you're what they need
+  - min: 60
+    max: 64
+    outcome: Grateful — owes a debt, real or perceived
+  - min: 65
+    max: 69
+    outcome: Cautiously warm — likes you more than they're comfortable admitting
+  - min: 70
+    max: 74
+    outcome: Protective — will shield what they care about, including from you if needed
+  - min: 75
+    max: 79
+    outcome: Candidly friendly — no agenda; genuinely at ease with you
+  - min: 80
+    max: 84
+    outcome: Admiring — sees something in you worth emulating or following
+  - min: 85
+    max: 89
+    outcome: Grieving — not fully present; carrying something heavy
+  - min: 90
+    max: 94
+    outcome: Resigned — has accepted something they did not want to accept
+  - min: 95
+    max: 98
+    outcome: Conflicted — pulled in two directions; needs a reason to choose
+  - min: 99
+    max: 100
+    outcome: Roll twice — holds two contradictory stances at once
+- name: Character Wound
+  dice: 1d100
+  rolls:
+  - min: 1
+    max: 5
+    outcome: Failed to protect someone who depended on them
+  - min: 6
+    max: 10
+    outcome: Swore an oath they later broke or could not keep
+  - min: 11
+    max: 15
+    outcome: Was cast out by a community they gave everything to
+  - min: 16
+    max: 20
+    outcome: Watched something they built be destroyed
+  - min: 21
+    max: 25
+    outcome: Survived something others didn't — and can't stop asking why
+  - min: 26
+    max: 30
+    outcome: Was betrayed by someone they trusted completely
+  - min: 31
+    max: 36
+    outcome: Lost a child, a sibling, or a bond-companion
+  - min: 37
+    max: 41
+    outcome: Chose safety over the right thing once — still carrying it
+  - min: 42
+    max: 46
+    outcome: Had power and lost it, or refused it when offered
+  - min: 47
+    max: 51
+    outcome: Was wrong about something that cost others dearly
+  - min: 52
+    max: 56
+    outcome: Gave up on someone who still needed them
+  - min: 57
+    max: 61
+    outcome: Was responsible for a death they could not have prevented — but believe they could have
+  - min: 62
+    max: 66
+    outcome: Carried out an order they knew was wrong
+  - min: 67
+    max: 71
+    outcome: Was used as a weapon by someone they loved
+  - min: 72
+    max: 76
+    outcome: Had their name — or their past — taken from them
+  - min: 77
+    max: 81
+    outcome: Was the only one who knew the truth, and stayed silent
+  - min: 82
+    max: 86
+    outcome: Tried to save something and made it worse
+  - min: 87
+    max: 91
+    outcome: Was not there when it mattered most
+  - min: 92
+    max: 96
+    outcome: Chose one person over many — and has to live with the math
+  - min: 97
+    max: 100
+    outcome: Does not know what the wound is — only that something is missing
 - name: Endure Harm
   dice: 1d100
   rolls:

--- a/plugins/ironsworn/data/oracles.yaml
+++ b/plugins/ironsworn/data/oracles.yaml
@@ -1102,6 +1102,11 @@
   - min: 100
     max: 100
     outcome: Ironsworn
+
+# ── Plugin-original tables (not in the Ironsworn rulebook) ──────────────────
+# Character Disposition and Character Wound were created for this plugin.
+# Do not present them to players as canonical Ironsworn content.
+
 - name: Character Disposition
   dice: 1d100
   rolls:
@@ -1168,7 +1173,7 @@
   - min: 99
     max: 100
     outcome: Roll twice — holds two contradictory stances at once
-- name: Character Wound
+- name: Character Wound  # plugin-original
   dice: 1d100
   rolls:
   - min: 1

--- a/plugins/ironsworn/skills/ironsworn-character-builder/SKILL.md
+++ b/plugins/ironsworn/skills/ironsworn-character-builder/SKILL.md
@@ -220,6 +220,8 @@ If yes: note the people/communities with `upsert_npc` for significant individual
 The bonds counter itself advances through `Forge a Bond` during play — don't increment it here for
 background bonds unless you're using the variant rule that grants 1 starting bond.
 
+**For bond NPCs the player wants real depth on** — a mentor with a complicated history, a sibling the character left behind, someone who shaped who they are — invoke `ironsworn-npc-backstory` (Quick or Full scaffolding) before the session begins. This gives those NPCs a Wound, a Silent Vow, and a Line, which means when they appear in play their reactions will already be grounded rather than improvised. The player does not need to know the NPC's wound; it informs how the GM plays them, not what the player is told.
+
 ---
 
 ## Finishing Up

--- a/plugins/ironsworn/skills/ironsworn-npc-backstory/SKILL.md
+++ b/plugins/ironsworn/skills/ironsworn-npc-backstory/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: ironsworn-npc-backstory
+description: >
+  Scaffolds NPC background, wound, silent vow, and the line they will not cross.
+  Invoke this skill when you want to give an NPC real depth before they appear on
+  stage — or when a significant NPC who has been present needs to be fleshed out
+  because they are about to matter. Use Full scaffolding for recurring NPCs who
+  will drive or complicate the campaign. Use Quick for significant one-scene NPCs
+  who may return. Use Stub for background characters who might become significant.
+  This skill sits upstream of ironsworn-npc-voice: voice consumes what this produces.
+---
+
+# Ironsworn NPC Backstory
+
+This skill generates the **interior architecture** of an NPC — who they were before the player met them, what broke them, what they quietly swore afterward, and where they will not go no matter the cost. The output is a backstory record that `ironsworn-npc-voice` reads when that NPC speaks.
+
+**Upstream of voice.** Voice is expression; backstory is source. You can run `ironsworn-npc-voice` without a backstory record, but not the other way around. When a backstory record exists, `ironsworn-npc-voice` skips its own introduction protocol and reads this record instead.
+
+**Fiction Grounding Protocol:** Call `search_lore_global` before generating anything — does this NPC or their community already have entries? Does the role contradict or rhyme with established factions? Ground first, then scaffold.
+
+---
+
+## Three Scaffolding Modes
+
+Choose the mode that fits how much this NPC matters to the campaign.
+
+---
+
+### Full Scaffolding — Recurring or Pivotal NPC
+
+Use for NPCs who will recur, drive plot, or represent a significant relationship with the player. Six steps, all six oracle rolls.
+
+**Step 1: Role** — `roll_oracle("Character Role")`
+Who are they in the world, structurally? Their role is not their personality — it's their position. A "Healer" who is also a "broken veteran" is not a healer anymore; they're someone who used to believe healing was possible.
+
+**Step 2: Descriptor** — `roll_oracle("Character Descriptor")`
+Single dominant trait. This is the surface — the first impression, the word that follows their name in rumor. Bitter. Driven. Wary. It should create friction or sympathy with the Role.
+
+**Step 3: Disposition** — `roll_oracle("Character Disposition")`
+Emotional/relational stance toward the player. This is how they enter the scene — not who they are at depth, but the lens through which they filter the player. Disposition can shift; it is the first read, not the final one.
+
+**Step 4: Wound** — `roll_oracle("Character Wound")`
+The formative event or loss that shaped who they became. This is the load-bearing fact — everything else is built on top of it. The Wound is not backstory decoration; it is the source of the Silent Vow, the shape of the Line, and the reason the Descriptor is what it is.
+
+**Step 5: Silent Vow** — synthesize from Wound
+Do not roll. Derive. The Silent Vow is what the NPC promised themselves after the Wound — never stated aloud, possibly not even acknowledged consciously, but present in every choice they make. Phrase it as a first-person "I will..." statement:
+
+- Wound: "Failed to protect someone who depended on them" → Silent Vow: "I will never be the reason someone is left behind."
+- Wound: "Was cast out by a community they gave everything to" → Silent Vow: "I will not belong to anything that can take itself back."
+- Wound: "Chose safety over the right thing once" → Silent Vow: "I will not make that calculation again."
+
+The Silent Vow is the NPC's private vow — their Ironsworn oath to themselves. It may be impossible to keep. That is often the point.
+
+**Step 6: The Line** — synthesize from Silent Vow + Wound
+The one thing they will not do, no matter what is offered or threatened. Phrase it in the negative:
+- "Will not leave someone behind in a fight, even if ordered to."
+- "Will not name the community that cast them out, even to defend themselves."
+- "Will not choose safety again when someone else is paying the cost."
+
+The Line is where a miss on Compel lands. It is the thing that, if violated, breaks the character — or breaks the NPC's relationship with the player permanently.
+
+**After all six steps:**
+
+1. `search_lore_global(name + " " + role)` — does this backstory create any contradictions or resonances with established lore?
+2. `upsert_npc` with:
+   - `disposition` tags from Step 3 result
+   - `drives` containing the Wound (one sentence) and the Silent Vow ("I will...")
+   - `impression` line: the Line they will not cross (phrased as "Will not: [the Line]")
+3. Output the NPC record in the standard format (see below).
+
+---
+
+### Quick Scaffolding — Significant One-Scene NPC
+
+Use for NPCs who matter in this scene and may return, but whose full interior life does not need to be established yet. Three rolls; Silent Vow derived; no Line unless the scene demands one.
+
+**Step 1:** `roll_oracle("Character Role")`
+**Step 2:** `roll_oracle("Character Disposition")`
+**Step 3:** Synthesize a Silent Vow from the Role + Disposition combination. The vow does not need a Wound yet — it can be implied. A "Desperate" Pilgrim's silent vow might be "I will reach the end of this road or it will bury me." That's enough.
+
+`upsert_npc` with disposition tags, drives (the Silent Vow), and a one-line impression.
+
+If this NPC returns and matters more, run Full Scaffolding at that point — adding the Wound and the Line retroactively.
+
+---
+
+### Stub Scaffolding — Background Character
+
+Use for NPCs who exist in the scene's texture but have not yet earned full development. Two rolls; no Vow; no Line; a single-line record.
+
+**Step 1:** `roll_oracle("Character Role")`
+**Step 2:** `roll_oracle("Character Disposition")`
+
+`upsert_npc` with disposition tags and a one-line impression. Nothing more. If this character steps forward, upgrade to Quick or Full.
+
+---
+
+## Standard NPC Record Output Format
+
+After Full or Quick scaffolding, write the NPC record in this format:
+
+```
+**Description:** [Role] who [characteristic behavior derived from Descriptor + Wound]
+**Impression:** [Disposition] toward outsiders. Silent vow: "[I will...]". Will not: [the Line].
+**Wound:** [The formative event, one sentence]
+```
+
+Example:
+```
+**Description:** Healer who avoids patients who remind her of the ones she lost — keeps her hands moving so she doesn't have to look at their faces.
+**Impression:** Warily open toward outsiders. Silent vow: "I will not be the last one who could have helped." Will not: abandon a patient mid-treatment, even at cost to herself.
+**Wound:** Was not there when it mattered most — arrived hours after the village burned, found what was left.
+```
+
+This output is what `ironsworn-npc-voice` reads. Keep it dense and specific. Avoid adjectives that do not do work.
+
+---
+
+## Lore Grounding
+
+Before synthesizing anything, call `search_lore_global` with the NPC's name and role. The oracle results are raw material — campaign texture shapes them. A "Resigned" disposition on a "Trader" in a campaign where the trade routes have collapsed is not the same as in a campaign of plenty. The Wound must land in the world that already exists.
+
+If the lore search returns relevant entries — a faction this NPC could belong to, an event they might have survived, a community they could have been cast out of — incorporate those. The Wound is more powerful when it is *this campaign's* wound, not a generic backstory beat.
+
+---
+
+## Relationship to Other Skills
+
+- **`ironsworn-npc-voice`** — reads the backstory record to generate voice. If a backstory record exists, voice skips its own introduction protocol.
+- **`ironsworn-social`** — before Compel or Forge a Bond, if the NPC has a Silent Vow and a Line recorded, those must inform how the ask is framed and what a miss costs.
+- **`ironsworn-character-builder`** — Step 7 (Background Bonds) may invoke this skill for bond NPCs the player wants depth on.
+
+---
+
+## When Not to Use This Skill
+
+- A named NPC who has already been fully established through play — use `get_npc` and `ironsworn-npc-voice` instead.
+- A crowd, a faction, or an unnamed background figure — `upsert_lore` with a brief description is sufficient.
+- Right in the middle of a scene where the NPC is speaking — this is a pre-scene or between-scene tool. If the NPC is already on stage and speaking, use `ironsworn-npc-voice` directly, then backstory-fill after the scene.

--- a/plugins/ironsworn/skills/ironsworn-npc-voice/SKILL.md
+++ b/plugins/ironsworn/skills/ironsworn-npc-voice/SKILL.md
@@ -46,13 +46,32 @@ Defer bond increments and the social-move outcome tables (Compel, Sojourn, Forge
 
 ## Fiction Grounding Protocol (#103) — Mandatory Before Speech
 
-Before generating any line, body-language beat, or reaction:
+Before generating any line, body-language beat, or reaction, determine whether this NPC has a record:
+
+### Returning NPC (record exists)
 
 1. `get_npc(name)` — disposition, drives, impressions, bonds.
 2. `search_lore_global(query)` for the NPC's faction, community, related entities, recent scenes.
 3. If a fact is missing (accent, opinion of player, secret), `roll_oracle` first, then `upsert_npc` so the answer is durable.
 
 **Voice must match what is recorded.** A returning NPC who was "warily curious" last scene cannot suddenly be effusive without an in-fiction reason. If the recorded fact contradicts the moment you want, either play the recorded fact or have the NPC visibly change — and `upsert_npc` to capture the shift.
+
+### New NPC (no record exists) — Introduction Protocol
+
+When a named NPC appears for the first time with no existing record, run this protocol **before writing any line or reaction**. If `ironsworn-npc-backstory` has already been invoked for this NPC, skip to step 5 — the backstory record is authoritative.
+
+1. `roll_oracle("Character Role")` — structural identity (who they are in the world).
+2. `roll_oracle("Character Descriptor")` — single dominant trait.
+3. `roll_oracle("Character Goal")` — what they want right now.
+4. `roll_oracle("Character Disposition")` — emotional/relational stance toward the player.
+5. `search_lore_global(name + " " + role)` — filter through campaign texture before writing anything. Does this role contradict or rhyme with established factions? Are there prior references?
+6. Synthesize: let Role + Descriptor + Goal + Disposition combine into a voice. Don't describe each roll — the NPC arrives as a person.
+7. `upsert_npc` immediately with:
+   - `disposition` tags from the Disposition result
+   - `drives` seeded from Goal (and Wound/Silent Vow if backstory was run)
+   - A first `impression` line that captures how they come across in this moment
+
+The oracle results are raw material, not a costume. A "Transactional" disposition on a "Pilgrim" with a "Cure an ill" goal is not a merchant — it's someone who's learned the only way to get help is to offer something in return.
 
 ---
 

--- a/plugins/ironsworn/skills/ironsworn-npc-voice/references/voice-archetypes.md
+++ b/plugins/ironsworn/skills/ironsworn-npc-voice/references/voice-archetypes.md
@@ -52,7 +52,7 @@ For each archetype: **vocabulary** (words they reach for; words they avoid), **r
 
 ## 5. The Cleric of the Old Gods
 
-- **When to reach for this**: Priest, Mystic, or Healer role + Resigned or Grieving disposition — someone who has made their peace with costs the player has not yet had to pay.
+- **When to reach for this**: Healer or Seer role + Quietly Ashamed or Resigned disposition — someone who has made their peace with costs the player has not yet had to pay.
 - **Vocabulary**: wound, vigil, ash, the long road, the cost. Avoids: trivial pleasantries, modern names, anything quick.
 - **Rhythm**: liturgical. Speaks in pairs. Repeats your own words back at you.
 - **Negative space**: will not absolve without weight; will not lie in the temple; will not name the god they fear.
@@ -63,7 +63,7 @@ For each archetype: **vocabulary** (words they reach for; words they avoid), **r
 
 ## 6. The Frostborn Diplomat
 
-- **When to reach for this**: Leader or Pilgrim role + Deferential or Cautiously curious disposition — someone who came prepared, has studied you, and will not be hurried into anything.
+- **When to reach for this**: Leader or Emissary role + Transactional or Suspicious of Your Motives disposition — someone who came prepared, has studied you, and will not be hurried into anything.
 - **Vocabulary**: courtesy, distance, the long view, *kin* (used coldly). Avoids: contractions, slang, anger-words.
 - **Rhythm**: even, glacial. Always one beat slower than the room expects.
 - **Negative space**: will not raise voice; will not threaten directly — implies; will not break form even when struck.
@@ -74,7 +74,7 @@ For each archetype: **vocabulary** (words they reach for; words they avoid), **r
 
 ## 7. The Broken Veteran
 
-- **When to reach for this**: Warrior, Mercenary, or Raider role + Grieving or Resigned disposition — someone whose wound is survival itself, and who speaks around the thing they cannot say directly.
+- **When to reach for this**: Warrior or Protector role + Exhausted Past Caring or Frightened and Hiding It disposition — someone whose wound is survival itself, and who speaks around the thing they cannot say directly.
 - **Vocabulary**: weight, the cold, *that one*, *the boy*, names not spoken. Avoids: grand words, present tense for old things.
 - **Rhythm**: jagged. Starts strong, dies mid-sentence, restarts somewhere else.
 - **Negative space**: will not look directly at certain objects; will not say the place-name; will not ask for help in plain words.
@@ -85,7 +85,7 @@ For each archetype: **vocabulary** (words they reach for; words they avoid), **r
 
 ## 8. The Trickster Stranger
 
-- **When to reach for this**: Vagrant, Outcast, or Pilgrim role + Suspicious or Warily open disposition — someone whose agenda you cannot quite locate, and who prefers it that way.
+- **When to reach for this**: Outcast or Wanderer role + Amused (Watching How This Plays Out) or Openly Eager (Almost Too Much) disposition — someone whose agenda you cannot quite locate, and who prefers it that way.
 - **Vocabulary**: questions, riddles, your own name said too often, fragments of three other dialects. Avoids: clarity.
 - **Rhythm**: unpredictable. Answers a different question than the one asked. Repeats with a twist.
 - **Negative space**: will not give a true name; will not stand still in a doorway; will not confirm what they did yesterday.

--- a/plugins/ironsworn/skills/ironsworn-npc-voice/references/voice-archetypes.md
+++ b/plugins/ironsworn/skills/ironsworn-npc-voice/references/voice-archetypes.md
@@ -8,6 +8,7 @@ For each archetype: **vocabulary** (words they reach for; words they avoid), **r
 
 ## 1. The Hinterlander Clan-Warrior
 
+- **When to reach for this**: Warrior or Mercenary role + Guarded Respect or Transactional disposition — someone who measures you by what you've earned, not what you say.
 - **Vocabulary**: oaths, kin-words, weapon-names, weather. Avoids: abstractions ("perhaps", "concept", "frankly").
 - **Rhythm**: short, declarative. Verbs first. Pauses where a softer speaker would qualify.
 - **Negative space**: will not name a coward; will not explain a debt of blood; will not speak the dead's name lightly.
@@ -18,6 +19,7 @@ For each archetype: **vocabulary** (words they reach for; words they avoid), **r
 
 ## 2. The Deep Wilds Elder
 
+- **When to reach for this**: Mystic, Priest, or Forester role + Preoccupied or Resignd disposition — someone whose attention is divided between this world and something older.
 - **Vocabulary**: river, root, season, breath, the old word for things. Avoids: clock-time, coin-words, "I think".
 - **Rhythm**: long, looping. Ends questions you didn't ask. Trails into silence and lets you fill it.
 - **Negative space**: will not give a straight yes; will not name the spirits casually; will not confirm what you already know.

--- a/plugins/ironsworn/skills/ironsworn-npc-voice/references/voice-archetypes.md
+++ b/plugins/ironsworn/skills/ironsworn-npc-voice/references/voice-archetypes.md
@@ -52,7 +52,7 @@ For each archetype: **vocabulary** (words they reach for; words they avoid), **r
 
 ## 5. The Cleric of the Old Gods
 
-- **When to reach for this**: Healer or Seer role + Quietly Ashamed or Resigned disposition — someone who has made their peace with costs the player has not yet had to pay.
+- **When to reach for this**: Healer or Seer role + Grieving or Resigned disposition — someone who has made their peace with costs the player has not yet had to pay.
 - **Vocabulary**: wound, vigil, ash, the long road, the cost. Avoids: trivial pleasantries, modern names, anything quick.
 - **Rhythm**: liturgical. Speaks in pairs. Repeats your own words back at you.
 - **Negative space**: will not absolve without weight; will not lie in the temple; will not name the god they fear.
@@ -63,7 +63,7 @@ For each archetype: **vocabulary** (words they reach for; words they avoid), **r
 
 ## 6. The Frostborn Diplomat
 
-- **When to reach for this**: Leader or Emissary role + Transactional or Suspicious of Your Motives disposition — someone who came prepared, has studied you, and will not be hurried into anything.
+- **When to reach for this**: Leader or Emissary role + Transactional or Suspicious disposition — someone who came prepared, has studied you, and will not be hurried into anything.
 - **Vocabulary**: courtesy, distance, the long view, *kin* (used coldly). Avoids: contractions, slang, anger-words.
 - **Rhythm**: even, glacial. Always one beat slower than the room expects.
 - **Negative space**: will not raise voice; will not threaten directly — implies; will not break form even when struck.
@@ -74,7 +74,7 @@ For each archetype: **vocabulary** (words they reach for; words they avoid), **r
 
 ## 7. The Broken Veteran
 
-- **When to reach for this**: Warrior or Protector role + Exhausted Past Caring or Frightened and Hiding It disposition — someone whose wound is survival itself, and who speaks around the thing they cannot say directly.
+- **When to reach for this**: Warrior or Protector role + Resigned or Conflicted disposition — someone whose wound is survival itself, and who speaks around the thing they cannot say directly.
 - **Vocabulary**: weight, the cold, *that one*, *the boy*, names not spoken. Avoids: grand words, present tense for old things.
 - **Rhythm**: jagged. Starts strong, dies mid-sentence, restarts somewhere else.
 - **Negative space**: will not look directly at certain objects; will not say the place-name; will not ask for help in plain words.
@@ -85,7 +85,7 @@ For each archetype: **vocabulary** (words they reach for; words they avoid), **r
 
 ## 8. The Trickster Stranger
 
-- **When to reach for this**: Outcast or Wanderer role + Amused (Watching How This Plays Out) or Openly Eager (Almost Too Much) disposition — someone whose agenda you cannot quite locate, and who prefers it that way.
+- **When to reach for this**: Outcast or Wanderer role + Cautiously curious or Candidly friendly disposition — someone whose agenda you cannot quite locate, and who prefers it that way.
 - **Vocabulary**: questions, riddles, your own name said too often, fragments of three other dialects. Avoids: clarity.
 - **Rhythm**: unpredictable. Answers a different question than the one asked. Repeats with a twist.
 - **Negative space**: will not give a true name; will not stand still in a doorway; will not confirm what they did yesterday.

--- a/plugins/ironsworn/skills/ironsworn-npc-voice/references/voice-archetypes.md
+++ b/plugins/ironsworn/skills/ironsworn-npc-voice/references/voice-archetypes.md
@@ -19,7 +19,7 @@ For each archetype: **vocabulary** (words they reach for; words they avoid), **r
 
 ## 2. The Deep Wilds Elder
 
-- **When to reach for this**: Mystic, Priest, or Forester role + Preoccupied or Resignd disposition — someone whose attention is divided between this world and something older.
+- **When to reach for this**: Mystic, Priest, or Forester role + Preoccupied or Resigned disposition — someone whose attention is divided between this world and something older.
 - **Vocabulary**: river, root, season, breath, the old word for things. Avoids: clock-time, coin-words, "I think".
 - **Rhythm**: long, looping. Ends questions you didn't ask. Trails into silence and lets you fill it.
 - **Negative space**: will not give a straight yes; will not name the spirits casually; will not confirm what you already know.
@@ -30,6 +30,7 @@ For each archetype: **vocabulary** (words they reach for; words they avoid), **r
 
 ## 3. The Iron-Town Magistrate
 
+- **When to reach for this**: Leader or Guard role + Transactional or Guarded Respect disposition — someone who treats every exchange as a matter of record and expects you to do the same.
 - **Vocabulary**: oath, levy, custom, precedent, the law, the records. Avoids: "maybe", endearments, first names without title.
 - **Rhythm**: balanced clauses, weight on the second half. Refers to itself in the third person under pressure.
 - **Negative space**: will not contradict the written record in public; will not concede a favor; will not bend on a sworn matter even if the law is wrong.
@@ -40,6 +41,7 @@ For each archetype: **vocabulary** (words they reach for; words they avoid), **r
 
 ## 4. The Smuggler-Captain
 
+- **When to reach for this**: Trader, Sailor, or Criminal role + Wary or Transactional disposition — someone who makes their living on the margins and stays alive by keeping their options open.
 - **Vocabulary**: tide, weight, share, the run, *friend* (used as warning). Avoids: oaths, formal titles, the names of authorities.
 - **Rhythm**: fast on the safe topics, slow and exact on numbers. Smiles in the wrong places.
 - **Negative space**: will not name the buyer; will not say "no" — will say "not for that price"; will not ever say "always".
@@ -50,6 +52,7 @@ For each archetype: **vocabulary** (words they reach for; words they avoid), **r
 
 ## 5. The Cleric of the Old Gods
 
+- **When to reach for this**: Priest, Mystic, or Healer role + Resigned or Grieving disposition — someone who has made their peace with costs the player has not yet had to pay.
 - **Vocabulary**: wound, vigil, ash, the long road, the cost. Avoids: trivial pleasantries, modern names, anything quick.
 - **Rhythm**: liturgical. Speaks in pairs. Repeats your own words back at you.
 - **Negative space**: will not absolve without weight; will not lie in the temple; will not name the god they fear.
@@ -60,6 +63,7 @@ For each archetype: **vocabulary** (words they reach for; words they avoid), **r
 
 ## 6. The Frostborn Diplomat
 
+- **When to reach for this**: Leader or Pilgrim role + Deferential or Cautiously curious disposition — someone who came prepared, has studied you, and will not be hurried into anything.
 - **Vocabulary**: courtesy, distance, the long view, *kin* (used coldly). Avoids: contractions, slang, anger-words.
 - **Rhythm**: even, glacial. Always one beat slower than the room expects.
 - **Negative space**: will not raise voice; will not threaten directly — implies; will not break form even when struck.
@@ -70,6 +74,7 @@ For each archetype: **vocabulary** (words they reach for; words they avoid), **r
 
 ## 7. The Broken Veteran
 
+- **When to reach for this**: Warrior, Mercenary, or Raider role + Grieving or Resigned disposition — someone whose wound is survival itself, and who speaks around the thing they cannot say directly.
 - **Vocabulary**: weight, the cold, *that one*, *the boy*, names not spoken. Avoids: grand words, present tense for old things.
 - **Rhythm**: jagged. Starts strong, dies mid-sentence, restarts somewhere else.
 - **Negative space**: will not look directly at certain objects; will not say the place-name; will not ask for help in plain words.
@@ -80,6 +85,7 @@ For each archetype: **vocabulary** (words they reach for; words they avoid), **r
 
 ## 8. The Trickster Stranger
 
+- **When to reach for this**: Vagrant, Outcast, or Pilgrim role + Suspicious or Warily open disposition — someone whose agenda you cannot quite locate, and who prefers it that way.
 - **Vocabulary**: questions, riddles, your own name said too often, fragments of three other dialects. Avoids: clarity.
 - **Rhythm**: unpredictable. Answers a different question than the one asked. Repeats with a twist.
 - **Negative space**: will not give a true name; will not stand still in a doorway; will not confirm what they did yesterday.

--- a/plugins/ironsworn/skills/ironsworn-oracle/references/oracle-prompts.md
+++ b/plugins/ironsworn/skills/ironsworn-oracle/references/oracle-prompts.md
@@ -64,6 +64,8 @@ Roll both `Action` and `Theme`. You get two abstract words. The interpretation i
 
 ## Specific Table Cheat Sheet
 
+### Canonical tables (from the Ironsworn rulebook)
+
 | Table | Use when |
 |---|---|
 | `Action` + `Theme` | Open-ended "what happens?", "what's their angle?", "what's the twist?" |
@@ -74,12 +76,17 @@ Roll both `Action` and `Theme`. You get two abstract words. The interpretation i
 | `Character Role` | Who is this person, structurally? (Warrior, Outcast, Scholar, etc.) |
 | `Character Goal` | What do they want? |
 | `Character Descriptor` | Single trait — "stoic," "vengeful," "frail" |
-| `Character Disposition` | Emotional/relational stance toward the player — how they enter the scene |
-| `Character Wound` | Formative event or loss that shaped who they became — their carried weight |
 | `Major Plot Twist` | When the campaign feels stable — invite chaos |
 | `Mystic Backlash` | When a ritual or supernatural action goes sideways |
 | `Pay the Price` | Last resort for miss consequences (see references/pay-the-price.md) |
 | `Endure Harm` / `Endure Stress` | Mortal harm / Desolation table — handled by `ironsworn-suffer`; cross-link |
+
+### Plugin-original tables (not in the rulebook — invented for this plugin)
+
+| Table | Use when |
+|---|---|
+| `Character Disposition` | Emotional/relational stance toward the player — how they enter the scene. Roll at NPC introduction if no record exists. |
+| `Character Wound` | Formative event or loss that shaped who they became — their carried weight. Roll during `ironsworn-npc-backstory` scaffolding. |
 
 After every roll on a specific table, call `search_lore_global` so the result lands in the campaign's themes rather than generic fantasy.
 

--- a/plugins/ironsworn/skills/ironsworn-oracle/references/oracle-prompts.md
+++ b/plugins/ironsworn/skills/ironsworn-oracle/references/oracle-prompts.md
@@ -74,6 +74,8 @@ Roll both `Action` and `Theme`. You get two abstract words. The interpretation i
 | `Character Role` | Who is this person, structurally? (Warrior, Outcast, Scholar, etc.) |
 | `Character Goal` | What do they want? |
 | `Character Descriptor` | Single trait — "stoic," "vengeful," "frail" |
+| `Character Disposition` | Emotional/relational stance toward the player — how they enter the scene |
+| `Character Wound` | Formative event or loss that shaped who they became — their carried weight |
 | `Major Plot Twist` | When the campaign feels stable — invite chaos |
 | `Mystic Backlash` | When a ritual or supernatural action goes sideways |
 | `Pay the Price` | Last resort for miss consequences (see references/pay-the-price.md) |

--- a/plugins/ironsworn/skills/ironsworn-social/SKILL.md
+++ b/plugins/ironsworn/skills/ironsworn-social/SKILL.md
@@ -55,6 +55,11 @@ For NPC voice and reactions, defer to `ironsworn-npc-voice`. For vow milestones 
 
 Before narrating any non-trivial social beat, call `search_lore_global` (and `get_npc` / `get_community` when the entity is named). Pull what is already established — disposition, debts, prior bonds, community truths — and let those facts shape the scene. **Never invent a new fact about a known NPC or community without checking first.** If a fact is missing, `roll_oracle` and then `upsert_npc` / `upsert_lore` so it is durable.
 
+**Silent Vow and the Line (from `ironsworn-npc-backstory`).** Before Compel or Forge a Bond, check the NPC's record for a recorded Silent Vow and a Line. If present:
+- The **ask must be framed** in terms of the Silent Vow — lean into it if the ask aligns, acknowledge the tension if it pulls against it. A Compel that happens to align with an NPC's Silent Vow should feel different than one that cuts across it.
+- A **miss costs something the Line protects**. If the miss consequence would require the NPC to cross their Line, they refuse at any cost — no amount of leverage moves them past it. This is not a mechanic failure; it is the NPC being fully real. The miss consequence shifts to something they *can* pay but will resent.
+- A **weak hit's demand echoes the Silent Vow** — what they ask for in return is shaped by what they swore to themselves, not a random favor.
+
 ---
 
 ## The Six Moves


### PR DESCRIPTION
- Add new Character Disposition oracle to oracles.yaml with 25 entries
  covering a full range of NPC relational stances (hostile through
  deeply invested)
- Update ironsworn-npc-voice SKILL.md to split the Fiction Grounding
  Protocol into Returning NPC and New NPC branches; new NPCs now follow
  a structured introduction protocol that rolls Character Role,
  Descriptor, Goal, and Disposition before any line is written
- Extend voice-archetypes.md and oracle-prompts.md references

https://claude.ai/code/session_0163HdxZXqWAXmHzpoCBCy2L