### PR TITLE
docs(v1): note Hermes Agent as alt-frontend candidate under OQ11

### DIFF
--- a/docs/design/agentic-rpg-v1.md
+++ b/docs/design/agentic-rpg-v1.md
@@ -1228,6 +1228,16 @@ Tracked separately. Major pieces:
 - **OQ11** What shape should the future alternate UI take (Electron,
   Tauri, web app, native mobile)? Out of scope for v1.0; flagged so
   that runtime decisions don't accidentally constrain it.
+  - **Candidate substrate:** [Hermes Agent](https://hermes-agent.nousresearch.com/)
+    (Nous Research, MIT) is a general-purpose agent runtime that solves
+    multi-platform dispatch (Discord/Slack/Telegram/WhatsApp/Signal/
+    Email/CLI), persistent memory + auto-generated skills, subagent
+    parallelization, sandboxed tool execution, and natural-language
+    scheduled automations out of the box. Adopting it would be a
+    frontend-level decision; our runtime stays domain-pure. Most
+    immediately interesting bits for us are multi-platform play
+    (Ironsworn over Discord) and scheduled automations (between-session
+    world clocks, faction turns — the sandbox-campaign future work).
 - **OQ12** Does Bun's `peerDependencies` handling produce clear-enough
   error messages for non-developer users when a peer constraint isn't
   satisfied (e.g., a setting requires a system the user hasn't

--- a/plugins/ironsworn/.claude-plugin/plugin.json
+++ b/plugins/ironsworn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ironsworn",
-  "version": "0.25.1",
+  "version": "0.25.2",
   "description": "Solo Ironsworn GM companion — fiction-first, dice-driven, with a living lore graph",
   "author": {
     "name": "Karim Naguib"


### PR DESCRIPTION
## Summary

Adds a sub-bullet under OQ11 in the v1.0 design doc noting Hermes Agent (https://hermes-agent.nousresearch.com/) as a candidate substrate for the alternate-frontend track. Documents that it solves multi-platform dispatch, persistent memory + auto-generated skills, subagent parallelization, sandboxed tool execution, and natural-language scheduled automations — and that adoption would be a frontend-level decision per D20.

Most immediately interesting for our use case: multi-platform play (Ironsworn over Discord) and scheduled automations (between-session world clocks for sandbox campaigns).

Plugin version bumped to 0.25.2 per Stop hook rule.

## Test plan
- [ ] CI green

---
_Generated by [Claude Code](https://claude.ai/code/session_013NWTzBz3kF7ARQouM5Fnap)_