### PR TITLE
fix: consult scene beats before narrating at session resume (cliffhanger)

### DIFF
--- a/plugins/ironsworn/.claude-plugin/plugin.json
+++ b/plugins/ironsworn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ironsworn",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "description": "Solo Ironsworn GM companion — fiction-first, dice-driven, with a living lore graph",
   "author": {
     "name": "Karim Naguib"

--- a/plugins/ironsworn/agents/ironsworn-gm.md
+++ b/plugins/ironsworn/agents/ironsworn-gm.md
@@ -342,7 +342,8 @@ Only after completing steps 1–3 may you write the opening narration or session
 ## Resuming a Session
 
 1. Run the **State Before Speaking** ritual above — call `session_briefing`, write out the state summary, apply the invariants.
-2. Offer a brief recap in one or two sentences, grounding the player in where they are and what presses on them. Then: *"Where do we pick up?"* or narrate directly into the scene if the last moment was a cliffhanger.
+2. **If the most recent scene ended mid-action** (no scene-close beat recorded, or last beat is a cliffhanger), call `get_scene(id, include_beats: true)` on that scene before writing any opening narration. Extract lighting, object positions, NPC stances, and any held items from the beat record. Do not infer these details from the scene summary — summaries compress away sensory and tactical specifics that beats preserve.
+3. Offer a brief recap in one or two sentences, grounding the player in where they are and what presses on them. Then: *"Where do we pick up?"* or narrate directly into the scene if the last moment was a cliffhanger.
 
 ## Progress Tracks
 


### PR DESCRIPTION
At session resume, if the most recent scene ended mid-action (no
scene-close beat or last beat is a cliffhanger), the GM agent must
call get_scene with include_beats:true before writing any opening
narration. Environmental details (lighting, NPC positions, held items)
must be anchored to the beat record, not inferred from the scene
summary which compresses away sensory/tactical specifics.

Fixes #154

https://claude.ai/code/session_01Cq6WE1d6EHEAxYWYrSMgRT