### PR TITLE
Add restore_vow, add_asset tools; improve undo_last for forsake_vow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,8 @@ bun run tsc --noEmit            # typecheck
 bun run src/server.ts           # start MCP server locally (from scribe/)
 # one-time legacy → world.duckdb migration:
 bun run plugins/ironsworn/scribe/src/migrate.ts [campaignPath]
+# package plugin for marketplace distribution (resolves workspace:* dep):
+bash plugins/ironsworn/scripts/pack-plugin.sh [output-dir]
 ```
 
 ## Architecture

--- a/packages/core/src/rag/extraction.test.ts
+++ b/packages/core/src/rag/extraction.test.ts
@@ -422,3 +422,42 @@ describe("extractLoreFromScene — beats fallback", () => {
     expect(capturedSceneText).toBe("The ironmaster forges a blade in silence.");
   });
 });
+
+// ---------------------------------------------------------------------------
+// issue #161: _makeDefaultExtractor strips markdown code fences
+// ---------------------------------------------------------------------------
+
+describe("_makeDefaultExtractor — fence stripping", () => {
+  function makeMockClient(responseText: string): import("./communities.js").AnthropicLike {
+    return {
+      messages: {
+        create: async () => ({
+          content: [{ type: "text", text: responseText }],
+        }),
+      },
+    };
+  }
+
+  const validResult = { entities: [], relations: [] };
+  const validJson = JSON.stringify(validResult);
+
+  it("parses bare JSON without code fence", async () => {
+    const extractor = _makeDefaultExtractor(makeMockClient(validJson));
+    const result = await extractor("scene text", []);
+    expect(result).toEqual(validResult);
+  });
+
+  it("strips ```json ... ``` fence and parses", async () => {
+    const fenced = "```json\n" + validJson + "\n```";
+    const extractor = _makeDefaultExtractor(makeMockClient(fenced));
+    const result = await extractor("scene text", []);
+    expect(result).toEqual(validResult);
+  });
+
+  it("strips plain ``` ... ``` fence and parses", async () => {
+    const fenced = "```\n" + validJson + "\n```";
+    const extractor = _makeDefaultExtractor(makeMockClient(fenced));
+    const result = await extractor("scene text", []);
+    expect(result).toEqual(validResult);
+  });
+});

--- a/packages/core/src/rag/extraction.ts
+++ b/packages/core/src/rag/extraction.ts
@@ -299,7 +299,7 @@ export function _makeDefaultExtractor(client: AnthropicLike): Extractor {
       messages: [{ role: "user", content: userPrompt }],
     });
 
-    const text = response.content
+    let text = response.content
       .flatMap((b) =>
         b.type === "text" && typeof b.text === "string" ? [b.text] : [],
       )
@@ -309,6 +309,10 @@ export function _makeDefaultExtractor(client: AnthropicLike): Extractor {
     if (text.length === 0) {
       throw new Error("Empty extraction response from Anthropic");
     }
+
+    // Strip markdown code fences if the model wrapped the JSON.
+    const fenceMatch = text.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/);
+    if (fenceMatch) text = fenceMatch[1]!.trim();
 
     const parsed = JSON.parse(text) as ExtractionResult;
     parsed.entities = parsed.entities.filter((e) =>

--- a/packages/core/src/state/npcs.test.ts
+++ b/packages/core/src/state/npcs.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { getNpc, upsertNpc, npcFilePath, findStaleNpcs, getNpcLastUpdated, listNpcs, writeNpcRaw } from "./npcs.js";
+import { getLore } from "../rag/lore.js";
 
 let campaignDir: string;
 
@@ -55,6 +56,21 @@ describe("upsertNpc", () => {
     await upsertNpc(campaignDir, "Stranger");
     const content = await getNpc(campaignDir, "Stranger");
     expect(content).toContain("(none)");
+  });
+
+  // issue #162: summary must include the NPC name so search_lore(name) can find the entity
+  it("stores the NPC name in the entity summary", async () => {
+    await upsertNpc(campaignDir, "Serin", "A shady merchant.", "Useful but untrustworthy");
+    const entity = await getLore(campaignDir, "Serin");
+    expect(entity).not.toBeNull();
+    expect(entity!.summary).toContain("Serin");
+  });
+
+  it("uses just the name as summary when no description or impression provided", async () => {
+    await upsertNpc(campaignDir, "Anonymous");
+    const entity = await getLore(campaignDir, "Anonymous");
+    expect(entity).not.toBeNull();
+    expect(entity!.summary).toBe("Anonymous");
   });
 });
 

--- a/packages/core/src/state/npcs.ts
+++ b/packages/core/src/state/npcs.ts
@@ -118,7 +118,10 @@ export async function upsertNpc(
     let history: NpcHistoryEntry[];
     let entityId: string;
     const slug = slugify(name);
-    const summary = `${desc} ${imp}`.trim();
+    // Always include the name in the summary so name-based search_lore queries find this NPC.
+    // Extra detail from description/impression improves semantic recall for content searches.
+    const summaryParts = [name, ...(description ? [description] : []), ...(impression ? [impression] : [])];
+    const summary = summaryParts.join(": ");
     const embedding = await _safeEmbedding(summary);
     const embeddingLiteral = `[${embedding.join(",")}]::FLOAT[768]`;
 

--- a/plugins/ironsworn/.claude-plugin/plugin.json
+++ b/plugins/ironsworn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ironsworn",
-  "version": "0.27.0",
+  "version": "0.28.0",
   "description": "Solo Ironsworn GM companion — fiction-first, dice-driven, with a living lore graph",
   "author": {
     "name": "Karim Naguib"

--- a/plugins/ironsworn/agents/ironsworn-gm.md
+++ b/plugins/ironsworn/agents/ironsworn-gm.md
@@ -76,7 +76,12 @@ Follow these steps on every player turn:
 
    **Scene beats — MANDATORY.** Every `record_scene` call MUST include a `beats` array. Never call `record_scene` with an empty or missing `beats` field. A summary-only recording is forbidden.
 
-   During play, as events happen, call `record_beat` to write individual beats to the open scene in real time — do not reconstruct beats from memory at scene close. At scene close, pass those same beats (plus any final ones) in the `record_scene` call.
+   **Scene lifecycle — open early, beat as you go, close with summary:**
+   1. **Open the scene immediately** when a new scene begins (after `session_briefing` or at a scene boundary): call `record_scene` with a one-sentence placeholder summary (`"[scene opening — summary TBD]"`) to get a `scene_id`. Store this ID for the duration of the scene.
+   2. **Beat in real time**: after each significant in-scene event, call `record_beat(scene_id, ...)`. Do NOT accumulate beats in memory and batch them.
+   3. **Close the scene**: when the scene ends, call `update_scene(scene_id, summary)` with the final 1-2 sentence summary. The beats written during play are already stored; you do not need to re-pass them.
+
+   Do NOT wait until scene-close to call `record_scene` — by then you have no `scene_id` to give `record_beat`, forcing you to reconstruct beats from memory, which loses detail and defeats the purpose.
 
    You MUST always capture these beat kinds:
    - `move` — every dice roll: move name, stat, and outcome in `metadata` (`{move, stat, outcome}`)
@@ -112,6 +117,7 @@ You narrate the world. The player narrates their character. This boundary is abs
 - **Never call `companion_suffer_harm` or `companion_restore_health` before seeding the companion.** If a companion asset has not yet been registered via `upsert_companion`, those tools will fail with "Companion not found". Always call `lookup_asset` and then `upsert_companion` the first time a companion asset appears in play, before using any companion mutation tools.
 - **Never write through multiple choice points without pausing.** If your narration passes a moment where the player would reasonably want to speak, act, or decide, stop there. One significant beat per turn unless no decision is pending.
 - **Never call `record_scene` without a `beats` array.** A scene with no beats is a scene that cannot be searched. Always populate `beats` with at minimum the move resolutions and any significant NPC dialogue from the scene. Use `record_beat` during play as events happen so beats are never reconstructed from memory.
+- **Never wait until scene-close to call `record_scene`.** Open the scene immediately with a placeholder summary to get a `scene_id`, use that ID with `record_beat` throughout play, then call `update_scene` at scene close with the final summary. Batching all beats into the final `record_scene` call forces reconstruction from memory and loses detail.
 
 ## Tone and Voice
 

--- a/plugins/ironsworn/scribe/package.json
+++ b/plugins/ironsworn/scribe/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "start": "bun run src/server.ts",
     "sheet": "bun run ../scripts/sheet.ts",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "pack": "bash ../scripts/pack-plugin.sh"
   },
   "dependencies": {
     "@agentic-rpg/core": "workspace:*",

--- a/plugins/ironsworn/scribe/src/state/character.ts
+++ b/plugins/ironsworn/scribe/src/state/character.ts
@@ -195,17 +195,25 @@ function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
 }
 
+function normalizePath(path: string): string[] {
+  // Accept both dot notation (a.b.c) and bracket notation (a[1].b or a[1][2])
+  return path
+    .replace(/\[(\d+)\]/g, ".$1")
+    .split(".")
+    .filter((p) => p.length > 0);
+}
+
 function setNestedField(obj: Record<string, unknown>, path: string, value: unknown): void {
-  const parts = path.split(".");
+  const parts = normalizePath(path);
   let current: Record<string, unknown> = obj;
   for (let i = 0; i < parts.length - 1; i++) {
-    const part = parts[i];
+    const part = parts[i]!;
     if (current[part] === undefined || current[part] === null || typeof current[part] !== "object") {
       throw new Error(`Path segment "${part}" does not exist or is not an object`);
     }
     current = current[part] as Record<string, unknown>;
   }
-  current[parts[parts.length - 1]] = value;
+  current[parts[parts.length - 1]!] = value;
 }
 
 async function mutate(
@@ -412,6 +420,32 @@ export async function closeTrack(
       throw new Error(`Progress track not found: "${trackName}"`);
     }
     track.status = "fulfilled";
+  });
+}
+
+export async function addAsset(
+  campaignPath: string,
+  assetName: string,
+  numAbilities: number,
+  unlockedAbilityIndex?: number,
+): Promise<MutationResult> {
+  return mutate(campaignPath, "addAsset", (char) => {
+    const existing = char.assets.find(
+      (a) => a.name.toLowerCase() === assetName.toLowerCase(),
+    );
+    if (existing) {
+      throw new Error(`Asset "${assetName}" already exists on this character`);
+    }
+    const abilities = Array.from({ length: numAbilities }, () => false);
+    if (unlockedAbilityIndex !== undefined) {
+      if (unlockedAbilityIndex < 0 || unlockedAbilityIndex >= numAbilities) {
+        throw new Error(
+          `Ability index ${unlockedAbilityIndex} out of range (asset has ${numAbilities} abilities)`,
+        );
+      }
+      abilities[unlockedAbilityIndex] = true;
+    }
+    char.assets.push({ name: assetName, abilities });
   });
 }
 

--- a/plugins/ironsworn/scribe/src/tools/mutations.test.ts
+++ b/plugins/ironsworn/scribe/src/tools/mutations.test.ts
@@ -846,3 +846,158 @@ describe("recommit_vow", () => {
     expect(text).toMatch(/not active/);
   });
 });
+
+// ---------------------------------------------------------------------------
+// issue #163: override bracket notation
+// ---------------------------------------------------------------------------
+
+describe("override bracket notation", () => {
+  it("accepts bracket notation for array indices", async () => {
+    const result = await client.callTool({
+      name: "override",
+      arguments: { path: "progressTracks[0].status", value: "fulfilled" },
+    });
+    expect(result.isError).not.toBe(true);
+    const parsed = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+    expect(parsed.ok).toBe(true);
+    const charFile = await readFile(join(campaignDir, "character.json"), "utf8");
+    const char = JSON.parse(charFile);
+    expect(char.progressTracks[0].status).toBe("fulfilled");
+  });
+
+  it("dot notation still works", async () => {
+    const result = await client.callTool({
+      name: "override",
+      arguments: { path: "progressTracks.0.status", value: "forsaken" },
+    });
+    expect(result.isError).not.toBe(true);
+    const charFile = await readFile(join(campaignDir, "character.json"), "utf8");
+    const char = JSON.parse(charFile);
+    expect(char.progressTracks[0].status).toBe("forsaken");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// issue #174: add_asset tool
+// ---------------------------------------------------------------------------
+
+describe("add_asset", () => {
+  it("adds a new asset to the character", async () => {
+    const result = await client.callTool({
+      name: "add_asset",
+      arguments: { asset_name: "Infiltrator", num_abilities: 3, unlocked_ability_index: 0 },
+    });
+    expect(result.isError).not.toBe(true);
+    const parsed = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.asset.name).toBe("Infiltrator");
+    expect(parsed.asset.abilities).toEqual([true, false, false]);
+  });
+
+  it("rejects duplicate asset", async () => {
+    await client.callTool({
+      name: "add_asset",
+      arguments: { asset_name: "Blade", num_abilities: 3 },
+    });
+    const result = await client.callTool({
+      name: "add_asset",
+      arguments: { asset_name: "Blade", num_abilities: 3 },
+    });
+    expect(result.isError).toBe(true);
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text).toMatch(/already exists/);
+  });
+
+  it("adds asset with all abilities locked when no index given", async () => {
+    const result = await client.callTool({
+      name: "add_asset",
+      arguments: { asset_name: "Scout", num_abilities: 3 },
+    });
+    expect(result.isError).not.toBe(true);
+    const parsed = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+    expect(parsed.asset.abilities).toEqual([false, false, false]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// issue #159: undo_last after forsake_vow
+// ---------------------------------------------------------------------------
+
+describe("undo_last after forsake_vow", () => {
+  it("restores character state and reopens thread", async () => {
+    // Set spirit=5 so stress doesn't bottom out
+    await writeFile(
+      join(campaignDir, "character.json"),
+      JSON.stringify({ ...CHARACTER_WITH_TRACKS, spirit: 5 }),
+    );
+
+    // Create a vow (also opens a thread via auto-open)
+    await client.callTool({
+      name: "create_progress_track",
+      arguments: { name: "Avenge the Fallen", rank: "dangerous", kind: "vow" },
+    });
+
+    // Forsake it
+    await client.callTool({
+      name: "forsake_vow",
+      arguments: { track_name: "Avenge the Fallen" },
+    });
+
+    // Verify it's forsaken and spirit reduced
+    const charBefore = JSON.parse(await readFile(join(campaignDir, "character.json"), "utf8"));
+    expect(charBefore.progressTracks.find((t: { name: string }) => t.name === "Avenge the Fallen").status).toBe("forsaken");
+    expect(charBefore.spirit).toBe(3); // 5 - 2 (dangerous)
+
+    // Undo
+    const undoResult = await client.callTool({ name: "undo_last", arguments: {} });
+    expect(undoResult.isError).not.toBe(true);
+    const parsed = JSON.parse((undoResult.content as Array<{ type: string; text: string }>)[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.threadReopened).toBe(true);
+
+    // Verify track is active again and spirit restored
+    const charAfter = JSON.parse(await readFile(join(campaignDir, "character.json"), "utf8"));
+    const track = charAfter.progressTracks.find((t: { name: string }) => t.name === "Avenge the Fallen");
+    expect(track.status).toBe("active");
+    expect(charAfter.spirit).toBe(5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// issue #165: restore_vow tool
+// ---------------------------------------------------------------------------
+
+describe("restore_vow", () => {
+  it("restores a forsaken vow atomically", async () => {
+    await writeFile(
+      join(campaignDir, "character.json"),
+      JSON.stringify({
+        ...CHARACTER_WITH_TRACKS,
+        spirit: 5,
+        progressTracks: [
+          { name: "Iron Oath", rank: "dangerous", kind: "vow", ticks: 10, status: "forsaken" },
+        ],
+      }),
+    );
+
+    const result = await client.callTool({
+      name: "restore_vow",
+      arguments: { track_name: "Iron Oath" },
+    });
+    expect(result.isError).not.toBe(true);
+    const parsed = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.track.status).toBe("active");
+    expect(parsed.spiritRestored).toBe(2);
+  });
+
+  it("rejects non-forsaken tracks", async () => {
+    const result = await client.callTool({
+      name: "restore_vow",
+      arguments: { track_name: "Remove Caldren from Holtfen" },
+    });
+    expect(result.isError).toBe(true);
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text).toMatch(/not forsaken/);
+  });
+});

--- a/plugins/ironsworn/scribe/src/tools/mutations.ts
+++ b/plugins/ironsworn/scribe/src/tools/mutations.ts
@@ -19,6 +19,7 @@ import {
   companionSufferHarm,
   companionRestoreHealth,
   upsertCompanion,
+  addAsset,
   upgradeAsset,
   closeTrack,
   Character,
@@ -29,7 +30,7 @@ import { tickProgress, vowXp, TICKS_PER_MARK, STRESS_BY_RANK, RANK_LADDER } from
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { recordMutation } from "@agentic-rpg/core";
-import { openThread, closeThread, loadThreads } from "../state/threads.js";
+import { openThread, closeThread, loadThreads, saveThreads } from "../state/threads.js";
 
 function characterDigest(char: Character) {
   const activeDebilities = Object.fromEntries(
@@ -511,6 +512,95 @@ export function register(server: McpServer, campaignPath: string): void {
   );
 
   server.tool(
+    "restore_vow",
+    [
+      "Atomically reverse a forsake_vow — use when undo_last is unavailable or fails.",
+      "",
+      "Atomically: sets track status back to 'active', restores spirit by the rank's stress amount",
+      "(troublesome=1, dangerous=2, formidable=3, extreme=4, epic=5),",
+      "and re-opens the matching thread if it was closed with a 'Forsaken' resolution.",
+    ].join("\n"),
+    {
+      track_name: z.string().describe("Name of the forsaken vow track to restore (case-insensitive)"),
+    },
+    async ({ track_name }) => {
+      try {
+        const character = await loadCharacter(campaignPath);
+        const idx = character.progressTracks.findIndex(
+          (t) => t.name.toLowerCase() === track_name.toLowerCase(),
+        );
+        if (idx === -1) {
+          return {
+            content: [{ type: "text", text: `Error: Progress track not found: "${track_name}"` }],
+            isError: true,
+          };
+        }
+        const track = character.progressTracks[idx]!;
+        if (track.kind !== "vow") {
+          return {
+            content: [{ type: "text", text: `Error: restore_vow applies to vow tracks only. Track "${track.name}" is kind="${track.kind}".` }],
+            isError: true,
+          };
+        }
+        if (track.status !== "forsaken") {
+          return {
+            content: [{ type: "text", text: `Error: Track "${track.name}" is not forsaken (status: ${track.status})` }],
+            isError: true,
+          };
+        }
+
+        const stressAmount = STRESS_BY_RANK[track.rank];
+        const before = structuredClone(character);
+        track.status = "active";
+        character.spirit = Math.min(5, character.spirit + stressAmount);
+        await saveCharacter(campaignPath, character);
+
+        let threadReopened = false;
+        const threads = await loadThreads(campaignPath);
+        const closedMatch = threads.find(
+          (t) =>
+            t.title.toLowerCase() === track_name.toLowerCase() &&
+            t.status === "closed" &&
+            (t.resolution === "Forsaken" || (t.resolution ?? "").startsWith("Forsaken:")),
+        );
+        if (closedMatch) {
+          closedMatch.status = "open";
+          delete closedMatch.closedAt;
+          delete closedMatch.resolution;
+          await saveThreads(campaignPath, threads);
+          threadReopened = true;
+        }
+
+        await appendJournal(campaignPath, {
+          timestamp: new Date().toISOString(),
+          kind: "restoreVow",
+          before,
+          after: await loadCharacter(campaignPath),
+        });
+        recordMutation(campaignPath);
+
+        return {
+          content: [{
+            type: "text",
+            text: JSON.stringify({
+              ok: true,
+              track: character.progressTracks[idx],
+              spiritRestored: stressAmount,
+              spirit: character.spirit,
+              threadReopened,
+            }),
+          }],
+        };
+      } catch (e) {
+        return {
+          content: [{ type: "text", text: `Error: ${e instanceof Error ? e.message : String(e)}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.tool(
     "recommit_vow",
     [
       "Recommit to a vow after a Fulfill Your Vow miss (RAW: 'You recommit').",
@@ -752,7 +842,7 @@ export function register(server: McpServer, campaignPath: string): void {
 
   server.tool(
     "undo_last",
-    "Undo the last character mutation by restoring from the journal",
+    "Undo the last character mutation by restoring from the journal. For forsake_vow mutations, also reopens the matching thread.",
     {},
     async () => {
       try {
@@ -776,12 +866,58 @@ export function register(server: McpServer, campaignPath: string): void {
           };
         }
 
-        const lastLine = lines[lines.length - 1]!;
-        const entry = JSON.parse(lastLine) as { before: Character; after: Character };
+        // Walk backwards to find the last parseable entry.
+        let entry: { kind?: string; before: Character; after: Character } | null = null;
+        for (let i = lines.length - 1; i >= 0; i--) {
+          try {
+            entry = JSON.parse(lines[i]!) as { kind?: string; before: Character; after: Character };
+            break;
+          } catch {
+            // Skip malformed lines and try the previous one.
+          }
+        }
+        if (!entry) {
+          return {
+            content: [{ type: "text", text: JSON.stringify({ ok: false, message: "No valid journal entry found to undo" }) }],
+          };
+        }
+
         await saveCharacter(campaignPath, entry.before);
+
+        // For forsake_vow, also reopen the thread that was closed.
+        let threadReopened = false;
+        if (entry.kind === "forsakeVow") {
+          const forsakenTrack = entry.after.progressTracks.find(
+            (t) => t.status === "forsaken" &&
+              entry!.before.progressTracks.find(
+                (b) => b.name === t.name && b.status === "active",
+              ),
+          );
+          if (forsakenTrack) {
+            const threads = await loadThreads(campaignPath);
+            const closedThread = threads.find(
+              (t) => t.title.toLowerCase() === forsakenTrack.name.toLowerCase() && t.status === "closed",
+            );
+            if (closedThread) {
+              closedThread.status = "open";
+              delete closedThread.closedAt;
+              delete closedThread.resolution;
+              await saveThreads(campaignPath, threads);
+              threadReopened = true;
+            }
+          }
+        }
+
         recordMutation(campaignPath);
         return {
-          content: [{ type: "text", text: JSON.stringify({ ok: true, restored: characterDigest(entry.before) }) }],
+          content: [{
+            type: "text",
+            text: JSON.stringify({
+              ok: true,
+              restored: characterDigest(entry.before),
+              ...(threadReopened ? { threadReopened: true } : {}),
+            }),
+          }],
         };
       } catch (e) {
         return {
@@ -899,6 +1035,33 @@ export function register(server: McpServer, campaignPath: string): void {
         recordMutation(campaignPath);
         return {
           content: [{ type: "text", text: JSON.stringify({ ok: true, experience: result.after.experience }) }],
+        };
+      } catch (e) {
+        return {
+          content: [{ type: "text", text: `Error: ${e instanceof Error ? e.message : String(e)}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.tool(
+    "add_asset",
+    "Add a new asset to the character sheet. Use when purchasing an asset the character does not yet own.",
+    {
+      asset_name: z.string().describe("Name of the asset to add (e.g. 'Infiltrator', 'Hound')"),
+      num_abilities: z.coerce.number().int().min(1).max(5).describe("Total number of abilities this asset has"),
+      unlocked_ability_index: z.coerce.number().int().min(0).optional().describe("Zero-based index of the first ability to unlock immediately (omit to add all abilities locked)"),
+    },
+    async ({ asset_name, num_abilities, unlocked_ability_index }) => {
+      try {
+        const result = await addAsset(campaignPath, asset_name, num_abilities, unlocked_ability_index);
+        recordMutation(campaignPath);
+        const asset = result.after.assets.find(
+          (a) => a.name.toLowerCase() === asset_name.toLowerCase(),
+        );
+        return {
+          content: [{ type: "text", text: JSON.stringify({ ok: true, asset }) }],
         };
       } catch (e) {
         return {

--- a/plugins/ironsworn/scribe/src/tools/narrative.test.ts
+++ b/plugins/ironsworn/scribe/src/tools/narrative.test.ts
@@ -143,6 +143,48 @@ describe("buildSceneWarnings", () => {
 });
 
 // ---------------------------------------------------------------------------
+// issue #164: open_thread vow + no rank warning
+// ---------------------------------------------------------------------------
+
+describe("open_thread — vow without rank warning", () => {
+  let server: McpServer;
+  let client: Client;
+
+  beforeEach(async () => {
+    server = new McpServer({ name: "test", version: "0.0.1" });
+    register(server, campaignDir);
+    client = new Client({ name: "test-client", version: "0.0.1" });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+  });
+
+  it("returns a warning when kind=vow but rank is omitted", async () => {
+    const result = await client.callTool({
+      name: "open_thread",
+      arguments: { title: "Avenge the Fallen", kind: "vow" },
+    });
+    expect(result.isError).not.toBe(true);
+    const parsed = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+    expect(parsed.progressTrack).toBeNull();
+    expect(typeof parsed.warning).toBe("string");
+    expect(parsed.warning).toContain("rank");
+  });
+
+  it("creates a progress track and no warning when rank is provided", async () => {
+    if (!(await ollamaAvailable())) return;
+    const result = await client.callTool({
+      name: "open_thread",
+      arguments: { title: "Iron Oath", kind: "vow", rank: "dangerous" },
+    });
+    expect(result.isError).not.toBe(true);
+    const parsed = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+    expect(parsed.progressTrack).not.toBeNull();
+    expect(parsed.warning).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // record_beat tool
 // ---------------------------------------------------------------------------
 

--- a/plugins/ironsworn/scribe/src/tools/narrative.ts
+++ b/plugins/ironsworn/scribe/src/tools/narrative.ts
@@ -273,16 +273,21 @@ export function register(server: McpServer, campaignPath: string): void {
 
         // Issue #2: auto-create a matching progress track for vow threads
         let track: ProgressTrack | undefined;
-        if (kind === "vow" && rank !== undefined) {
-          const character = await loadCharacter(campaignPath);
-          track = { name: title, rank: rank as ProgressTrack["rank"], kind: "vow", ticks: 0, status: "active" };
-          character.progressTracks.push(track);
-          await saveCharacter(campaignPath, character);
+        let warning: string | undefined;
+        if (kind === "vow") {
+          if (rank !== undefined) {
+            const character = await loadCharacter(campaignPath);
+            track = { name: title, rank: rank as ProgressTrack["rank"], kind: "vow", ticks: 0, status: "active" };
+            character.progressTracks.push(track);
+            await saveCharacter(campaignPath, character);
+          } else {
+            warning = "No progress track created — rank is required for vow threads. Call create_progress_track separately or re-open with a rank.";
+          }
         }
 
         recordMutation(campaignPath);
         return {
-          content: [{ type: "text", text: JSON.stringify({ ...thread, progressTrack: track ?? null }) }],
+          content: [{ type: "text", text: JSON.stringify({ ...thread, progressTrack: track ?? null, ...(warning ? { warning } : {}) }) }],
         };
       } catch (e) {
         return {

--- a/plugins/ironsworn/scripts/pack-plugin.sh
+++ b/plugins/ironsworn/scripts/pack-plugin.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# pack-plugin.sh — package the ironsworn plugin for marketplace distribution
+#
+# Usage: bash scripts/pack-plugin.sh [output-dir]
+#
+# Produces a self-contained copy of plugins/ironsworn/ where scribe's
+# @agentic-rpg/core workspace dependency is resolved to a real directory,
+# so `bun install` works outside the monorepo (fixes #170, #171).
+#
+# The script must be run from the repo root.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../" && pwd)"
+PLUGIN_SRC="$REPO_ROOT/plugins/ironsworn"
+CORE_SRC="$REPO_ROOT/packages/core"
+OUTPUT_DIR="${1:-$REPO_ROOT/dist/ironsworn}"
+
+echo "[pack] Cleaning output dir: $OUTPUT_DIR"
+rm -rf "$OUTPUT_DIR"
+mkdir -p "$OUTPUT_DIR"
+
+echo "[pack] Copying plugin sources..."
+# Copy everything except scribe/node_modules (re-installed below)
+rsync -a --exclude='scribe/node_modules' "$PLUGIN_SRC/" "$OUTPUT_DIR/"
+
+echo "[pack] Copying @agentic-rpg/core into scribe/node_modules..."
+CORE_DEST="$OUTPUT_DIR/scribe/node_modules/@agentic-rpg/core"
+mkdir -p "$(dirname "$CORE_DEST")"
+rsync -a --exclude='node_modules' "$CORE_SRC/" "$CORE_DEST/"
+
+echo "[pack] Rewriting workspace:* dep in scribe/package.json..."
+cd "$OUTPUT_DIR/scribe"
+# Replace workspace:* reference with the bundled local copy
+node -e "
+const fs = require('fs');
+const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+pkg.dependencies['@agentic-rpg/core'] = 'file:node_modules/@agentic-rpg/core';
+fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+"
+
+echo "[pack] Running bun install in scribe (external packages only)..."
+bun install
+
+echo "[pack] Done. Plugin packaged at: $OUTPUT_DIR"
+echo "[pack] Test with: SCRIBE_CAMPAIGN=<path> bun run $OUTPUT_DIR/scribe/src/server.ts"


### PR DESCRIPTION
## Summary

- **#159** `undo_last`: walks past malformed journal lines; also reopens the thread closed by `forsake_vow`
- **#160** GM agent prompt: clarifies open-early/beat-as-you-go/close-with-summary scene lifecycle so `record_beat` is called with a real `scene_id` from the start
- **#161** `extract_session_lore`: strips markdown code fences from LLM response before `JSON.parse` (fixes backtick parse error)
- **#162** `upsert_npc`: NPC name always included in entity summary so `search_lore(name)` can find newly-upserted NPCs
- **#163** `override`: accepts bracket notation (`progressTracks[14].status`) via `normalizePath()`
- **#164** `open_thread`: returns a `warning` field when `kind=vow` but `rank` is omitted, instead of silently returning `progressTrack: null`
- **#165** New `restore_vow` tool atomically reverses `forsake_vow` (track → active, spirit restored, thread reopened)
- **#170** / **#171** New `scripts/pack-plugin.sh` bundles the plugin with `@agentic-rpg/core` copied in and `workspace:*` rewritten to `file:` for marketplace installs
- **#174** New `add_asset` tool adds a brand-new asset to the character sheet

## Test plan

- 7 new unit tests in `mutations.test.ts` (override bracket notation, add_asset, undo_last+forsake_vow, restore_vow)
- 3 new tests in `extraction.test.ts` (fence stripping: bare JSON, \`\`\`json, plain \`\`\`)
- 2 new tests in `npcs.test.ts` (NPC name in entity summary)
- 2 new tests in `narrative.test.ts` (open_thread vow without rank)
- All 616 tests pass

Closes #159
Closes #160
Closes #161
Closes #162
Closes #163
Closes #164
Closes #165
Closes #170
Closes #171
Closes #174

https://claude.ai/code/session_012Y8v1DD4MK9Eyk2UB8Vjcf