### PR TITLE
feat: add recall() unified grounding tool (v0.35.0)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -40,6 +40,10 @@ export type { EmbeddingPin, WorldJson } from "./world.js";
 export { slugify, recordProvenance, upsertLore, searchLore, linkLore, getLoreGraph, getLore, listProvenance, exportLore, exportProvenance, replayProvenance, checkpointLore, canonizeEntity, decanonizeEntity, canonizeRelation, decanonizeRelation, LORE_TYPES } from "./rag/lore.js";
 export type { LoreType, ProvenanceInput, ProvenanceEntry, LoreRelation, LoreEntity, LinkLoreInput, UpsertLoreInput, UpsertLoreResult, LoreSearchHit, LoreGraph, LoreEntityExport, LoreRelationExport } from "./rag/lore.js";
 
+// RAG — recall (unified grounding dossier)
+export { recall } from "./rag/recall.js";
+export type { NearFilter, RecallOptions, RecallScene, RecallEntity, RecallCommunity, RecallResult } from "./rag/recall.js";
+
 // RAG — contradictions
 export {
   checkEntityContradiction,

--- a/packages/core/src/rag/recall.test.ts
+++ b/packages/core/src/rag/recall.test.ts
@@ -112,11 +112,39 @@ describe("recall", () => {
     expect(result.entities.length).toBeLessThanOrEqual(2);
   });
 
-  it("throws if near.entity is provided (not yet implemented)", async () => {
+  it("near.entity restricts results to graph neighbors of anchor", async () => {
     if (!(await ollamaAvailable())) return;
+    const { linkLore } = await import("./lore.js");
 
-    await expect(
-      recall(campaignDir, "iron", { near: { entity: "some-id" } })
-    ).rejects.toThrow("near.entity");
+    const { id: anchorId } = await upsertLore(campaignDir, {
+      canonical: "Caldren Village",
+      type: "place",
+      summary: "A settlement in the Hinterlands.",
+    });
+    const { id: neighborId } = await upsertLore(campaignDir, {
+      canonical: "Elder Marn",
+      type: "person",
+      summary: "The elder of Caldren, keeper of the village record.",
+    });
+    const { id: unrelatedId } = await upsertLore(campaignDir, {
+      canonical: "The Sunken Forge",
+      type: "place",
+      summary: "An ancient forge far to the south, no ties to Caldren.",
+    });
+    await linkLore(campaignDir, {
+      from: anchorId,
+      to: neighborId,
+      relation: "governed-by",
+    });
+
+    const result = await recall(campaignDir, "elder keeper village settlement", {
+      near: { entity: anchorId },
+      limit: 10,
+    });
+
+    const ids = result.entities.map((e) => e.id);
+    // Neighbor must appear; unrelated entity must not
+    expect(ids).toContain(neighborId);
+    expect(ids).not.toContain(unrelatedId);
   });
 });

--- a/packages/core/src/rag/recall.test.ts
+++ b/packages/core/src/rag/recall.test.ts
@@ -147,4 +147,41 @@ describe("recall", () => {
     expect(ids).toContain(neighborId);
     expect(ids).not.toContain(unrelatedId);
   });
+
+  it("near.entity - canonical name anchor works (no UUID required)", async () => {
+    if (!(await ollamaAvailable())) return;
+    const { linkLore } = await import("./lore.js");
+
+    const { id: anchorId } = await upsertLore(campaignDir, {
+      canonical: "Caldren Village",
+      type: "place",
+      summary: "A settlement in the Hinterlands.",
+    });
+    const { id: neighborId } = await upsertLore(campaignDir, {
+      canonical: "Elder Marn",
+      type: "person",
+      summary: "The elder of Caldren, keeper of the village record.",
+    });
+    const { id: unrelatedId } = await upsertLore(campaignDir, {
+      canonical: "The Sunken Forge",
+      type: "place",
+      summary: "An ancient forge far to the south, no ties to Caldren.",
+    });
+    await linkLore(campaignDir, {
+      from: anchorId,
+      to: neighborId,
+      relation: "governed-by",
+    });
+
+    // Pass the canonical name instead of a UUID — must not throw
+    const result = await recall(campaignDir, "elder keeper village settlement", {
+      near: { entity: "Caldren Village" },
+      limit: 10,
+    });
+
+    const ids = result.entities.map((e) => e.id);
+    // Neighbor must appear; unrelated entity must not
+    expect(ids).toContain(neighborId);
+    expect(ids).not.toContain(unrelatedId);
+  });
 });

--- a/packages/core/src/rag/recall.test.ts
+++ b/packages/core/src/rag/recall.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { recall } from "./recall.js";
+import { upsertLore } from "./lore.js";
+import { recordScene, setSceneEntityRefs } from "./scenes.js";
+
+let _ollamaReady: boolean | null = null;
+async function ollamaAvailable(): Promise<boolean> {
+  if (_ollamaReady !== null) return _ollamaReady;
+  try {
+    const baseUrl = process.env["OLLAMA_BASE_URL"] ?? "http://localhost:11434";
+    const res = await fetch(`${baseUrl}/api/embed`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model: "nomic-embed-text", input: "t" }),
+    });
+    _ollamaReady = res.ok;
+  } catch { _ollamaReady = false; }
+  return _ollamaReady;
+}
+
+let campaignDir: string;
+
+beforeEach(async () => {
+  campaignDir = await mkdtemp(join(tmpdir(), "scribe-recall-test-"));
+});
+
+afterEach(async () => {
+  await rm(campaignDir, { recursive: true, force: true });
+});
+
+describe("recall", () => {
+  it("returns a RecallResult with query, entities, and communities fields", async () => {
+    if (!(await ollamaAvailable())) return;
+
+    const result = await recall(campaignDir, "ancient forge");
+    expect(result.query).toBe("ancient forge");
+    expect(Array.isArray(result.entities)).toBe(true);
+    expect(Array.isArray(result.communities)).toBe(true);
+  });
+
+  it("returns entities matching the query", async () => {
+    if (!(await ollamaAvailable())) return;
+
+    const { id } = await upsertLore(campaignDir, {
+      canonical: "The Sunken Forge",
+      type: "place",
+      summary: "An ancient forge submerged beneath the Caldren fen.",
+    });
+
+    const result = await recall(campaignDir, "ancient forge");
+    const match = result.entities.find((e) => e.id === id);
+    expect(match).toBeDefined();
+    expect(match!.canonical).toBe("The Sunken Forge");
+    expect(match!.scenes).toBeDefined();
+    expect(Array.isArray(match!.scenes)).toBe(true);
+  });
+
+  it("hydrates scenes for returned entities via scene_entity_refs", async () => {
+    if (!(await ollamaAvailable())) return;
+
+    const { id: entityId } = await upsertLore(campaignDir, {
+      canonical: "Lona the Healer",
+      type: "person",
+      summary: "A healer in Caldren who owes Zura a debt.",
+    });
+    const sceneId = await recordScene(campaignDir, "Lona tended the wound without looking up.", "scene");
+    await setSceneEntityRefs(campaignDir, sceneId, [{ entity_id: entityId, role: "present" }]);
+
+    const result = await recall(campaignDir, "healer Lona");
+    const entity = result.entities.find((e) => e.id === entityId);
+    expect(entity).toBeDefined();
+    expect(entity!.scenes.length).toBeGreaterThan(0);
+    expect(entity!.scenes[0]!.id).toBe(sceneId);
+  });
+
+  it("caps scenes per entity at scenes_per_entity (default 2)", async () => {
+    if (!(await ollamaAvailable())) return;
+
+    const { id: entityId } = await upsertLore(campaignDir, {
+      canonical: "The Iron Gate",
+      type: "place",
+      summary: "A crumbling iron gate at the edge of the Hinterlands.",
+    });
+
+    // Record 4 scenes referencing this entity
+    for (let i = 0; i < 4; i++) {
+      const sceneId = await recordScene(campaignDir, `Scene ${i} at the Iron Gate`, "scene");
+      await setSceneEntityRefs(campaignDir, sceneId, [{ entity_id: entityId, role: "present" }]);
+    }
+
+    const result = await recall(campaignDir, "iron gate");
+    const entity = result.entities.find((e) => e.id === entityId);
+    expect(entity).toBeDefined();
+    expect(entity!.scenes.length).toBeLessThanOrEqual(2);
+  });
+
+  it("respects the limit option", async () => {
+    if (!(await ollamaAvailable())) return;
+
+    for (let i = 0; i < 5; i++) {
+      await upsertLore(campaignDir, {
+        canonical: `Entity ${i}`,
+        type: "concept",
+        summary: "A concept related to iron and forge craft.",
+      });
+    }
+
+    const result = await recall(campaignDir, "iron forge craft", { limit: 2 });
+    expect(result.entities.length).toBeLessThanOrEqual(2);
+  });
+
+  it("throws if near.entity is provided (not yet implemented)", async () => {
+    if (!(await ollamaAvailable())) return;
+
+    await expect(
+      recall(campaignDir, "iron", { near: { entity: "some-id" } })
+    ).rejects.toThrow("near.entity");
+  });
+});

--- a/packages/core/src/rag/recall.ts
+++ b/packages/core/src/rag/recall.ts
@@ -1,0 +1,130 @@
+import { resolveWorldContext } from "../world.js";
+import { getWorldDb } from "./world-db.js";
+import { searchLore } from "./lore.js";
+import { searchCommunities } from "./communities.js";
+import type { LoreType } from "./lore.js";
+import type { CommunitySearchHit } from "./communities.js";
+
+export type NearFilter =
+  | { entity: string };
+  // Future: | { coordinates: { x: number; y: number }; radius: number; metric: string }
+
+export interface RecallOptions {
+  kind?: LoreType;
+  near?: NearFilter;
+  limit?: number;
+  include_sibling_campaigns?: boolean;
+  scenes_per_entity?: number;   // default 2
+  communities?: number;         // default 3
+}
+
+export interface RecallScene {
+  id: string;
+  text: string;
+  timestamp: string;
+  kind: string;
+}
+
+export interface RecallEntity {
+  id: string;
+  slug: string;
+  canonical: string;
+  type: LoreType;
+  summary: string;
+  score: number;
+  scenes: RecallScene[];
+}
+
+export interface RecallCommunity {
+  id: string;
+  level: number;
+  summary: string;
+  score: number;
+}
+
+export interface RecallResult {
+  query: string;
+  entities: RecallEntity[];
+  communities: RecallCommunity[];
+}
+
+export async function recall(
+  campaignPath: string,
+  query: string,
+  opts?: RecallOptions,
+): Promise<RecallResult> {
+  if (opts?.near !== undefined) {
+    throw new Error("near.entity is not yet implemented in recall()");
+  }
+
+  const limit = opts?.limit ?? 5;
+  const scenesPerEntity = opts?.scenes_per_entity ?? 2;
+  const communityLimit = opts?.communities ?? 3;
+  const includeSiblings = opts?.include_sibling_campaigns ?? false;
+
+  const ctx = await resolveWorldContext(campaignPath);
+
+  // Parallel: entity search + community search + open DB connection
+  const [entityHits, communityHits, instance] = await Promise.all([
+    searchLore(campaignPath, query, limit, opts?.kind, { includeSiblings }),
+    searchCommunities(campaignPath, query, communityLimit, undefined, { includeSiblings }),
+    getWorldDb(ctx),
+  ]);
+
+  // Batch-fetch recent scenes for all matched entities via scene_entity_refs
+  const entityIds = entityHits.map((e) => e.id);
+  const scenesByEntity = new Map<string, RecallScene[]>();
+  for (const id of entityIds) scenesByEntity.set(id, []);
+
+  if (entityIds.length > 0) {
+    const placeholders = entityIds.map(() => "?").join(",");
+    const conn = await instance.connect();
+    try {
+      const rows = (
+        await conn.runAndReadAll(
+          `SELECT s.id, s.text, s.timestamp, s.kind, ser.entity_id
+           FROM scene_entity_refs ser
+           JOIN scenes s ON s.id = ser.scene_id
+           WHERE ser.entity_id IN (${placeholders})
+             AND s.campaign_id = ?
+           ORDER BY s.timestamp DESC`,
+          [...entityIds, ctx.campaignId],
+        )
+      ).getRowObjectsJS() as Record<string, unknown>[];
+
+      for (const row of rows) {
+        const eid = String(row["entity_id"] ?? "");
+        const bucket = scenesByEntity.get(eid);
+        if (bucket && bucket.length < scenesPerEntity) {
+          bucket.push({
+            id: String(row["id"] ?? ""),
+            text: String(row["text"] ?? ""),
+            timestamp: String(row["timestamp"] ?? ""),
+            kind: String(row["kind"] ?? "scene"),
+          });
+        }
+      }
+    } finally {
+      conn.closeSync();
+    }
+  }
+
+  const entities: RecallEntity[] = entityHits.map((hit) => ({
+    id: hit.id,
+    slug: hit.slug,
+    canonical: hit.canonical,
+    type: hit.type,
+    summary: hit.summary,
+    score: hit.score,
+    scenes: scenesByEntity.get(hit.id) ?? [],
+  }));
+
+  const communities: RecallCommunity[] = communityHits.map((c: CommunitySearchHit) => ({
+    id: c.id,
+    level: c.level,
+    summary: c.summary,
+    score: c.score,
+  }));
+
+  return { query, entities, communities };
+}

--- a/packages/core/src/rag/recall.ts
+++ b/packages/core/src/rag/recall.ts
@@ -72,7 +72,7 @@ export async function recall(
       const anchorRows = (
         await conn.runAndReadAll(
           `SELECT id FROM entities
-           WHERE id = ? OR lower(canonical) = lower(?) OR lower(slug) = lower(?)
+           WHERE (id = ? OR lower(canonical) = lower(?) OR lower(slug) = lower(?))
              AND (campaign_id IS NULL OR campaign_id = ?)
            LIMIT 1`,
           [anchorRef, anchorRef, anchorRef, ctx.campaignId],
@@ -102,12 +102,13 @@ export async function recall(
   }
 
   // Build entity search SQL — restrict to nearIds if present
-  const embeddingLiteral = await getWorldEmbedding(query).then(
-    (emb) => `[${emb.join(",")}]::FLOAT[768]`,
-  );
-
   let entityHits: LoreSearchHit[];
+  let communityHits: CommunitySearchHit[];
   if (nearIds !== null && nearIds.size > 0) {
+    // Embedding only needed for the manual cosine-similarity SQL on this path
+    const embeddingLiteral = await getWorldEmbedding(query).then(
+      (emb) => `[${emb.join(",")}]::FLOAT[768]`,
+    );
     const idList = [...nearIds];
     const placeholders = idList.map(() => "?").join(",");
     const conn = await instance.connect();
@@ -135,13 +136,15 @@ export async function recall(
     } finally {
       conn.closeSync();
     }
+    // Community search (always unrestricted — thematic framing shouldn't be proximity-filtered)
+    communityHits = await searchCommunities(campaignPath, query, communityLimit, undefined, { includeSiblings });
   } else {
-    // No near filter (or unknown anchor) — unrestricted search
-    entityHits = await searchLore(campaignPath, query, limit, opts?.kind, { includeSiblings });
+    // No near filter (or unknown anchor) — unrestricted search, run in parallel
+    [entityHits, communityHits] = await Promise.all([
+      searchLore(campaignPath, query, limit, opts?.kind, { includeSiblings }),
+      searchCommunities(campaignPath, query, communityLimit, undefined, { includeSiblings }),
+    ]);
   }
-
-  // Community search (always unrestricted — thematic framing shouldn't be proximity-filtered)
-  const communityHits = await searchCommunities(campaignPath, query, communityLimit, undefined, { includeSiblings });
 
   // Batch-fetch recent scenes for matched entities
   const entityIds = entityHits.map((e) => e.id);

--- a/packages/core/src/rag/recall.ts
+++ b/packages/core/src/rag/recall.ts
@@ -72,10 +72,12 @@ export async function recall(
       const anchorRows = (
         await conn.runAndReadAll(
           `SELECT id FROM entities
-           WHERE (id = ? OR lower(canonical) = lower(?) OR lower(slug) = lower(?))
+           WHERE (lower(id::TEXT) = lower(?) OR lower(canonical) = lower(?) OR lower(slug) = lower(?)
+                  OR EXISTS (SELECT 1 FROM unnest(aliases) AS t(alias) WHERE lower(alias) = lower(?)))
              AND (campaign_id IS NULL OR campaign_id = ?)
+           ORDER BY (campaign_id IS NOT NULL) DESC
            LIMIT 1`,
-          [anchorRef, anchorRef, anchorRef, ctx.campaignId],
+          [anchorRef, anchorRef, anchorRef, anchorRef, ctx.campaignId],
         )
       ).getRowObjectsJS() as Record<string, unknown>[];
       if (anchorRows.length === 0) {

--- a/packages/core/src/rag/recall.ts
+++ b/packages/core/src/rag/recall.ts
@@ -1,8 +1,8 @@
 import { resolveWorldContext } from "../world.js";
-import { getWorldDb } from "./world-db.js";
+import { getWorldDb, getWorldEmbedding } from "./world-db.js";
 import { searchLore } from "./lore.js";
 import { searchCommunities } from "./communities.js";
-import type { LoreType } from "./lore.js";
+import type { LoreType, LoreSearchHit } from "./lore.js";
 import type { CommunitySearchHit } from "./communities.js";
 
 export type NearFilter =
@@ -53,25 +53,97 @@ export async function recall(
   query: string,
   opts?: RecallOptions,
 ): Promise<RecallResult> {
-  if (opts?.near !== undefined) {
-    throw new Error("near.entity is not yet implemented in recall()");
-  }
-
   const limit = opts?.limit ?? 5;
   const scenesPerEntity = opts?.scenes_per_entity ?? 2;
   const communityLimit = opts?.communities ?? 3;
   const includeSiblings = opts?.include_sibling_campaigns ?? false;
 
   const ctx = await resolveWorldContext(campaignPath);
+  const instance = await getWorldDb(ctx);
 
-  // Parallel: entity search + community search + open DB connection
-  const [entityHits, communityHits, instance] = await Promise.all([
-    searchLore(campaignPath, query, limit, opts?.kind, { includeSiblings }),
-    searchCommunities(campaignPath, query, communityLimit, undefined, { includeSiblings }),
-    getWorldDb(ctx),
-  ]);
+  // Resolve near.entity to a set of allowed entity IDs (1-hop neighbors + anchor itself)
+  let nearIds: Set<string> | null = null;
+  if (opts?.near !== undefined) {
+    const { entity: anchorRef } = opts.near as { entity: string };
+    // Resolve anchor: try UUID first, then canonical/alias lookup
+    const conn = await instance.connect();
+    try {
+      // Resolve anchor id
+      const anchorRows = (
+        await conn.runAndReadAll(
+          `SELECT id FROM entities
+           WHERE id = ? OR lower(canonical) = lower(?) OR lower(slug) = lower(?)
+             AND (campaign_id IS NULL OR campaign_id = ?)
+           LIMIT 1`,
+          [anchorRef, anchorRef, anchorRef, ctx.campaignId],
+        )
+      ).getRowObjectsJS() as Record<string, unknown>[];
+      if (anchorRows.length === 0) {
+        // Unknown anchor — fall through to unrestricted search
+      } else {
+        const anchorId = String(anchorRows[0]!["id"]);
+        // Fetch 1-hop neighbors (both directions) with visibility filter
+        const neighborRows = (
+          await conn.runAndReadAll(
+            `SELECT DISTINCT
+               CASE WHEN from_entity = ? THEN to_entity ELSE from_entity END AS neighbor_id
+             FROM relations
+             WHERE (from_entity = ? OR to_entity = ?)
+               AND (campaign_id IS NULL OR campaign_id = ?)
+               AND invalid_at IS NULL`,
+            [anchorId, anchorId, anchorId, ctx.campaignId],
+          )
+        ).getRowObjectsJS() as Record<string, unknown>[];
+        nearIds = new Set([anchorId, ...neighborRows.map((r) => String(r["neighbor_id"]))]);
+      }
+    } finally {
+      conn.closeSync();
+    }
+  }
 
-  // Batch-fetch recent scenes for all matched entities via scene_entity_refs
+  // Build entity search SQL — restrict to nearIds if present
+  const embeddingLiteral = await getWorldEmbedding(query).then(
+    (emb) => `[${emb.join(",")}]::FLOAT[768]`,
+  );
+
+  let entityHits: LoreSearchHit[];
+  if (nearIds !== null && nearIds.size > 0) {
+    const idList = [...nearIds];
+    const placeholders = idList.map(() => "?").join(",");
+    const conn = await instance.connect();
+    try {
+      const rows = (
+        await conn.runAndReadAll(
+          `SELECT id, slug, canonical, type, summary,
+                  array_cosine_similarity(embedding, ${embeddingLiteral}) AS score
+           FROM entities
+           WHERE id IN (${placeholders})
+             AND (campaign_id IS NULL OR campaign_id = ?)
+           ORDER BY score DESC LIMIT ?`,
+          [...idList, ctx.campaignId, limit],
+        )
+      ).getRowObjectsJS() as Record<string, unknown>[];
+      entityHits = rows.map((row) => ({
+        id: String(row["id"] ?? ""),
+        slug: String(row["slug"] ?? ""),
+        canonical: String(row["canonical"] ?? ""),
+        type: String(row["type"] ?? "concept") as LoreType,
+        summary: String(row["summary"] ?? ""),
+        score: typeof row["score"] === "number" ? row["score"]
+          : typeof row["score"] === "bigint" ? Number(row["score"]) : Number.NaN,
+      }));
+    } finally {
+      conn.closeSync();
+    }
+  } else {
+    // No near filter (or unknown anchor) — unrestricted search
+    entityHits = await searchLore(campaignPath, query, limit, opts?.kind, { includeSiblings });
+  }
+
+  // Community search (always unrestricted — thematic framing shouldn't be proximity-filtered)
+  const communityHits = await searchCommunities(campaignPath, query, communityLimit, undefined, { includeSiblings });
+
+  // Batch-fetch recent scenes for matched entities
   const entityIds = entityHits.map((e) => e.id);
   const scenesByEntity = new Map<string, RecallScene[]>();
   for (const id of entityIds) scenesByEntity.set(id, []);

--- a/plugins/ironsworn/.claude-plugin/plugin.json
+++ b/plugins/ironsworn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ironsworn",
-  "version": "0.34.0",
+  "version": "0.35.0",
   "description": "Solo Ironsworn GM companion — fiction-first, dice-driven, with a living lore graph",
   "author": {
     "name": "Karim Naguib"

--- a/plugins/ironsworn/agents/ironsworn-gm.md
+++ b/plugins/ironsworn/agents/ironsworn-gm.md
@@ -134,16 +134,16 @@ You narrate the world. The player narrates their character. This boundary is abs
 
 The Ironlands are not a backdrop — they are a character. Cold, beautiful, indifferent. The land does not want the player to succeed. It simply continues: wind across scree, rot in the longhouse thatch, the smell of woodsmoke and blood. Speak the world into being with specific, sensory details. Not "the forest was dark" — "the pines closed over the path and the light went grey."
 
-Ground every scene in the established lore. Before narrating a location, NPC, or faction the player hasn't encountered before, call `search_lore` AND `search_lore_global` **in parallel in the same turn** — `search_lore` pulls entity-level facts (names, relations, prior appearances), `search_lore_global` pulls the thematic cluster those facts sit inside (what this region of the campaign is *about*). Synthesize both before narrating. The dark elves track oaths — let that color every encounter with them. Oath-debt shapes leadership — let that color every jarl and elder. Corruption-touched beasts move wrong — describe the wrongness. Waking darkness has a texture — give it one.
+Ground every scene in the established lore. Before narrating a location, NPC, or faction the player hasn't encountered before, call `recall` with the subject as the query — it returns matching entities, their recent scenes, and relevant community summaries in a single call. Synthesize all three before narrating.
 
-**Lore collision check (mandatory).** Before introducing ANY new named entity — person, faction, place, object, or role title — into narration, call `search_lore` with that name. **This is an entity-resolution lookup, not a grounding call — do NOT pair it with `search_lore_global`.** If the lore graph already records that name with a different meaning, choose a different name before writing a single word of fiction. Do not reuse established proper nouns for unrelated concepts. Example: if "Sentinels" is already recorded as supernatural enforcers from the Old World, do not use "Sentinel" as a title for local patrol wardens — pick a distinct name (Wardens, Watch-keepers, Holtfen Guard, etc.) and use it consistently from that scene forward.
+**Lore collision check (mandatory).** Before introducing ANY new named entity — person, faction, place, object, or role title — into narration, call `search_lore` with that name. **This is a targeted lookup, not a grounding call — do NOT use `recall` for this.** If the lore graph already records that name with a different meaning, choose a different name before writing a single word of fiction.
 
-**Local vs. Global Lore.** Two lore-search tools exist, and they answer different questions:
+**When to use `recall` vs `search_lore`:**
 
-- `search_lore` — entity-level. Name/alias resolution, collision checks, per-NPC or per-place facts. Use it whenever you want specific names, relations, or prior appearances.
-- `search_lore_global` — theme-level. Cluster summaries produced by `recompute_communities` — "what is this cluster about," "what's the shape of the iron-economy side of the campaign," "what's the central tension across the whole story so far." Returns 2–4 sentence summaries per cluster with similarity scores.
-
-Pair them (call both in parallel) whenever you consult lore to ground a scene — the specific facts and the thematic framing belong together. Do NOT pair them for the name-collision check above; that is an entity-resolution lookup only. If `search_lore_global` returns nothing, it usually means `recompute_communities` hasn't been run yet — fall back to `search_lore` alone.
+- `recall` — full grounding: call it before narrating any scene. Returns entities + their recent scenes + thematic community summaries. One call; everything you need to narrate.
+- `search_lore` — targeted lookup: name-collision checks, resolving a specific ID, or when you need to query by type. Does not return scenes or communities.
+- `search_lore_global` — community summaries only: use when `recall` returns no community hits (i.e., `recompute_communities` hasn't run yet) and you want theme-level framing.
+- `near: { entity: "<id>" }` on `recall` — scope grounding to a place's graph neighborhood: "show me only entities connected to Caldren Village."
 
 **Entities, canon, and overlay.** Everything in the lore graph is an *entity* (person, place, faction, material, concept, creature, event, truth, thread). Record new lore with `upsert_entity` (`upsert_lore` / `upsert_npc` still work as aliases). Every entity is **either world canon or campaign-scoped**:
 
@@ -184,7 +184,7 @@ Complication and opportunity should feel inevitable in retrospect, like they wer
 
 Before narrating any fiction that introduces or invokes a place, NPC, faction, or past event:
 
-1. **Search first** — Call `search_lore_global` (or `search_lore` if the scope is specific) for the subject.
+1. **Ground first** — Call `recall` for the subject. It returns entities, their recent scenes, and community summaries in one call. For a specific place, pass `near: { entity: "<place-id>" }` to restrict results to entities connected to that place.
 2. **If results exist** — Weave them in. Honor what's already established: voice, faction ties, past beats.
 3. **If no results** — You are inventing something new. Narrate it, then call `upsert_entity` (or its `upsert_lore` alias) after the beat to record it. It lands campaign-scoped; canonize it later only if it becomes true for the whole world.
 4. **Never contradict** — If a roll or oracle says something that conflicts with established lore, treat the conflict itself as the complication.

--- a/plugins/ironsworn/scribe/src/tools/lore.ts
+++ b/plugins/ironsworn/scribe/src/tools/lore.ts
@@ -12,6 +12,8 @@ import {
   decanonizeRelation,
   LORE_TYPES,
   type LoreType,
+  recall,
+  type RecallOptions,
 } from "@agentic-rpg/core";
 import {
   recomputeCommunities,
@@ -252,6 +254,53 @@ export function register(server: McpServer, campaignPath: string): void {
       try {
         const results = await searchCommunities(campaignPath, query, k, undefined, { includeSiblings: include_sibling_campaigns ?? false });
         return { content: [{ type: "text", text: JSON.stringify(results) }] };
+      } catch (e) {
+        return {
+          content: [{ type: "text", text: `Error: ${e instanceof Error ? e.message : String(e)}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+
+  server.tool(
+    "recall",
+    [
+      "Unified grounding dossier: one call returns matching entities, their recent scenes, and relevant community summaries.",
+      "Replaces the parallel search_lore + search_lore_global pattern for scene grounding.",
+      "Use this as the first tool call before narrating any scene that introduces or invokes a place, NPC, faction, or past event.",
+      "search_lore and search_lore_global remain available for targeted lookups (entity-resolution checks, name-collision detection).",
+      "Returns { query, entities: [{ id, slug, canonical, type, summary, score, scenes: [{ id, text, timestamp, kind }] }], communities: [{ id, level, summary, score }] }.",
+    ].join(" "),
+    {
+      query: z.string().describe("Search query — what to ground (e.g. 'Caldren village', 'Lona the healer', 'the iron-oath network')"),
+      kind: z.enum(LORE_TYPES).optional().describe("Filter entities to a specific type"),
+      near: z.object({ entity: z.string() }).optional().describe(
+        "Restrict entity results to 1-hop lore-graph neighbors of this entity (id, canonical, or alias)"
+      ),
+      limit: z.coerce.number().int().positive().optional().describe("Max entities to return (default 5)"),
+      scenes_per_entity: z.coerce.number().int().positive().optional().describe(
+        "Max recent scenes per entity (default 2)"
+      ),
+      communities: z.coerce.number().int().positive().optional().describe(
+        "Max community summaries to return (default 3)"
+      ),
+      include_sibling_campaigns: z.boolean().optional().describe(
+        "When true, search across all campaigns in the world (default false)"
+      ),
+    },
+    async ({ query, kind, near, limit, scenes_per_entity, communities, include_sibling_campaigns }) => {
+      try {
+        const opts: RecallOptions = {
+          kind: kind as LoreType | undefined,
+          near: near ? { entity: near.entity } : undefined,
+          limit,
+          scenes_per_entity,
+          communities,
+          include_sibling_campaigns,
+        };
+        const result = await recall(campaignPath, query, opts);
+        return { content: [{ type: "text", text: JSON.stringify(result) }] };
       } catch (e) {
         return {
           content: [{ type: "text", text: `Error: ${e instanceof Error ? e.message : String(e)}` }],

--- a/plugins/ironsworn/skills/ironsworn-scene-craft/SKILL.md
+++ b/plugins/ironsworn/skills/ironsworn-scene-craft/SKILL.md
@@ -29,8 +29,8 @@ A scene has a place, a moment, a stake, and an exit. This skill is the operation
 
 | Tool | When |
 |---|---|
-| `search_lore_global` | Before framing — anchor place, faces, threads (Fiction Grounding #103) |
-| `search_lore` / `get_npc` | Resolve a named place or NPC the scene needs |
+| `recall` | Before framing — grounding dossier: entities + scenes + communities (Fiction Grounding #103) |
+| `search_lore` | Targeted lookup: name-collision check, type filter, resolving a specific ID |
 | `list_threads` | Pick an open thread to surface as visible tension |
 | `search_scenes` | Sanity-check tone/sensory choices against prior scenes (continuity) |
 | `search_rules` | Re-pull rule text whenever this skill is invoked second-hand |
@@ -55,11 +55,10 @@ If the moment is a transition or montage, defer to `ironsworn-pacing` *before* f
 
 Before the first sentence:
 
-1. `search_lore_global` for the place. Prior detail is canon — match it.
-2. `search_lore` / `get_npc` for any face on stage.
-3. `list_threads` (k=3–5) — pick one to surface as visible tension.
+1. `recall` for the place and any faces on stage. Returns entities + their recent scenes + community summaries in one call. Pass `near: { entity: "<place-id>" }` to restrict to entities connected to this place.
+2. `list_threads` (k=3–5) — pick one to surface as visible tension.
 
-Never invent against the lore graph. If search returns nothing, you may invent — then `upsert_lore` so the next scene matches.
+Never invent against the lore graph. If recall returns nothing, you may invent — then `upsert_entity` so the next scene matches.
 
 ---
 
@@ -105,7 +104,7 @@ End on **one** of: a **question** (explicit or implicit), an **image** that reso
 
 ## Common Mistakes
 
-- **Skipping Fiction Grounding.** `search_lore_global` first, always.
+- **Skipping Fiction Grounding.** `recall` first, always.
 - **Five sensory details instead of three.** The fourth blunts the first three.
 - **Sight-only descriptions.** Smell, sound, and temperature do more work per word.
 - **Opening without a visible stake.** That's stage dressing.


### PR DESCRIPTION
## Summary

- Adds `recall(query, opts?)` in `packages/core/src/rag/recall.ts` — a single call that returns matching entities, their recent scenes (batch JOIN, no N+1), and community summaries in one grounding dossier
- `near: { entity }` option restricts the entity search to 1-hop graph neighbors of an anchor entity, resolving anchors by UUID, canonical name, slug, or alias (DuckDB UUID→TEXT cast to avoid conversion errors)
- Registers `recall` as an MCP tool in `scribe/src/tools/lore.ts`; `search_lore` and `search_lore_global` remain for targeted lookups and fallback
- Updates GM agent (`ironsworn-gm.md`) and scene-craft skill (`SKILL.md`) to call `recall` first for scene grounding instead of the old parallel two-call pattern
- 7 tests in `recall.test.ts` including a canonical-name anchor test that would have caught the UUID cast bug

## Test plan

- [ ] `bun test` in `packages/core` — 352 pass
- [ ] `bun test` in `plugins/ironsworn/scribe` — 320 pass
- [ ] `bun run tsc --noEmit` in `plugins/ironsworn/scribe` — 0 errors
- [ ] Verify `recall` appears in MCP tool list when scribe server starts
- [ ] In a live session: call `recall("Caldren Village")` and confirm entities + scenes + communities return in one response
- [ ] In a live session: call `recall("query", { near: { entity: "Caldren Village" } })` and confirm only graph-adjacent entities are returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)