### PR TITLE
docs: fix orphaned heading + reconcile knowledge-graph.md with landed temporal work

### DIFF
--- a/docs/design/agentic-rpg-v1.md
+++ b/docs/design/agentic-rpg-v1.md
@@ -276,7 +276,7 @@ without you in the loop.
   story, and hex-crawl extension points wait until storyteller
   quality earns the right to scale.
 
-
+## Four levels of modularity
 
 v1.0 separates four concerns that v0.x conflated. Each is independently
 authored, distributed, and licensed:

--- a/docs/design/knowledge-graph.md
+++ b/docs/design/knowledge-graph.md
@@ -17,7 +17,10 @@ Closest cousins in the wild:
   graph, Claude-written cluster summaries, hybrid retrieval. We use the same
   Leiden + summarize loop in `rag/communities.ts`.
 - **Graphiti** — temporal narrative KG built from agent transcripts. We
-  share the extraction-from-prose pattern but defer bi-temporal edges.
+  share the extraction-from-prose pattern, adopted its extraction
+  approach into the DuckDB extractor (the 2026-06 Graphiti spike), and
+  now carry lightweight bi-temporal edges (`valid_at` / `invalid_at`)
+  on relations.
 - **Neo4j GenAI patterns** — vector-augmented property graph. Same shape;
   we use DuckDB rather than a graph DB.
 
@@ -143,16 +146,28 @@ narrative inference.
 **Revisit if:** ever. This is a setting-fiction system, not a logic
 database.
 
-### No bi-temporal validity windows
+### Lightweight bi-temporal validity (landed 2026-06)
 
-Relations do not carry `valid_from / valid_until`. A king who is deposed
-gets a new relation (`deposed-by`) and the GM judges from the relation's
-provenance which version is current. Graphiti does this properly; we
-defer until NPC churn forces it. See #55's "non-goals."
+> **Status update.** This started as a non-goal ("defer until NPC churn
+> forces it"). It was reversed and substantially implemented — narrating
+> a dead NPC as alive is the canonical coherence failure, which is too
+> central to a *storyteller* to defer. See the "v1 sequencing" section of
+> `agentic-rpg-v1.md` (priority #3).
 
-**Revisit if:** NPC state churn (deaths, role changes, faction shifts)
-makes the GM context regularly misrepresent the current state of a
-relation. Symptom: the GM agent narrates an NPC as alive who has died.
+Relations carry `valid_at` / `invalid_at` columns (`migrations/world.ts`,
+`rag/world-db.ts`). Extraction runs a `supersedes`-driven
+`invalidateRelations` pass, and all lore grounding reads apply a
+current-fact filter (`invalid_at IS NULL`) so deposed/dead/changed
+relations drop out of context automatically. A king who is deposed has
+his "rules" relation stamped `invalid_at` and the successor's relation
+opened — the GM no longer relies on reading provenance to guess which is
+current.
+
+**Deliberately still out of scope:** arbitrary historical "as-of
+`<timestamp>`" reads. Grounding reads filter to *current* facts only;
+querying the world's state as it stood at some past moment is not built.
+**Revisit if:** a play pattern needs the GM to narrate the past as it was
+believed then (flashbacks, unreliable memory, retconned canon).
 
 ### No cross-world entity references
 
@@ -204,7 +219,11 @@ between the two*.
   not bespoke clustering.
 - **D4** One world DB, campaign as a column (per #166). Visibility filter
   on every read.
-- **D5** No bi-temporal validity. Deferred until forced by symptom.
+- **D5** ~~No bi-temporal validity. Deferred until forced by symptom.~~
+  **Reversed (landed 2026-06):** lightweight bi-temporal edges
+  (`valid_at` / `invalid_at`) + `supersedes`-driven invalidation +
+  current-fact filter on grounding reads. Historical "as-of" reads
+  remain out of scope.
 - **D6** No reasoning engine. Inference is the GM agent's job.
 - **D7** Coherence enforced by ritual (canonize) + prompt (fiction
   grounding), not by schema constraints.
@@ -215,9 +234,11 @@ between the two*.
   surfaced in the extraction prompt (today: free-form with examples)?
   Tracked informally; revisit after Q1 retrieval quality is evaluated on
   more campaigns.
-- **OQ2** Do we need an explicit "supersedes" relation between entities
+- ~~**OQ2** Do we need an explicit "supersedes" relation between entities
   (the new Magistrate supersedes the deposed one) as a lighter alternative
-  to bi-temporal edges? Cheap to add; defer until a real case forces it.
+  to bi-temporal edges?~~ **Resolved (landed 2026-06):** yes —
+  `supersedes`-driven `invalidateRelations` runs in extraction, stamping
+  the superseded relation's `invalid_at`. See D5.
 - **OQ3** How does the canonize ritual surface in the UI/agent workflow?
   Slash command, end-of-session prompt, or implicit on extraction-with-
   high-confidence? Probably explicit slash command; settle when

--- a/plugins/ironsworn/.claude-plugin/plugin.json
+++ b/plugins/ironsworn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ironsworn",
-  "version": "0.30.0",
+  "version": "0.30.1",
   "description": "Solo Ironsworn GM companion — fiction-first, dice-driven, with a living lore graph",
   "author": {
     "name": "Karim Naguib"


### PR DESCRIPTION
## Summary

Two corrections surfaced during a design-doc review.

### 1. `agentic-rpg-v1.md` — restore lost heading

The `## Four levels of modularity` heading was dropped in an earlier edit, leaving the section content orphaned under blank lines (broke the TOC and section flow). Restored.

### 2. `knowledge-graph.md` — reconcile with the landed temporal work

The doc still declared bi-temporal validity a deferred non-goal, but it shipped in code (2026-06): `valid_at` / `invalid_at` columns on relations, `supersedes`-driven `invalidateRelations` in extraction, and a current-fact filter (`invalid_at IS NULL`) on all lore grounding reads. Four passages reconciled:

- **Graphiti cousin line** — notes we adopted its extraction approach into the DuckDB extractor and now carry bi-temporal edges.
- **"No bi-temporal validity windows"** → **"Lightweight bi-temporal validity (landed 2026-06)"** — describes what landed, with a status note on why the non-goal was reversed (narrating a dead NPC as alive is the canonical storyteller-coherence failure), and calls out the one remaining out-of-scope piece: arbitrary historical "as-of `<timestamp>`" reads.
- **D5** — struck through, marked reversed/landed.
- **OQ2** (`supersedes` edges) — marked resolved.

This keeps `knowledge-graph.md` consistent with `agentic-rpg-v1.md`'s v1-sequencing status block (priority #3, substantially done) and with the code.

Docs only. Version 0.30.0 → 0.30.1.

## Test plan
- [ ] CI green (docs-only)
- [ ] Version-bump check passes