### PR TITLE
fix: rename update_scene and delete_scene parameter id→scene_id for consistency

### DIFF
--- a/plugins/ironsworn/.claude-plugin/plugin.json
+++ b/plugins/ironsworn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ironsworn",
-  "version": "0.28.1",
+  "version": "0.28.2",
   "description": "Solo Ironsworn GM companion — fiction-first, dice-driven, with a living lore graph",
   "author": {
     "name": "Karim Naguib"

--- a/plugins/ironsworn/scribe/src/tools/narrative.test.ts
+++ b/plugins/ironsworn/scribe/src/tools/narrative.test.ts
@@ -271,3 +271,102 @@ describe("record_beat tool", () => {
     expect(text).toContain("non-existent-id");
   });
 });
+
+// ---------------------------------------------------------------------------
+// update_scene tool
+// ---------------------------------------------------------------------------
+
+describe("update_scene tool", () => {
+  let server: McpServer;
+  let client: Client;
+
+  beforeEach(async () => {
+    server = new McpServer({ name: "test", version: "0.0.1" });
+    register(server, campaignDir);
+    client = new Client({ name: "test-client", version: "0.0.1" });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+  });
+
+  it("accepts scene_id parameter (not id) and updates the scene", async () => {
+    if (!(await ollamaAvailable())) return;
+    const sceneId = await recordScene(campaignDir, "Original summary.", "exploration");
+
+    const result = await client.callTool({
+      name: "update_scene",
+      arguments: { scene_id: sceneId, summary: "Updated summary." },
+    });
+    expect(result.isError).not.toBe(true);
+    const parsed = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.id).toBe(sceneId);
+
+    const scene = await getScene(campaignDir, sceneId);
+    expect(scene).not.toBeNull();
+    expect(scene!.text).toBe("Updated summary.");
+  });
+
+  it("returns error for unknown scene_id", async () => {
+    if (!(await ollamaAvailable())) return;
+    // Initialize the DB
+    await recordScene(campaignDir, "Placeholder to init DB.");
+
+    const result = await client.callTool({
+      name: "update_scene",
+      arguments: { scene_id: "non-existent-id", summary: "Should fail." },
+    });
+    expect(result.isError).toBe(true);
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text).toContain("non-existent-id");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// delete_scene tool
+// ---------------------------------------------------------------------------
+
+describe("delete_scene tool", () => {
+  let server: McpServer;
+  let client: Client;
+
+  beforeEach(async () => {
+    server = new McpServer({ name: "test", version: "0.0.1" });
+    register(server, campaignDir);
+    client = new Client({ name: "test-client", version: "0.0.1" });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+  });
+
+  it("accepts scene_id parameter (not id) and deletes the scene", async () => {
+    if (!(await ollamaAvailable())) return;
+    const sceneId = await recordScene(campaignDir, "A scene to be deleted.", "exploration");
+
+    const result = await client.callTool({
+      name: "delete_scene",
+      arguments: { scene_id: sceneId },
+    });
+    expect(result.isError).not.toBe(true);
+    const parsed = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.id).toBe(sceneId);
+
+    const scene = await getScene(campaignDir, sceneId);
+    expect(scene).toBeNull();
+  });
+
+  it("returns error for unknown scene_id", async () => {
+    if (!(await ollamaAvailable())) return;
+    // Initialize the DB
+    await recordScene(campaignDir, "Placeholder to init DB.");
+
+    const result = await client.callTool({
+      name: "delete_scene",
+      arguments: { scene_id: "non-existent-id" },
+    });
+    expect(result.isError).toBe(true);
+    const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text).toContain("non-existent-id");
+  });
+});

--- a/plugins/ironsworn/scribe/src/tools/narrative.ts
+++ b/plugins/ironsworn/scribe/src/tools/narrative.ts
@@ -118,7 +118,7 @@ export function register(server: McpServer, campaignPath: string): void {
     "update_scene",
     "Update an existing scene record. Only provided fields are changed. Use append_beats to add new beats without replacing existing ones.",
     {
-      id: z.string().describe("ID of the scene to update"),
+      scene_id: z.string().describe("ID of the scene to update"),
       summary: z.string().optional().describe("New summary text (replaces existing)"),
       kind: z.string().optional().describe("New kind of scene"),
       npcs: z.array(z.string()).optional().describe("NPC names to verify are recorded"),
@@ -130,23 +130,23 @@ export function register(server: McpServer, campaignPath: string): void {
         "Fiction/RP quality feedback to set or replace on this scene"
       ),
     },
-    async ({ id, summary, kind, npcs, lore_ids, append_beats, quality_notes }) => {
+    async ({ scene_id, summary, kind, npcs, lore_ids, append_beats, quality_notes }) => {
       try {
-        const existing = await getScene(campaignPath, id);
+        const existing = await getScene(campaignPath, scene_id);
         if (existing === null) {
           return {
-            content: [{ type: "text", text: `Error: Scene not found: ${id}` }],
+            content: [{ type: "text", text: `Error: Scene not found: ${scene_id}` }],
             isError: true,
           };
         }
-        await updateScene(campaignPath, id, { summary, kind, quality_notes });
+        await updateScene(campaignPath, scene_id, { summary, kind, quality_notes });
         if (append_beats && append_beats.length > 0) {
-          await recordBeats(campaignPath, id, append_beats as BeatInput[]);
+          await recordBeats(campaignPath, scene_id, append_beats as BeatInput[]);
         }
         recordMutation(campaignPath);
         const { warnings, stubbed } = await buildSceneWarnings(campaignPath, npcs, lore_ids);
         return {
-          content: [{ type: "text", text: JSON.stringify({ ok: true, id, warnings, stubbed }) }],
+          content: [{ type: "text", text: JSON.stringify({ ok: true, id: scene_id, warnings, stubbed }) }],
         };
       } catch (e) {
         return {
@@ -230,21 +230,21 @@ export function register(server: McpServer, campaignPath: string): void {
     "delete_scene",
     "Delete a scene record by ID",
     {
-      id: z.string().describe("ID of the scene to delete"),
+      scene_id: z.string().describe("ID of the scene to delete"),
     },
-    async ({ id }) => {
+    async ({ scene_id }) => {
       try {
-        const existing = await getScene(campaignPath, id);
+        const existing = await getScene(campaignPath, scene_id);
         if (existing === null) {
           return {
-            content: [{ type: "text", text: `Error: Scene not found: ${id}` }],
+            content: [{ type: "text", text: `Error: Scene not found: ${scene_id}` }],
             isError: true,
           };
         }
-        await deleteScene(campaignPath, id);
+        await deleteScene(campaignPath, scene_id);
         recordMutation(campaignPath);
         return {
-          content: [{ type: "text", text: JSON.stringify({ ok: true, id }) }],
+          content: [{ type: "text", text: JSON.stringify({ ok: true, id: scene_id }) }],
         };
       } catch (e) {
         return {


### PR DESCRIPTION
## Summary

`update_scene` and `delete_scene` used `id` as the scene identifier parameter, while every other scene tool (`record_beat`, `get_scene`) uses `scene_id`. This caused confusing validation errors when callers used the consistent `scene_id` name. Both tools are now renamed to use `scene_id`, matching the rest of the API surface.

## Changes

- Renamed `update_scene` parameter: `id` → `scene_id`
- Renamed `delete_scene` parameter: `id` → `scene_id`
- Added tests for `update_scene` and `delete_scene` verifying the corrected parameter name is accepted and works end-to-end
- Bumped plugin version to 0.25.2

## Testing

- `bun test src/tools/narrative.test.ts` — all 20 tests pass (new Ollama-dependent tests are correctly skipped when Ollama is unavailable)
- `bun test` — all 294 tests pass
- `bun run tsc --noEmit` — no TypeScript errors

Closes #176