### PR TITLE
Eval diagnostics + extraction findings → point-of-entry recording pivot (v0.36.0)

### DIFF
--- a/docs/design/agentic-rpg-v1.md
+++ b/docs/design/agentic-rpg-v1.md
@@ -155,6 +155,12 @@ pattern: rules are commodity data plus pure functions.
 
 ### v1 priorities, in order
 
+> **Status (as of 2026-06-21):** #1 ✅ done · #2 ❌ not started ·
+> #3 🟡 substantially done · #4 ❌ not started · #5 ❌ not started ·
+> #6 ❌ deferred by design. The gating decision (#1) is closed and the
+> DuckDB substrate is locked, which unblocks the rest. Next pickup: #2
+> (extraction evaluation harness).
+
 1. **Graphiti spike (gating decision).** ✅ **Resolved (2026-06-16): Path B.**
    Promote OQ1 from open question
    to the *first* decision. Feed the Zura corpus into Graphiti +
@@ -171,11 +177,19 @@ pattern: rules are commodity data plus pure functions.
    with known-correct entities and relations, scored on every prompt
    or model change. Without this, extraction quality is vibes.
    Required regardless of which way the Graphiti spike resolves.
-3. **Temporal truth.** Reverse the bi-temporal deferral in
-   `knowledge-graph.md`. If the Graphiti spike adopts Graphiti, bi-
-   temporal edges come for free. If it doesn't, add lightweight
-   `supersedes` edges (already filed as OQ2 in `knowledge-graph.md`)
-   plus an "as-of" filter on grounding reads.
+3. **Temporal truth.** 🟡 **Substantially done (landed 2026-06; spike
+   Phases 1–2, preserved through the Path B rollback).** Reverse the
+   bi-temporal deferral in `knowledge-graph.md`. If the Graphiti spike
+   adopts Graphiti, bi-temporal edges come for free. If it doesn't, add
+   lightweight `supersedes` edges (already filed as OQ2 in
+   `knowledge-graph.md`) plus an "as-of" filter on grounding reads.
+   **Done:** `valid_at`/`invalid_at` columns on relations
+   (`migrations/world.ts`, `rag/world-db.ts`), `supersedes`-driven
+   `invalidateRelations` in extraction, and a current-fact filter
+   (`invalid_at IS NULL`) on all lore grounding reads (`rag/lore.ts`).
+   **Remaining:** arbitrary historical "as-of `<timestamp>`" reads —
+   reads currently filter to *current* facts only, not a queryable past
+   state.
 4. **Write-time contradiction surfacing.** On `upsert_entity` /
    `link`, run a similarity check against existing canon and flag
    apparent contradictions (different summary for an existing alias;
@@ -1277,7 +1291,9 @@ in one world, with shared world canon).
 
 ## Migration from v0.x
 
-Tracked separately. Major pieces (✅ = landed, 🚧 = partially landed):
+Tracked separately. Major pieces (✅ = landed, 🚧 = partially landed,
+❌ = not started). As of 2026-06-21: #2, #3 landed; #1 partial; #4–#11
+not started.
 
 1. 🚧 Refactor the public repo into a Bun workspace monorepo:
    `packages/core` + `packages/system-ironsworn` +
@@ -1296,23 +1312,23 @@ Tracked separately. Major pieces (✅ = landed, 🚧 = partially landed):
    on the current DuckDB substrate — effectively Path B with DuckDB;
    the spike decides whether to port.)* **Resolved 2026-06-16: committed
    to Path B (DuckDB); Path A storage rejected.**
-4. Implement the setting-seed-at-world-init mechanism; package the
+4. ❌ Implement the setting-seed-at-world-init mechanism; package the
    Ironlands canon as `@agentic-rpg/setting-ironlands`. Verify a fresh
    world with no setting installed boots cleanly with no seed.
-5. Move existing skills into `@agentic-rpg/craft-default`; verify they
+5. ❌ Move existing skills into `@agentic-rpg/craft-default`; verify they
    don't leak system-specific tool names.
-6. Implement `recall` as the unified retrieval tool; deprecate the v0.x
+6. ❌ Implement `recall` as the unified retrieval tool; deprecate the v0.x
    split.
-7. Add per-tool retrieval budgets; tune.
-8. Implement the canonize slash command; integrate with `extract_session_lore`.
-9. Implement the future-proofing extension points (coordinates convention,
+7. ❌ Add per-tool retrieval budgets; tune.
+8. ❌ Implement the canonize slash command; integrate with `extract_session_lore`.
+9. ❌ Implement the future-proofing extension points (coordinates convention,
    bulk ops, `near` parameter union, `procgen` manifest type, `tick`
    primitive). Each is small individually; together they make v1.0 the
    architecture-stable target.
-10. Repackage the v0.x Delve expansion as `@karimn/ironsworn-delve` (or
+10. ❌ Repackage the v0.x Delve expansion as `@karimn/ironsworn-delve` (or
     similar) on a private registry; verify install via `bun add` works
     end-to-end with the new contribution mechanism.
-11. Move player-directive content out of CC memory into runtime-owned
+11. ❌ Move player-directive content out of CC memory into runtime-owned
     `preferences.md` files (world + per-campaign). Implement
     `remember(scope, note)` MCP tool. Read existing `.remember/`
     directories and project-level `CLAUDE.md` files into

--- a/docs/superpowers/plans/2026-06-27-point-of-entry-recording.md
+++ b/docs/superpowers/plans/2026-06-27-point-of-entry-recording.md
@@ -1,0 +1,769 @@
+# Point-of-Entry Structured Recording — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the GM record world canon (entities + relations) on the beat at narration time, via `record_beat`, instead of reconstructing it from prose with batch extraction.
+
+**Architecture:** A new core function `recordBeatCanon` resolves entity/relation names against the existing graph (exact-match reuse via `getLore`, else create) and writes them with beat provenance — the back half of `extractLoreFromScene` without the LLM. It rides the existing async beat queue: `BeatInput` gains optional `entities`/`relations`, the queue worker calls `recordBeatCanon` after writing the beat, and skipped items surface through the existing notice channel. The `record_beat` MCP tool gains the two params. Prompts make recording a habit; `extract_session_lore` is reframed as optional backfill.
+
+**Tech Stack:** Bun, TypeScript, DuckDB (`@agentic-rpg/core`), MCP server (scribe), Ollama embeddings (`nomic-embed-text`).
+
+## Global Constraints
+
+- Greenfield only — no migration of existing worlds.
+- Reliability is prompt discipline only — no enforcement hooks.
+- Unresolved relation endpoints are **skipped with a notice**, never auto-stubbed.
+- Point-of-entry dedup is **exact-match only** (`getLore` / `resolveExisting`) — no fuzzy/embedding dedup on this path.
+- Entity provenance and relation provenance use `{ source_kind: "beat", source_id: <sceneId> }`.
+- Relations carry `valid_at = <scene timestamp>`; `supersedes:true` calls `invalidateRelations` first.
+- No further extraction-quality optimization is in scope.
+- Run commands from `packages/core` (core) or `plugins/ironsworn/scribe` (scribe). Tests: `bun test`. Typecheck: `bun run tsc --noEmit`.
+- Tests that exercise `upsertLore` need Ollama (it embeds the summary); guard them with an `ollamaAvailable()` early-return, mirroring `packages/core/src/rag/extraction.test.ts`.
+- **Every PR bumps `plugins/ironsworn/.claude-plugin/plugin.json`** (Stop hook enforces it).
+
+---
+
+## File Structure
+
+- **Create** `packages/core/src/rag/beat-canon.ts` — `recordBeatCanon()` + `BeatEntity`/`BeatRelation`/`BeatCanonResult` types. The resolution+write logic.
+- **Create** `packages/core/src/rag/beat-canon.test.ts` — unit tests for the above.
+- **Modify** `packages/core/src/rag/scenes.ts` — add optional `entities`/`relations` to `BeatInput`.
+- **Modify** `packages/core/src/rag/beat-queue.ts` — worker calls `recordBeatCanon` after the beat write; queues skip-notices.
+- **Modify** `packages/core/src/index.ts` — export `recordBeatCanon` + types.
+- **Create** `packages/core/src/rag/graph-health.ts` + `graph-health.test.ts` — golden-free fragmentation + relation-coverage checks.
+- **Modify** `plugins/ironsworn/scribe/src/tools/narrative.ts` — `record_beat` tool gains `entities`/`relations` params.
+- **Modify** `plugins/ironsworn/agents/ironsworn-gm.md`, `plugins/ironsworn/skills/ironsworn-scene-craft/SKILL.md`, `plugins/ironsworn/commands/extract-session-lore.md` — protocol + backfill framing.
+- **Modify** `docs/design/agentic-rpg-v1.md` — four reconciliation edits.
+- **Modify** `plugins/ironsworn/.claude-plugin/plugin.json` — version bump.
+
+---
+
+## Task 1: `recordBeatCanon` core function
+
+**Files:**
+- Create: `packages/core/src/rag/beat-canon.ts`
+- Test: `packages/core/src/rag/beat-canon.test.ts`
+
+**Interfaces:**
+- Consumes (existing, from `./lore.js`): `getLore(campaignPath, identifier) => Promise<LoreEntity | null>`; `upsertLore(campaignPath, { canonical, type, summary, aliases?, provenance? }) => Promise<UpsertLoreResult>`; `linkLore(campaignPath, { from, to, relation, notes?, valid_at?, provenance? })`; `invalidateRelations(campaignPath, fromId, toId, timestamp)`; `LORE_TYPES: readonly string[]`, `LoreType`. From `./scenes.js`: `getScene(campaignPath, sceneId) => Promise<{ timestamp: string } | null>`.
+- Produces: `recordBeatCanon(campaignPath: string, sceneId: string, entities?: BeatEntity[], relations?: BeatRelation[]) => Promise<BeatCanonResult>`; types `BeatEntity { canonical, type, summary, aliases? }`, `BeatRelation { from, to, label, notes?, supersedes? }`, `BeatCanonResult { entities_created, entities_reused, relations_linked, skipped: string[] }`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `packages/core/src/rag/beat-canon.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { recordBeatCanon } from "./beat-canon.js";
+import { upsertLore, getLore, exportLore } from "./lore.js";
+import { recordScene } from "./scenes.js";
+
+let _ollamaReady: boolean | null = null;
+async function ollamaAvailable(): Promise<boolean> {
+  if (_ollamaReady !== null) return _ollamaReady;
+  try {
+    const baseUrl = process.env["OLLAMA_BASE_URL"] ?? "http://localhost:11434";
+    const res = await fetch(`${baseUrl}/api/embed`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model: "nomic-embed-text", input: "t" }),
+    });
+    _ollamaReady = res.ok;
+  } catch {
+    _ollamaReady = false;
+  }
+  return _ollamaReady;
+}
+
+let dir: string;
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "beat-canon-test-"));
+});
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+describe("recordBeatCanon — entities", () => {
+  it("reuses an existing entity by exact canonical match (no duplicate)", async () => {
+    if (!(await ollamaAvailable())) return;
+    await upsertLore(dir, { canonical: "Lona", type: "person", summary: "A healer in Caldren." });
+    const sceneId = await recordScene(dir, "Lona tends the sick.");
+
+    const r = await recordBeatCanon(dir, sceneId,
+      [{ canonical: "Lona", type: "person", summary: "A healer." }], []);
+
+    expect(r.entities_reused).toBe(1);
+    expect(r.entities_created).toBe(0);
+    const { entities } = await exportLore(dir);
+    expect(entities.filter((e) => e.canonical.toLowerCase() === "lona").length).toBe(1);
+  });
+
+  it("creates a new campaign-scoped entity when not found", async () => {
+    if (!(await ollamaAvailable())) return;
+    const sceneId = await recordScene(dir, "Vera guards the gate of Stonehaven.");
+
+    const r = await recordBeatCanon(dir, sceneId,
+      [{ canonical: "Stonehaven", type: "place", summary: "A fortified settlement." }], []);
+
+    expect(r.entities_created).toBe(1);
+    expect(await getLore(dir, "Stonehaven")).not.toBeNull();
+  });
+
+  it("skips an entity with an invalid type", async () => {
+    if (!(await ollamaAvailable())) return;
+    const sceneId = await recordScene(dir, "Something happens.");
+    const r = await recordBeatCanon(dir, sceneId,
+      [{ canonical: "Bogus", type: "notatype" as never, summary: "x" }], []);
+    expect(r.entities_created).toBe(0);
+    expect(r.skipped.length).toBe(1);
+  });
+});
+
+describe("recordBeatCanon — relations", () => {
+  it("links a relation when both endpoints already exist", async () => {
+    if (!(await ollamaAvailable())) return;
+    await upsertLore(dir, { canonical: "Vera", type: "person", summary: "A guard." });
+    await upsertLore(dir, { canonical: "Stonehaven", type: "place", summary: "A settlement." });
+    const sceneId = await recordScene(dir, "Vera guards Stonehaven.");
+
+    const r = await recordBeatCanon(dir, sceneId, [],
+      [{ from: "Vera", to: "Stonehaven", label: "GUARDS" }]);
+
+    expect(r.relations_linked).toBe(1);
+    const { relations } = await exportLore(dir);
+    expect(relations.some((x) => x.relation === "GUARDS")).toBe(true);
+  });
+
+  it("resolves an endpoint created in the same call (entities then relations)", async () => {
+    if (!(await ollamaAvailable())) return;
+    const sceneId = await recordScene(dir, "Lona serves the Thornwood.");
+    const r = await recordBeatCanon(dir, sceneId,
+      [
+        { canonical: "Lona", type: "person", summary: "A healer." },
+        { canonical: "Thornwood", type: "faction", summary: "A faction." },
+      ],
+      [{ from: "Lona", to: "Thornwood", label: "MEMBER_OF" }]);
+    expect(r.entities_created).toBe(2);
+    expect(r.relations_linked).toBe(1);
+  });
+
+  it("skips a relation with an unresolved endpoint and reports it", async () => {
+    if (!(await ollamaAvailable())) return;
+    await upsertLore(dir, { canonical: "Oracle", type: "person", summary: "A seer." });
+    const sceneId = await recordScene(dir, "The oracle serves the hidden god.");
+
+    const r = await recordBeatCanon(dir, sceneId, [],
+      [{ from: "Oracle", to: "Hidden God", label: "SERVES" }]);
+
+    expect(r.relations_linked).toBe(0);
+    expect(r.skipped.length).toBe(1);
+    expect(r.skipped[0]).toContain("Hidden God");
+  });
+
+  it("invalidates a prior relation when supersedes is true", async () => {
+    if (!(await ollamaAvailable())) return;
+    await upsertLore(dir, { canonical: "Caldren", type: "person", summary: "A warden." });
+    await upsertLore(dir, { canonical: "Holtfen", type: "place", summary: "A village." });
+    const scene1 = await recordScene(dir, "Caldren leads Holtfen.");
+    await recordBeatCanon(dir, scene1, [], [{ from: "Caldren", to: "Holtfen", label: "HOLDS_TITLE" }]);
+    const scene2 = await recordScene(dir, "Caldren is banished from Holtfen.");
+
+    await recordBeatCanon(dir, scene2, [],
+      [{ from: "Caldren", to: "Holtfen", label: "BANISHED_FROM", supersedes: true }]);
+
+    const { relations } = await exportLore(dir);
+    const prior = relations.find((x) => x.relation === "HOLDS_TITLE");
+    expect(prior!.invalid_at).not.toBeNull();
+  });
+
+  it("is idempotent — re-recording the same canon adds no duplicates", async () => {
+    if (!(await ollamaAvailable())) return;
+    const sceneId = await recordScene(dir, "Vera guards Stonehaven.");
+    const beatEntities = [
+      { canonical: "Vera", type: "person" as const, summary: "A guard." },
+      { canonical: "Stonehaven", type: "place" as const, summary: "A settlement." },
+    ];
+    const beatRels = [{ from: "Vera", to: "Stonehaven", label: "GUARDS" }];
+    await recordBeatCanon(dir, sceneId, beatEntities, beatRels);
+    const r2 = await recordBeatCanon(dir, sceneId, beatEntities, beatRels);
+
+    expect(r2.entities_created).toBe(0);
+    expect(r2.entities_reused).toBe(2);
+    const { entities, relations } = await exportLore(dir);
+    expect(entities.filter((e) => e.canonical === "Vera").length).toBe(1);
+    expect(relations.filter((x) => x.relation === "GUARDS").length).toBe(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/core && bun test src/rag/beat-canon.test.ts`
+Expected: FAIL with `Cannot find module './beat-canon.js'`.
+
+- [ ] **Step 3: Implement `recordBeatCanon`**
+
+Create `packages/core/src/rag/beat-canon.ts`:
+
+```ts
+import {
+  upsertLore,
+  getLore,
+  linkLore,
+  invalidateRelations,
+  LORE_TYPES,
+  type LoreType,
+} from "./lore.js";
+import { getScene } from "./scenes.js";
+
+export interface BeatEntity {
+  canonical: string;
+  type: LoreType;
+  summary: string;
+  aliases?: string[];
+}
+
+export interface BeatRelation {
+  from: string;
+  to: string;
+  label: string;
+  notes?: string;
+  supersedes?: boolean;
+}
+
+export interface BeatCanonResult {
+  entities_created: number;
+  entities_reused: number;
+  relations_linked: number;
+  skipped: string[];
+}
+
+// Resolve + write the structured canon a beat establishes. Entities first
+// (exact-match reuse via getLore, else create campaign-scoped), then relations
+// (both endpoints must resolve against the graph, which now includes the
+// just-created entities). Unresolved relation endpoints are skipped with a
+// notice — never auto-stubbed — to preserve the exact-match cleanliness that
+// makes point-of-entry recording fragmentation-free.
+export async function recordBeatCanon(
+  campaignPath: string,
+  sceneId: string,
+  entities: BeatEntity[] = [],
+  relations: BeatRelation[] = [],
+): Promise<BeatCanonResult> {
+  const result: BeatCanonResult = {
+    entities_created: 0,
+    entities_reused: 0,
+    relations_linked: 0,
+    skipped: [],
+  };
+
+  const scene = await getScene(campaignPath, sceneId);
+  const validAt = scene?.timestamp;
+
+  for (const e of entities) {
+    if (!LORE_TYPES.includes(e.type)) {
+      result.skipped.push(`entity "${e.canonical}": invalid type "${e.type}"`);
+      continue;
+    }
+    const existing = await getLore(campaignPath, e.canonical);
+    if (existing !== null) {
+      result.entities_reused++;
+      continue;
+    }
+    await upsertLore(campaignPath, {
+      canonical: e.canonical,
+      type: e.type,
+      summary: e.summary,
+      aliases: e.aliases,
+      provenance: { source_kind: "beat", source_id: sceneId },
+    });
+    result.entities_created++;
+  }
+
+  for (const r of relations) {
+    const fromEntity = await getLore(campaignPath, r.from);
+    const toEntity = await getLore(campaignPath, r.to);
+    if (fromEntity === null || toEntity === null) {
+      const missing = fromEntity === null ? r.from : r.to;
+      result.skipped.push(
+        `relation ${r.from} -[${r.label}]-> ${r.to}: "${missing}" not found — ground it or add it to entities`,
+      );
+      continue;
+    }
+    if (r.supersedes && validAt) {
+      await invalidateRelations(campaignPath, fromEntity.id, toEntity.id, validAt);
+    }
+    await linkLore(campaignPath, {
+      from: fromEntity.id,
+      to: toEntity.id,
+      relation: r.label,
+      notes: r.notes,
+      valid_at: validAt,
+      provenance: { source_kind: "beat", source_id: sceneId },
+    });
+    result.relations_linked++;
+  }
+
+  return result;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/core && bun test src/rag/beat-canon.test.ts`
+Expected: PASS (all cases; or trivially pass/return early if Ollama is unreachable).
+
+- [ ] **Step 5: Typecheck and commit**
+
+```bash
+cd packages/core && bun run tsc --noEmit
+git add packages/core/src/rag/beat-canon.ts packages/core/src/rag/beat-canon.test.ts
+git commit -m "feat: recordBeatCanon — resolve + write beat canon (entities + relations)"
+```
+
+---
+
+## Task 2: Wire structured canon into the beat pipeline
+
+**Files:**
+- Modify: `packages/core/src/rag/scenes.ts` (the `BeatInput` interface)
+- Modify: `packages/core/src/rag/beat-queue.ts` (the worker loop, `_runWorker`)
+- Modify: `packages/core/src/index.ts` (exports)
+- Test: `packages/core/src/rag/beat-queue.test.ts` (existing file — add a case)
+
+**Interfaces:**
+- Consumes: `recordBeatCanon`, `BeatEntity`, `BeatRelation` from Task 1 (`./beat-canon.js`).
+- Produces: `BeatInput` now has optional `entities?: BeatEntity[]` and `relations?: BeatRelation[]`. When a beat carries them, the queue worker writes the canon after the beat row and queues any `skipped` notices (drainable via `drainNotices`). `recordBeatCanon` + types are re-exported from `@agentic-rpg/core`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `packages/core/src/rag/beat-queue.test.ts` (import `recordScene`, `getLore`, `drainNotices`, `pushBeat`, and an `ollamaAvailable()` guard as in Task 1):
+
+```ts
+describe("pushBeat — structured canon", () => {
+  it("writes a beat's entities and relations, surfacing skips as notices", async () => {
+    if (!(await ollamaAvailable())) return;
+    const dir = await mkdtemp(join(tmpdir(), "beat-queue-canon-"));
+    const sceneId = await recordScene(dir, "Vera guards Stonehaven; a stranger watches.");
+
+    const entry = await pushBeat(dir, sceneId, {
+      kind: "narration",
+      text: "Vera guards Stonehaven.",
+      entities: [
+        { canonical: "Vera", type: "person", summary: "A guard." },
+        { canonical: "Stonehaven", type: "place", summary: "A settlement." },
+      ],
+      relations: [
+        { from: "Vera", to: "Stonehaven", label: "GUARDS" },
+        { from: "Vera", to: "The Stranger", label: "WATCHED_BY" }, // unresolved → skipped
+      ],
+    });
+    await entry.settled;
+
+    expect(await getLore(dir, "Vera")).not.toBeNull();
+    expect(await getLore(dir, "Stonehaven")).not.toBeNull();
+    const notices = drainNotices(dir);
+    expect(notices.some((n) => n.includes("The Stranger"))).toBe(true);
+
+    await rm(dir, { recursive: true, force: true });
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd packages/core && bun test src/rag/beat-queue.test.ts`
+Expected: FAIL — `entities`/`relations` are not a known `BeatInput` field (tsc error) and no canon is written.
+
+- [ ] **Step 3: Extend `BeatInput`**
+
+In `packages/core/src/rag/scenes.ts`, find the `BeatInput` interface and add the two optional fields (import the types at the top of the file: `import type { BeatEntity, BeatRelation } from "./beat-canon.js";`):
+
+```ts
+export interface BeatInput {
+  kind: string;
+  text: string;
+  speaker?: string;
+  metadata?: Record<string, unknown>;
+  // Structured canon this beat establishes (point-of-entry recording).
+  entities?: BeatEntity[];
+  relations?: BeatRelation[];
+}
+```
+
+(Keep any existing fields on `BeatInput`; only add `entities`/`relations`.)
+
+- [ ] **Step 4: Write the canon in the worker**
+
+In `packages/core/src/rag/beat-queue.ts`, add the import and call `recordBeatCanon` after the beat row is written, inside `_runWorker`'s try-block. Replace:
+
+```ts
+      entry.beatIndex = await _recordBeat(campaignPath, entry.sceneId, entry.beat);
+      entry._resolve();
+```
+
+with:
+
+```ts
+      entry.beatIndex = await _recordBeat(campaignPath, entry.sceneId, entry.beat);
+      const { entities, relations } = entry.beat;
+      if ((entities && entities.length > 0) || (relations && relations.length > 0)) {
+        const canon = await recordBeatCanon(campaignPath, entry.sceneId, entities, relations);
+        for (const skip of canon.skipped) {
+          _queueNotice(campaignPath, `[core] beat canon skipped: ${skip}`);
+        }
+      }
+      entry._resolve();
+```
+
+Add at the top of `beat-queue.ts`:
+
+```ts
+import { recordBeatCanon } from "./beat-canon.js";
+```
+
+- [ ] **Step 5: Export from core**
+
+In `packages/core/src/index.ts`, add:
+
+```ts
+export {
+  recordBeatCanon,
+  type BeatEntity,
+  type BeatRelation,
+  type BeatCanonResult,
+} from "./rag/beat-canon.js";
+```
+
+- [ ] **Step 6: Run tests + typecheck**
+
+Run: `cd packages/core && bun test src/rag/beat-queue.test.ts && bun run tsc --noEmit`
+Expected: PASS; clean typecheck.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/core/src/rag/scenes.ts packages/core/src/rag/beat-queue.ts packages/core/src/index.ts packages/core/src/rag/beat-queue.test.ts
+git commit -m "feat: write beat canon through the async beat queue + notices"
+```
+
+---
+
+## Task 3: `record_beat` MCP tool — `entities` + `relations` params
+
+**Files:**
+- Modify: `plugins/ironsworn/scribe/src/tools/narrative.ts` (the `record_beat` tool registration)
+
+**Interfaces:**
+- Consumes: the extended `BeatInput` (Task 2) — `pushBeat` accepts `entities`/`relations` on the beat.
+- Produces: the `record_beat` MCP tool accepts optional `entities` and `relations` arrays and forwards them to `pushBeat`; on `wait=true`, any skip-notices are drained into the response (the handler already drains notices).
+
+- [ ] **Step 1: Add the Zod params**
+
+In `plugins/ironsworn/scribe/src/tools/narrative.ts`, in the `record_beat` registration's parameter object (alongside `scene_id`, `kind`, `text`, `speaker`, `metadata`, `wait`), add (import `LORE_TYPES` from `@agentic-rpg/core` at the top if not already imported):
+
+```ts
+      entities: z
+        .array(
+          z.object({
+            canonical: z.string(),
+            type: z.enum(LORE_TYPES),
+            summary: z.string(),
+            aliases: z.array(z.string()).optional(),
+          }),
+        )
+        .optional()
+        .describe("Canon this beat establishes. Reuse exact canonical names from grounding; new names create campaign-scoped entities."),
+      relations: z
+        .array(
+          z.object({
+            from: z.string(),
+            to: z.string(),
+            label: z.string(),
+            notes: z.string().optional(),
+            supersedes: z.boolean().optional(),
+          }),
+        )
+        .optional()
+        .describe("Relationships this beat asserts between known entities (existing or in this beat's `entities`). Endpoints that resolve to neither are skipped with a notice."),
+```
+
+- [ ] **Step 2: Forward them to `pushBeat`**
+
+In the same handler, the `pushBeat` call currently passes `{ kind, text, speaker, metadata }`. Change it to include the new fields:
+
+```ts
+      const entry = await pushBeat(campaignPath, scene_id, { kind, text, speaker, metadata, entities, relations });
+```
+
+and add `entities`, `relations` to the handler's destructured argument list (`async ({ scene_id, kind, text, speaker, metadata, wait, entities, relations }) => {`).
+
+- [ ] **Step 3: Typecheck + run scribe tests**
+
+Run: `cd plugins/ironsworn/scribe && bun run tsc --noEmit && bun test`
+Expected: clean typecheck; existing tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add plugins/ironsworn/scribe/src/tools/narrative.ts
+git commit -m "feat: record_beat MCP tool accepts entities + relations"
+```
+
+---
+
+## Task 4: Golden-free graph-health checks
+
+**Files:**
+- Create: `packages/core/src/rag/graph-health.ts`
+- Test: `packages/core/src/rag/graph-health.test.ts`
+
+**Interfaces:**
+- Produces two pure functions over an entity/relation list (no golden, no DB):
+  `fragmentationClusters(entities: { canonical: string; type: string; aliases: string[] }[]) => { type: string; names: string[] }[]` — groups **same-type** entities whose canonical token sets are in a strict subset relation (`Lago ⊂ Lago Rhian`), the signature of a fragmented node; and
+  `relationCoverage(entities: { id: string }[], relations: { from_id: string; to_id: string }[]) => { withRelation: number; total: number; ratio: number }`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `packages/core/src/rag/graph-health.test.ts`:
+
+```ts
+import { describe, it, expect } from "bun:test";
+import { fragmentationClusters, relationCoverage } from "./graph-health.js";
+
+describe("fragmentationClusters", () => {
+  it("groups same-type entities whose names are in a subset relation", () => {
+    const clusters = fragmentationClusters([
+      { canonical: "Lago Rhian", type: "person", aliases: [] },
+      { canonical: "Lago", type: "person", aliases: [] },
+      { canonical: "Ashfen Settlement", type: "place", aliases: [] },
+      { canonical: "Ashfen", type: "place", aliases: [] },
+      { canonical: "Caldren", type: "person", aliases: [] },
+    ]);
+    const flat = clusters.map((c) => c.names.sort());
+    expect(flat).toContainEqual(["Lago", "Lago Rhian"]);
+    expect(flat).toContainEqual(["Ashfen", "Ashfen Settlement"]);
+    expect(flat.flat()).not.toContain("Caldren"); // stands alone
+  });
+
+  it("does not cluster distinct same-pattern names (neither is a subset)", () => {
+    const clusters = fragmentationClusters([
+      { canonical: "Ashfen Harvest Vow", type: "thread", aliases: [] },
+      { canonical: "Greyhollow Harvest Vow", type: "thread", aliases: [] },
+    ]);
+    expect(clusters.length).toBe(0); // each has a unique discriminator token
+  });
+
+  it("does not cluster a subset-named entity of a different type", () => {
+    // "Caldren" (person) must not merge with "Caldren's Wardenship" (thread).
+    const clusters = fragmentationClusters([
+      { canonical: "Caldren", type: "person", aliases: [] },
+      { canonical: "Caldren Wardenship", type: "thread", aliases: [] },
+    ]);
+    expect(clusters.length).toBe(0);
+  });
+});
+
+describe("relationCoverage", () => {
+  it("reports the fraction of entities with at least one relation", () => {
+    const cov = relationCoverage(
+      [{ id: "a" }, { id: "b" }, { id: "c" }, { id: "d" }],
+      [{ from_id: "a", to_id: "b" }],
+    );
+    expect(cov.total).toBe(4);
+    expect(cov.withRelation).toBe(2); // a and b
+    expect(cov.ratio).toBeCloseTo(0.5);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/core && bun test src/rag/graph-health.test.ts`
+Expected: FAIL — `Cannot find module './graph-health.js'`.
+
+- [ ] **Step 3: Implement**
+
+Create `packages/core/src/rag/graph-health.ts`:
+
+```ts
+// Golden-free graph-health indicators, runnable against any world's graph.
+// Fragmentation: candidate duplicate nodes detected among the graph's OWN
+// entities — same type, and one canonical's token set a strict subset of the
+// other ("Lago" ⊂ "Lago Rhian"). Relation coverage: how connected the graph is.
+// Indicators, not scores.
+
+const STOPWORDS = new Set(["of", "the", "a", "at", "for"]);
+
+function tokens(name: string): Set<string> {
+  return new Set(
+    name
+      .toLowerCase()
+      .replace(/['’]s\b/g, "")
+      .replace(/[^a-z0-9\s]/g, " ")
+      .split(/\s+/)
+      .filter((t) => t.length > 0 && !STOPWORDS.has(t)),
+  );
+}
+
+// True when one token set is a strict subset of the other (different sizes).
+function subsetMerge(a: Set<string>, b: Set<string>): boolean {
+  if (a.size === 0 || b.size === 0 || a.size === b.size) return false;
+  const [small, big] = a.size < b.size ? [a, b] : [b, a];
+  for (const t of small) if (!big.has(t)) return false;
+  return true;
+}
+
+export function fragmentationClusters(
+  entities: { canonical: string; type: string; aliases: string[] }[],
+): { type: string; names: string[] }[] {
+  const toks = entities.map((e) => tokens(e.canonical));
+  const parent = entities.map((_, i) => i);
+  const find = (i: number): number => (parent[i] === i ? i : (parent[i] = find(parent[i]!)));
+  for (let i = 0; i < entities.length; i++) {
+    for (let j = i + 1; j < entities.length; j++) {
+      if (entities[i]!.type !== entities[j]!.type) continue; // same-type only
+      if (subsetMerge(toks[i]!, toks[j]!)) parent[find(i)] = find(j);
+    }
+  }
+  const groups = new Map<number, string[]>();
+  for (let i = 0; i < entities.length; i++) {
+    const root = find(i);
+    (groups.get(root) ?? groups.set(root, []).get(root)!).push(entities[i]!.canonical);
+  }
+  return [...groups.values()]
+    .filter((names) => names.length > 1)
+    .map((names) => ({ type: entities.find((e) => names.includes(e.canonical))!.type, names }));
+}
+
+export function relationCoverage(
+  entities: { id: string }[],
+  relations: { from_id: string; to_id: string }[],
+): { withRelation: number; total: number; ratio: number } {
+  const connected = new Set<string>();
+  for (const r of relations) {
+    connected.add(r.from_id);
+    connected.add(r.to_id);
+  }
+  const withRelation = entities.filter((e) => connected.has(e.id)).length;
+  const total = entities.length;
+  return { withRelation, total, ratio: total === 0 ? 0 : withRelation / total };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/core && bun test src/rag/graph-health.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Export + commit**
+
+Add to `packages/core/src/index.ts`:
+
+```ts
+export { fragmentationClusters, relationCoverage } from "./rag/graph-health.js";
+```
+
+```bash
+cd packages/core && bun run tsc --noEmit
+git add packages/core/src/rag/graph-health.ts packages/core/src/rag/graph-health.test.ts packages/core/src/index.ts
+git commit -m "feat: golden-free graph-health checks (fragmentation + relation coverage)"
+```
+
+---
+
+## Task 5: Protocol & prompt updates
+
+**Files:**
+- Modify: `plugins/ironsworn/agents/ironsworn-gm.md` (Fiction Grounding Protocol)
+- Modify: `plugins/ironsworn/skills/ironsworn-scene-craft/SKILL.md` (protocol reminder)
+- Modify: `plugins/ironsworn/commands/extract-session-lore.md` (backfill framing)
+
+**Interfaces:** none (content only). No code; verified by reading the rendered protocol.
+
+- [ ] **Step 1: Rewrite the Fiction Grounding Protocol**
+
+In `plugins/ironsworn/agents/ironsworn-gm.md`, replace the numbered Fiction Grounding Protocol list (currently: search → weave → invent+`upsert_entity` → never contradict) with:
+
+```markdown
+1. **Ground first** — Call `recall` (or `search_lore` for a specific scope) for the subject before you name it.
+2. **Narrate** the beat.
+3. **Record the beat with its canon** — call `record_beat` carrying:
+   - `entities`: any new canon the beat established, **using the exact canonical names that grounding returned** (reuse them; never coin a variant like "Lago" when canon says "Lago Rhian");
+   - `relations`: the relationships the beat asserted between those entities (`{ from, to, label }`).
+   **MANDATORY:** a beat that establishes a new entity or a relationship MUST carry it in that same `record_beat` call. Recording the prose without its structured canon is forbidden, exactly like a summary-only scene.
+4. **Never contradict** established canon — if a roll or oracle conflicts with it, treat the conflict itself as the complication.
+```
+
+- [ ] **Step 2: Update the scene-craft reminder**
+
+In `plugins/ironsworn/skills/ironsworn-scene-craft/SKILL.md`, find the fiction-grounding reminder and add a line: "Record the canon a beat establishes **on the beat** — `record_beat` with `entities` and `relations`, reusing exact grounded names. Don't leave relations for later extraction."
+
+- [ ] **Step 3: Reframe the extract command**
+
+In `plugins/ironsworn/commands/extract-session-lore.md`, change the description/body to position it as a backfill: replace the opening line with "Optional backfill. The GM records canon on the beat during play; run this only to catch lore from scenes where structured recording was missed. It dedups against already-recorded entities and relations." Keep the tool call instruction.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add plugins/ironsworn/agents/ironsworn-gm.md plugins/ironsworn/skills/ironsworn-scene-craft/SKILL.md plugins/ironsworn/commands/extract-session-lore.md
+git commit -m "docs: protocol records relations on the beat; extraction reframed as backfill"
+```
+
+---
+
+## Task 6: v1 design-doc reconciliation + version bump
+
+**Files:**
+- Modify: `docs/design/agentic-rpg-v1.md` (four edits)
+- Modify: `plugins/ironsworn/.claude-plugin/plugin.json` (version bump)
+
+**Interfaces:** none (docs + version).
+
+- [ ] **Step 1: Invert failure-mode #1**
+
+In `docs/design/agentic-rpg-v1.md`, in the "Why coherence is the hard problem" section, rewrite failure mode #1 (currently "**Extraction quality.** ... Highest-leverage component; currently treated as carry-forward.") to:
+
+```markdown
+1. **Capture at point of entry.** The highest-leverage fix is *not* better
+   extraction — batch extraction is a lossy prose→structure reconstruction that
+   lacks the author's knowledge of what is canonical and reliable name grounding.
+   The GM, at narration time, has both. Canon (entities **and relations**) should
+   be recorded on the beat via `record_beat`; extraction is demoted to optional
+   backfill. (Established 2026-06 after measurement: relation recall caps because
+   relations were never recorded where known; a two-pass extractor was a measured
+   negative result; the dedup regression was largely name fragmentation from
+   re-deriving names independently. See
+   `docs/superpowers/specs/2026-06-27-point-of-entry-recording-design.md`.)
+```
+
+- [ ] **Step 2: Update priorities + status header**
+
+In the "v1 priorities, in order" section, add a new priority for point-of-entry recording as the primary canon-capture path, and reframe the extraction-eval priority (#2) as *backfill-quality measurement, not the primary quality lever*. Update the status header line to note point-of-entry recording as the active item.
+
+- [ ] **Step 3: Update the fiction-grounding protocol + tool surface**
+
+In the doc's "The fiction-grounding protocol" section, extend the steps to record **relations on the beat** (not just `upsert_entity`). In the "Tool surface" section, note that `record_scene`/`record_beat` now carry structured canon, and reposition `extract_session_lore` as optional backfill.
+
+- [ ] **Step 4: Bump the plugin version**
+
+In `plugins/ironsworn/.claude-plugin/plugin.json`, bump the `version` field by a minor increment (new feature).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/design/agentic-rpg-v1.md plugins/ironsworn/.claude-plugin/plugin.json
+git commit -m "docs: reconcile v1 design with point-of-entry recording; bump plugin version"
+```
+
+---
+
+## Final verification
+
+- [ ] Run the full core suite: `cd packages/core && bun test` — all pass.
+- [ ] Run the scribe suite: `cd plugins/ironsworn/scribe && bun test` — all pass.
+- [ ] Typecheck both packages: `bun run tsc --noEmit` in each.
+- [ ] Confirm `plugin.json` version increased vs `origin/main`.

--- a/docs/superpowers/specs/2026-06-27-point-of-entry-recording-design.md
+++ b/docs/superpowers/specs/2026-06-27-point-of-entry-recording-design.md
@@ -1,0 +1,245 @@
+# Point-of-Entry Structured Recording — Design Spec
+
+**Status:** design spec, approved 2026-06-27. Greenfield (new worlds only).
+
+**Goal:** Capture world canon — entities *and relations* — at the moment the
+GM narrates it, on the beat, instead of reconstructing it later from prose via
+batch LLM extraction. Make authorial point-of-entry recording the primary path
+to the knowledge graph; demote `extract_session_lore` to optional backfill.
+
+## Why this exists (the finding that motivates it)
+
+A session spent trying to improve `extract_session_lore` quality hit a wall.
+Reliable, multi-run measurement against the Zura golden set showed:
+
+- Relation recall is the worst metric (~0.15–0.24 across variants) because the
+  batch extractor reconstructs **100% of relations from prose** — the hardest
+  possible version of the task. The GM never records the relations it narrates.
+- A two-pass extractor (entities then relations over a fixed vocabulary) was a
+  measured **negative result**: ~2× API cost, no precision/dedup recovery. It
+  falsified the hypothesis that relation pressure drives entity over-extraction
+  — the entity pass over-extracts on its own.
+- An audit of the dedup regression found the extractor produces only ~2 true
+  off-world false positives, but heavy **fragmentation** (`Lago` vs
+  `Lago Rhian`, `Ashfen` vs `Ashfen Settlement`) — the same entity under
+  multiple names — because batch extraction re-derives names independently and
+  drifts.
+
+Root cause: batch extraction is a **lossy prose→structure reconstruction** that
+lacks the author's knowledge of what is canonical and lacks reliable grounding
+to reuse existing names. The GM, at the moment of narration, has both. The
+architecture already half-intends this — the fiction-grounding protocol mandates
+`upsert_entity` for new entities — but **relations are never recorded at point
+of entry**, and batch extraction re-derives entities independently, reintroducing
+fragmentation.
+
+This spec closes that gap.
+
+## Architecture & data flow
+
+Structured canon is captured *on the beat*, riding the call the GM is already
+mandated to make live during play (`record_beat`).
+
+```
+CURRENT:  record_beat(prose) ──────────────► beat row
+          extract_session_lore (batch LLM re-reads prose) ──► entities + relations
+
+NEW:      record_beat(prose, entities?, relations?) ──► beat row
+                                  │  (rides the existing async beat pipeline)
+                                  ▼
+                          resolve names against existing graph (resolveExisting)
+                                  │
+                                  ▼
+                          write entities + relations, provenance = this beat
+          extract_session_lore ──► OPTIONAL backfill (idempotent dedup)
+```
+
+Why this dissolves the failure modes:
+
+- **Relations** are captured where they are *known* (the GM just narrated them),
+  not reconstructed from prose. Fixes the worst metric at its source.
+- **Fragmentation** disappears because entity/endpoint names resolve by **exact
+  match** against the existing graph (`resolveExisting`, in
+  `packages/core/src/rag/lore.ts`). That works *because* the GM grounded first
+  (`recall`) and reuses the existing canonical name — unlike batch extraction.
+- **Over-extraction** disappears because recording is a deliberate authorial act,
+  not a "pull everything from prose" sweep.
+
+Key property: at point of entry, dedup is **exact-match** (cheap, safe), because
+naming is deliberate. We never need the fuzzy/embedding dedup that batch
+extraction forces — which carried a real false-merge risk.
+
+## `record_beat` schema & resolution
+
+New optional parameters; existing ones (`scene_id`, `kind`, `text`, `speaker`,
+`metadata`, `wait`) unchanged:
+
+```ts
+record_beat({
+  scene_id, kind, text, speaker?, metadata?, wait?,            // unchanged
+  entities?:  [{ canonical, type, summary, aliases? }],        // canon this beat establishes
+  relations?: [{ from, to, label, notes?, supersedes? }],      // links this beat establishes
+})
+```
+
+Resolution runs in the beat's existing async settle path (completes before
+return when `wait=true`):
+
+1. **Entities** — for each, `resolveExisting(canonical / aliases)`:
+   - **Found** → reuse the existing entity (reference; do not overwrite its
+     summary). This is the anti-fragmentation guarantee.
+   - **Not found** → create campaign-scoped via `upsertLore`, provenance
+     `{ source_kind: "beat", source_id }`.
+
+2. **Relations** — resolve `from`/`to` against the existing graph **plus the
+   entities in this same beat**:
+   - **Both resolve** → `linkLore` with `valid_at = scene timestamp` and beat
+     provenance. `supersedes: true` → call `invalidateRelations` first (reuses
+     existing temporal logic). Duplicate links are idempotent (`ON CONFLICT`).
+   - **An endpoint does not resolve** → **skip the relation and surface a
+     notice** ("'Y' not found — ground it or add it to `entities`"). We do NOT
+     auto-stub: auto-creating a node from a bare endpoint name would reintroduce
+     the fragmentation this design eliminates, and grounding-first discipline
+     plus backfill extraction cover the genuinely-missed case.
+
+**Error handling:** scene-not-found returns the existing error; an invalid
+entity `type` is skipped with a notice; unresolved relation endpoints are
+skipped with a notice (above). Notices drain to the GM through the existing
+notice channel, so omissions are visible during play.
+
+**Async note:** the structured writes happen in the beat's background settle
+(like the embedding write today), preserving `record_beat`'s fire-and-forget
+default; `wait=true` blocks until they complete.
+
+## Protocol & prompt changes (GM behavior)
+
+This is what turns mechanism into habit. Content changes in two places: the GM
+agent's **Fiction Grounding Protocol** (`plugins/ironsworn/agents/ironsworn-gm.md`)
+and the scene-craft skill's reminder
+(`plugins/ironsworn/skills/ironsworn-scene-craft/SKILL.md`).
+
+Revised protocol:
+
+1. **Ground first** — `recall` the subject before naming it. *(Already exists.)*
+2. **Narrate** the beat.
+3. **Record the beat with its canon** — call `record_beat` carrying:
+   - `entities`: new canon the beat established, **using the exact canonical
+     names returned by grounding** (reuse; never coin a variant);
+   - `relations`: the relationships the beat asserted between those entities.
+4. **MANDATORY** — a beat that establishes a new entity or a relationship MUST
+   carry it in that same `record_beat` call (mirrors the existing rule that a
+   summary-only scene recording is forbidden).
+5. **Never contradict** established canon. *(Already exists.)*
+
+Two emphases do the heavy lifting and must be stated explicitly and repeatedly:
+
+- **Reuse exact grounded names** — the single anti-fragmentation instruction.
+  The exact-match resolution only pays off if the GM reuses names.
+- **Relations are first-class at point of entry** — closing the gap where they
+  were left entirely to batch extraction.
+
+Reliability is **prompt discipline only** (consistent with how `record_beat` is
+already mandated). No enforcement hooks; the backfill path is the safety net.
+
+## Extraction as backfill + measurement
+
+**Backfill.** Idempotent dedup is already present — `upsertLore` matches
+existing entities by exact canonical/alias, `linkLore` is `ON CONFLICT`. So
+extraction run after point-of-entry recording reuses what the GM recorded. The
+residual caveat (extraction may still coin a name variant) is **accepted**:
+extraction is now the rarely-used exception path. The `extract_session_lore`
+command's framing changes from "how lore gets into the graph" to "optional
+backfill — run it if you suspect the GM missed something."
+
+**Explicit scope boundary:** no further extraction-quality optimization is in
+scope. The pivot is to stop polishing the lossy reconstruction. The diagnostics
+and type-aware prompt produced this session remain on their branch as artifacts;
+this design supersedes the *strategy*, not those files.
+
+**Measurement** (honestly softer — the real cost of the pivot, since quality now
+depends on GM behavior):
+
+1. **Mechanism correctness** → unit tests (below).
+2. **Recording quality in real play** → **golden-free graph-health checks**
+   runnable against any world's graph after a session. NOTE: the diagnostics
+   built this session (`entityRecallByType`, near-duplicates, false-positives)
+   are golden-*relative* — they compare against the eval's golden set and cannot
+   run on an arbitrary world. The graph-health checks are small new golden-free
+   adaptations of the same ideas: fragmentation = near-duplicate clusters found
+   by self-similarity *among the graph's own entities* (no golden); relation
+   coverage = fraction of entities with ≥1 current relation, relations-per-entity.
+   Indicators, not a golden score. These are lightweight; if they slip, the
+   mechanism unit tests and backfill eval remain the gates.
+3. **Backfill quality** → the existing extraction eval remains as the reference
+   for the fallback path and a guard that we did not break extraction.
+
+A play-session golden ("ideal recorded canon" for a scripted session) is noted
+as future work, not built here.
+
+## Testing (TDD, mechanism-level)
+
+Logic lives in `@agentic-rpg/core`; the MCP tool is a thin wrapper. Tests follow
+existing `scenes.test.ts` / `extraction.test.ts` patterns (Ollama-guarded where
+embeddings are needed):
+
+- `entities` with an existing name → reuses, no duplicate node.
+- `entities` with a new name → creates campaign-scoped entity with beat provenance.
+- `relations` with both endpoints resolving → `linkLore` written with `valid_at`
+  + beat provenance.
+- relation endpoint defined in the same beat's `entities` → resolves (new entity
+  + link in one call).
+- relation with an unresolved endpoint → skipped + notice surfaced.
+- `supersedes: true` → `invalidateRelations` invoked.
+- idempotency: re-recording the same entity/relation → no duplicate.
+- `wait=true` → structured writes complete before return.
+
+## v1 design-doc reconciliation
+
+This pivot revises claims in `docs/design/agentic-rpg-v1.md`. The implementation
+updates these four sections so the architectural source of truth stays consistent:
+
+1. **"Why coherence is the hard problem" → failure mode #1 (Extraction quality).**
+   Currently calls extraction the "highest-leverage component." Rewrite: the
+   highest-leverage fix is authorial capture at point of entry; extraction is a
+   lossy reconstruction demoted to backfill. Record *why* (this session's
+   measured findings).
+2. **"v1 priorities, in order" + the status header.** Add a new priority —
+   point-of-entry structured recording as the primary canon-capture path — and
+   reframe #2 (the extraction eval harness) as *backfill-quality measurement*,
+   not the primary quality lever.
+3. **"The fiction-grounding protocol."** The doc's version stops at
+   `upsert_entity`; update it to record **relations on the beat**.
+4. **"Tool surface."** Note that `record_scene` / `record_beat` now carry
+   structured canon, and reposition `extract_session_lore` as optional backfill.
+
+## Scope
+
+**In scope:** `record_beat` schema + resolution in core; the MCP wrapper;
+Fiction-Grounding-Protocol rewrite (agent + scene-craft skill);
+`extract_session_lore` repositioned as optional backfill (framing only);
+small golden-free graph-health checks (fragmentation clustering + relation
+coverage); the four v1-doc edits above.
+
+**Non-goals:**
+
+- Migration of existing worlds — **greenfield only**.
+- Any further extraction-quality optimization.
+- A play-session golden eval — future work.
+- Enforcement hooks — **prompt discipline only**.
+- Auto-stub for unresolved endpoints — chose **skip + notice**.
+- Scene-level structured payload — chose **beats**.
+- Changes to `recall` / search — already built.
+
+## Decisions
+
+- **D1** Greenfield only; existing worlds keep using extraction as-is.
+- **D2** Extraction stays as optional backfill (not removed), deduping against
+  recorded canon via existing exact-match/`ON CONFLICT` idempotency.
+- **D3** Reliability is prompt discipline only — no enforcement hooks.
+- **D4** Recording mechanism is **structured beats**: `record_beat` carries
+  `entities` + `relations`. Rejected: protocol-only (verbose, easier to forget)
+  and scene-level payload (reintroduces reconstruct-from-memory at scene close).
+- **D5** Unresolved relation endpoints are skipped with a notice, never
+  auto-stubbed, to preserve exact-match cleanliness.
+- **D6** Point-of-entry dedup is exact-match only (`resolveExisting`); no fuzzy
+  or embedding dedup on this path.

--- a/packages/core/eval/diagnostics.test.ts
+++ b/packages/core/eval/diagnostics.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "bun:test";
 import {
   classifyRelationDrops,
   aggregateRelationDrops,
+  entityRecallByType,
   type RelationDropBreakdown,
 } from "./diagnostics.js";
 
@@ -139,5 +140,36 @@ describe("aggregateRelationDrops", () => {
     const a = aggregateRelationDrops([]);
     expect(a.emitted).toBe(0);
     expect(a.unresolvedEndpoints).toEqual([]);
+  });
+});
+
+describe("entityRecallByType", () => {
+  it("computes matched/total/recall per golden type", () => {
+    const allGolden = [
+      { type: "person" },
+      { type: "person" },
+      { type: "thread" },
+      { type: "thread" },
+      { type: "event" },
+    ];
+    // one person and both threads were missed
+    const unmatched = [{ type: "person" }, { type: "thread" }, { type: "thread" }];
+    const rows = entityRecallByType(allGolden, unmatched);
+    const byType = Object.fromEntries(rows.map((r) => [r.type, r]));
+    expect(byType["person"]).toEqual({ type: "person", matched: 1, total: 2, recall: 0.5 });
+    expect(byType["thread"]).toEqual({ type: "thread", matched: 0, total: 2, recall: 0 });
+    expect(byType["event"]).toEqual({ type: "event", matched: 1, total: 1, recall: 1 });
+  });
+
+  it("sorts rows by recall ascending (worst types first)", () => {
+    const allGolden = [{ type: "person" }, { type: "thread" }, { type: "event" }];
+    const unmatched = [{ type: "thread" }];
+    const rows = entityRecallByType(allGolden, unmatched);
+    expect(rows[0]!.type).toBe("thread"); // recall 0, surfaced first
+    expect(rows[0]!.recall).toBe(0);
+  });
+
+  it("returns an empty list when there are no golden entities", () => {
+    expect(entityRecallByType([], [])).toEqual([]);
   });
 });

--- a/packages/core/eval/diagnostics.test.ts
+++ b/packages/core/eval/diagnostics.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from "bun:test";
+import {
+  classifyRelationDrops,
+  aggregateRelationDrops,
+  type RelationDropBreakdown,
+} from "./diagnostics.js";
+
+const THRESHOLD = 0.6;
+
+describe("classifyRelationDrops", () => {
+  it("counts a fully resolvable, confident relation as survived", () => {
+    const b = classifyRelationDrops(
+      [{ from: "Lona", to: "Caldren", relation: "LOCATED_IN", confidence: 0.9 }],
+      ["Lona", "Caldren"],
+      THRESHOLD,
+    );
+    expect(b.emitted).toBe(1);
+    expect(b.survived).toBe(1);
+    expect(b.droppedLowConfidence).toBe(0);
+    expect(b.droppedEndpointUnresolved).toBe(0);
+    expect(b.unresolvedEndpoints).toEqual([]);
+  });
+
+  it("classifies a sub-threshold relation as droppedLowConfidence", () => {
+    const b = classifyRelationDrops(
+      [{ from: "Lona", to: "Caldren", relation: "LOCATED_IN", confidence: 0.3 }],
+      ["Lona", "Caldren"],
+      THRESHOLD,
+    );
+    expect(b.droppedLowConfidence).toBe(1);
+    expect(b.droppedEndpointUnresolved).toBe(0);
+    expect(b.survived).toBe(0);
+  });
+
+  it("does NOT endpoint-check a low-confidence relation (mirrors production order)", () => {
+    // confidence gate short-circuits before endpoint resolution in extraction.ts,
+    // so an unresolved endpoint on a dropped-for-confidence relation is not tallied.
+    const b = classifyRelationDrops(
+      [{ from: "X", to: "Y", relation: "KNOWS", confidence: 0.3 }],
+      [],
+      THRESHOLD,
+    );
+    expect(b.droppedLowConfidence).toBe(1);
+    expect(b.droppedEndpointUnresolved).toBe(0);
+    expect(b.unresolvedEndpoints).toEqual([]);
+  });
+
+  it("classifies an unresolved endpoint and records the offending name", () => {
+    const b = classifyRelationDrops(
+      [{ from: "Oracle", to: "Hidden God", relation: "SERVES", confidence: 0.8 }],
+      ["Oracle"],
+      THRESHOLD,
+    );
+    expect(b.survived).toBe(0);
+    expect(b.droppedEndpointUnresolved).toBe(1);
+    expect(b.unresolvedEndpoints).toEqual([{ name: "Hidden God", count: 1 }]);
+  });
+
+  it("resolves endpoints case-insensitively against the persisted name set", () => {
+    const b = classifyRelationDrops(
+      [{ from: "LONA", to: "caldren", relation: "LOCATED_IN", confidence: 0.9 }],
+      ["Lona", "Caldren"],
+      THRESHOLD,
+    );
+    expect(b.survived).toBe(1);
+    expect(b.droppedEndpointUnresolved).toBe(0);
+  });
+
+  it("counts a relation once when both endpoints fail but tallies both names", () => {
+    const b = classifyRelationDrops(
+      [{ from: "the market", to: "the road", relation: "NEAR", confidence: 0.8 }],
+      ["Caldren"],
+      THRESHOLD,
+    );
+    expect(b.droppedEndpointUnresolved).toBe(1);
+    expect(b.unresolvedEndpoints).toEqual([
+      { name: "the market", count: 1 },
+      { name: "the road", count: 1 },
+    ]);
+  });
+
+  it("tallies repeated unresolved endpoint names and sorts by count descending", () => {
+    const b = classifyRelationDrops(
+      [
+        { from: "Lona", to: "the market", relation: "AT", confidence: 0.8 },
+        { from: "Fen", to: "the market", relation: "AT", confidence: 0.8 },
+        { from: "Arda", to: "the market", relation: "AT", confidence: 0.8 },
+        { from: "Lona", to: "the road", relation: "ON", confidence: 0.8 },
+      ],
+      ["Lona", "Fen", "Arda"],
+      THRESHOLD,
+    );
+    expect(b.droppedEndpointUnresolved).toBe(4);
+    expect(b.unresolvedEndpoints).toEqual([
+      { name: "the market", count: 3 },
+      { name: "the road", count: 1 },
+    ]);
+  });
+
+  it("treats an entity alias as resolvable (alias names are part of the set)", () => {
+    // The harness builds the name set from canonical + aliases, so a relation
+    // endpoint that used an alias must resolve.
+    const b = classifyRelationDrops(
+      [{ from: "the healer Lona", to: "Caldren", relation: "LOCATED_IN", confidence: 0.9 }],
+      ["Lona", "the healer Lona", "Caldren"],
+      THRESHOLD,
+    );
+    expect(b.survived).toBe(1);
+    expect(b.droppedEndpointUnresolved).toBe(0);
+  });
+});
+
+describe("aggregateRelationDrops", () => {
+  it("sums numeric fields across runs", () => {
+    const runs: RelationDropBreakdown[] = [
+      { emitted: 3, survived: 1, droppedLowConfidence: 1, droppedEndpointUnresolved: 1, unresolvedEndpoints: [{ name: "the market", count: 1 }] },
+      { emitted: 2, survived: 2, droppedLowConfidence: 0, droppedEndpointUnresolved: 0, unresolvedEndpoints: [] },
+    ];
+    const a = aggregateRelationDrops(runs);
+    expect(a.emitted).toBe(5);
+    expect(a.survived).toBe(3);
+    expect(a.droppedLowConfidence).toBe(1);
+    expect(a.droppedEndpointUnresolved).toBe(1);
+  });
+
+  it("merges and re-sorts unresolved endpoint tallies across runs", () => {
+    const runs: RelationDropBreakdown[] = [
+      { emitted: 0, survived: 0, droppedLowConfidence: 0, droppedEndpointUnresolved: 0, unresolvedEndpoints: [{ name: "the market", count: 2 }, { name: "the road", count: 1 }] },
+      { emitted: 0, survived: 0, droppedLowConfidence: 0, droppedEndpointUnresolved: 0, unresolvedEndpoints: [{ name: "the road", count: 3 }] },
+    ];
+    const a = aggregateRelationDrops(runs);
+    expect(a.unresolvedEndpoints).toEqual([
+      { name: "the road", count: 4 },
+      { name: "the market", count: 2 },
+    ]);
+  });
+
+  it("returns an all-zero breakdown for an empty run list", () => {
+    const a = aggregateRelationDrops([]);
+    expect(a.emitted).toBe(0);
+    expect(a.unresolvedEndpoints).toEqual([]);
+  });
+});

--- a/packages/core/eval/diagnostics.ts
+++ b/packages/core/eval/diagnostics.ts
@@ -1,0 +1,108 @@
+// Relation-loss diagnostics for the extraction eval. Pure functions over the
+// extractor's RAW emitted relations + the persisted entity name set — no DB,
+// no Ollama — so they unit-test alongside score.ts / aggregate.ts.
+//
+// Purpose: relation recall is the pipeline's weakest metric, and a missed
+// relation has two opposite causes that demand opposite fixes:
+//   - never emitted by the LLM but expected      → PROMPT problem (see scorer recall)
+//   - emitted, then dropped before it persists   → PLUMBING problem (this module)
+// For the plumbing side we mirror extraction.ts's drop logic and ORDER: the
+// confidence gate runs first and short-circuits, so a low-confidence relation
+// is never endpoint-checked.
+
+export interface EmittedRelation {
+  from: string;
+  to: string;
+  relation: string;
+  confidence: number;
+}
+
+export interface UnresolvedEndpoint {
+  name: string;
+  count: number;
+}
+
+export interface RelationDropBreakdown {
+  emitted: number;
+  // Survived both gates (confidence ok AND both endpoints resolvable) → would link.
+  survived: number;
+  droppedLowConfidence: number;
+  droppedEndpointUnresolved: number;
+  // Endpoint names that failed to resolve, most frequent first — the actionable
+  // list for diagnosing name-agreement loss between entity and relation extraction.
+  unresolvedEndpoints: UnresolvedEndpoint[];
+}
+
+function norm(s: string): string {
+  return s.toLowerCase().trim();
+}
+
+function sortTally(tally: Map<string, number>): UnresolvedEndpoint[] {
+  return [...tally.entries()]
+    .map(([name, count]) => ({ name, count }))
+    .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name));
+}
+
+export function classifyRelationDrops(
+  emitted: EmittedRelation[],
+  persistedEntityNames: string[],
+  threshold: number,
+): RelationDropBreakdown {
+  const names = new Set(persistedEntityNames.map(norm));
+  const resolves = (name: string): boolean => names.has(norm(name));
+
+  let survived = 0;
+  let droppedLowConfidence = 0;
+  let droppedEndpointUnresolved = 0;
+  const unresolved = new Map<string, number>();
+
+  for (const r of emitted) {
+    // Confidence gate first — mirrors extraction.ts, which `continue`s before
+    // touching the endpoints. Do NOT tally endpoints for these.
+    if (r.confidence < threshold) {
+      droppedLowConfidence++;
+      continue;
+    }
+    const fromOk = resolves(r.from);
+    const toOk = resolves(r.to);
+    if (fromOk && toOk) {
+      survived++;
+      continue;
+    }
+    droppedEndpointUnresolved++;
+    if (!fromOk) unresolved.set(r.from, (unresolved.get(r.from) ?? 0) + 1);
+    if (!toOk) unresolved.set(r.to, (unresolved.get(r.to) ?? 0) + 1);
+  }
+
+  return {
+    emitted: emitted.length,
+    survived,
+    droppedLowConfidence,
+    droppedEndpointUnresolved,
+    unresolvedEndpoints: sortTally(unresolved),
+  };
+}
+
+export function aggregateRelationDrops(
+  runs: RelationDropBreakdown[],
+): RelationDropBreakdown {
+  const merged = new Map<string, number>();
+  const acc: RelationDropBreakdown = {
+    emitted: 0,
+    survived: 0,
+    droppedLowConfidence: 0,
+    droppedEndpointUnresolved: 0,
+    unresolvedEndpoints: [],
+  };
+  for (const r of runs) {
+    acc.emitted += r.emitted;
+    acc.survived += r.survived;
+    acc.droppedLowConfidence += r.droppedLowConfidence;
+    acc.droppedEndpointUnresolved += r.droppedEndpointUnresolved;
+    for (const e of r.unresolvedEndpoints) {
+      merged.set(e.name, (merged.get(e.name) ?? 0) + e.count);
+    }
+  }
+  acc.unresolvedEndpoints = sortTally(merged);
+  return acc;
+}

--- a/packages/core/eval/diagnostics.ts
+++ b/packages/core/eval/diagnostics.ts
@@ -83,6 +83,34 @@ export function classifyRelationDrops(
   };
 }
 
+export interface TypeRecall {
+  type: string;
+  matched: number;
+  total: number;
+  recall: number;
+}
+
+// Per-type entity recall, worst-recall type first. Relations connect abstract
+// entities (threads/events/concepts/truths), so a type the extractor misses
+// silently caps the relation recall that depends on it — this surfaces which
+// types to target in the extraction prompt.
+export function entityRecallByType(
+  allGolden: { type: string }[],
+  unmatchedGolden: { type: string }[],
+): TypeRecall[] {
+  const total = new Map<string, number>();
+  for (const g of allGolden) total.set(g.type, (total.get(g.type) ?? 0) + 1);
+  const missed = new Map<string, number>();
+  for (const g of unmatchedGolden) missed.set(g.type, (missed.get(g.type) ?? 0) + 1);
+
+  return [...total.entries()]
+    .map(([type, t]) => {
+      const matched = t - (missed.get(type) ?? 0);
+      return { type, matched, total: t, recall: t === 0 ? 0 : matched / t };
+    })
+    .sort((a, b) => a.recall - b.recall || a.type.localeCompare(b.type));
+}
+
 export function aggregateRelationDrops(
   runs: RelationDropBreakdown[],
 ): RelationDropBreakdown {

--- a/packages/core/eval/run-eval.ts
+++ b/packages/core/eval/run-eval.ts
@@ -66,6 +66,8 @@ async function runOnce(
   drops: RelationDropBreakdown;
   typeRecall: TypeRecall[];
   missedGolden: string[];
+  nearDuplicates: string[];
+  falsePositives: string[];
 }> {
   const dir = await mkdtemp(join(tmpdir(), "eval-run-"));
 
@@ -113,9 +115,17 @@ async function runOnce(
   const matching = await matchEntities(actual.entities, golden.entities, getWorldEmbedding);
   const typeRecall = entityRecallByType(golden.entities, matching.unmatchedGolden);
   const missedGolden = matching.unmatchedGolden.map((g) => `${g.canonical} (${g.type})`);
+  // Near-duplicate actuals (a second extracted entity that collapsed onto an
+  // already-matched golden) — these are what tank the dedup score; seeing the
+  // names tells us whether the fix is lexical (reorderings) or semantic.
+  const nearDuplicates = matching.nearDuplicates.map((e) => `${e.canonical} (${e.type})`);
+  // False positives: extracted entities matching NO golden. The precision metric
+  // counts these as wrong — but golden is a curated subset, so some may be
+  // legitimate-but-uncurated. Dumping them tells us whether precision is fair.
+  const falsePositives = matching.falsePositives.map((e) => `${e.canonical} (${e.type})`);
 
   const card = await scoreExtraction(actual, golden, getWorldEmbedding);
-  return { card, drops, typeRecall, missedGolden };
+  return { card, drops, typeRecall, missedGolden, nearDuplicates, falsePositives };
 }
 
 function band(s: MetricStats): string {
@@ -207,9 +217,11 @@ async function main(): Promise<void> {
   const drops: RelationDropBreakdown[] = [];
   let lastTypeRecall: TypeRecall[] = [];
   let lastMissed: string[] = [];
+  let lastNearDup: string[] = [];
+  let lastFalsePos: string[] = [];
   for (let i = 0; i < RUNS; i++) {
     console.log(`--- run ${i + 1}/${RUNS} ---`);
-    const { card, drops: d, typeRecall, missedGolden } = await runOnce(scenes, golden, extractor);
+    const { card, drops: d, typeRecall, missedGolden, nearDuplicates, falsePositives } = await runOnce(scenes, golden, extractor);
     console.log(
       `  entity F1 ${fmt(card.entity.f1)}  recall ${fmt(card.entity.recall)}  dedup ${fmt(card.dedup.score)}  temporal ${card.temporal.correct}/${card.temporal.total}`,
     );
@@ -220,11 +232,25 @@ async function main(): Promise<void> {
     drops.push(d);
     lastTypeRecall = typeRecall;
     lastMissed = missedGolden;
+    lastNearDup = nearDuplicates;
+    lastFalsePos = falsePositives;
   }
 
   printAggregate(aggregateScorecards(cards));
   printRelationDrops(aggregateRelationDrops(drops), RUNS);
   printEntityRecallByType(lastTypeRecall, lastMissed);
+  if (lastNearDup.length > 0) {
+    console.log("");
+    console.log(`Near-duplicate entities (final run, ${lastNearDup.length}) — collapsed onto`);
+    console.log("an already-matched golden entity; these tank the dedup score:");
+    for (const n of lastNearDup) console.log(`    ${n}`);
+  }
+  if (lastFalsePos.length > 0) {
+    console.log("");
+    console.log(`False-positive entities (final run, ${lastFalsePos.length}) — matched NO golden.`);
+    console.log("Audit: are these genuine junk, or legitimate-but-uncurated canon?");
+    for (const n of lastFalsePos) console.log(`    ${n}`);
+  }
 }
 
 main().catch((e) => {

--- a/packages/core/eval/run-eval.ts
+++ b/packages/core/eval/run-eval.ts
@@ -22,7 +22,17 @@ import { exportLore } from "../src/rag/lore.js";
 import { getWorldEmbedding } from "../src/rag/world-db.js";
 import { scoreExtraction, type ActualState, type GoldenSet, type Scorecard } from "./score.js";
 import { aggregateScorecards, type AggregateScorecard, type MetricStats } from "./aggregate.js";
+import {
+  classifyRelationDrops,
+  aggregateRelationDrops,
+  type EmittedRelation,
+  type RelationDropBreakdown,
+} from "./diagnostics.js";
 import type { SerializedScene } from "./scene-record.js";
+
+// extractLoreFromScene's default when no confidenceThreshold is passed (and the
+// eval passes none). The drop classifier must use the same value as production.
+const CONF_THRESHOLD = 0.6;
 
 const here = fileURLToPath(new URL(".", import.meta.url));
 const FIXTURES = join(here, "fixtures");
@@ -49,13 +59,25 @@ async function runOnce(
   scenes: SerializedScene[],
   golden: GoldenSet,
   extractor: ReturnType<typeof _makeDefaultExtractor>,
-): Promise<Scorecard> {
+): Promise<{ card: Scorecard; drops: RelationDropBreakdown }> {
   const dir = await mkdtemp(join(tmpdir(), "eval-run-"));
+
+  // Capture every relation the extractor EMITTED (raw, pre-filter) so we can
+  // classify what production then dropped. Wrap per-run for a fresh tally.
+  const emitted: EmittedRelation[] = [];
+  const capturing: typeof extractor = async (text, existing) => {
+    const result = await extractor(text, existing);
+    for (const r of result.relations) {
+      emitted.push({ from: r.from, to: r.to, relation: r.relation, confidence: r.confidence });
+    }
+    return result;
+  };
+
   let failed = 0;
   for (const sc of scenes) {
     const id = await recordScene(dir, sc.text, sc.kind, undefined, sc.beats);
     try {
-      await extractLoreFromScene(dir, id, { extractor });
+      await extractLoreFromScene(dir, id, { extractor: capturing });
     } catch (e) {
       failed++;
       console.warn(`Extraction failed for scene ${id}: ${(e as Error).message}`);
@@ -74,7 +96,13 @@ async function runOnce(
       invalidated: r.invalid_at !== null,
     })),
   };
-  return scoreExtraction(actual, golden, getWorldEmbedding);
+
+  // Persisted-name set mirrors getLore's resolution surface (canonical + aliases).
+  const persistedNames = entities.flatMap((e) => [e.canonical, ...e.aliases]);
+  const drops = classifyRelationDrops(emitted, persistedNames, CONF_THRESHOLD);
+
+  const card = await scoreExtraction(actual, golden, getWorldEmbedding);
+  return { card, drops };
 }
 
 function band(s: MetricStats): string {
@@ -96,6 +124,28 @@ function printAggregate(a: AggregateScorecard): void {
   console.log("");
   console.log("Aggregate JSON (copy into baseline.json to accept):");
   console.log(JSON.stringify(a, null, 2));
+}
+
+// Diagnose where emitted relations are lost. Recall failures split into "never
+// emitted" (prompt problem, visible in the scorer's relation recall) vs.
+// "emitted then dropped" (plumbing problem, shown here). Totals are summed
+// across all runs.
+function printRelationDrops(d: RelationDropBreakdown, runs: number): void {
+  const pct = (n: number): string =>
+    d.emitted === 0 ? "  0%" : `${Math.round((100 * n) / d.emitted)}%`.padStart(4);
+  console.log("");
+  console.log(`Relation-drop diagnostics (summed over ${runs} runs)`);
+  console.log(`  emitted by extractor       ${d.emitted}`);
+  console.log(`  survived (would link)      ${d.survived}  (${pct(d.survived)})`);
+  console.log(`  dropped: low confidence    ${d.droppedLowConfidence}  (${pct(d.droppedLowConfidence)})`);
+  console.log(`  dropped: endpoint unresolved ${d.droppedEndpointUnresolved}  (${pct(d.droppedEndpointUnresolved)})`);
+  if (d.unresolvedEndpoints.length > 0) {
+    console.log("  top unresolved endpoint names (extractor named a relation endpoint");
+    console.log("  that never became an entity — name-agreement loss):");
+    for (const e of d.unresolvedEndpoints.slice(0, 15)) {
+      console.log(`    ${String(e.count).padStart(3)}  ${e.name}`);
+    }
+  }
 }
 
 async function main(): Promise<void> {
@@ -126,16 +176,22 @@ async function main(): Promise<void> {
   );
 
   const cards: Scorecard[] = [];
+  const drops: RelationDropBreakdown[] = [];
   for (let i = 0; i < RUNS; i++) {
     console.log(`--- run ${i + 1}/${RUNS} ---`);
-    const c = await runOnce(scenes, golden, extractor);
+    const { card, drops: d } = await runOnce(scenes, golden, extractor);
     console.log(
-      `  entity F1 ${fmt(c.entity.f1)}  dedup ${fmt(c.dedup.score)}  temporal ${c.temporal.correct}/${c.temporal.total}`,
+      `  entity F1 ${fmt(card.entity.f1)}  dedup ${fmt(card.dedup.score)}  temporal ${card.temporal.correct}/${card.temporal.total}`,
     );
-    cards.push(c);
+    console.log(
+      `  relations: ${d.emitted} emitted → ${d.survived} survived, ${d.droppedLowConfidence} low-conf, ${d.droppedEndpointUnresolved} unresolved`,
+    );
+    cards.push(card);
+    drops.push(d);
   }
 
   printAggregate(aggregateScorecards(cards));
+  printRelationDrops(aggregateRelationDrops(drops), RUNS);
 }
 
 main().catch((e) => {

--- a/packages/core/eval/run-eval.ts
+++ b/packages/core/eval/run-eval.ts
@@ -20,13 +20,15 @@ import { recordScene } from "../src/rag/scenes.js";
 import { extractLoreFromScene, _makeDefaultExtractor } from "../src/rag/extraction.js";
 import { exportLore } from "../src/rag/lore.js";
 import { getWorldEmbedding } from "../src/rag/world-db.js";
-import { scoreExtraction, type ActualState, type GoldenSet, type Scorecard } from "./score.js";
+import { scoreExtraction, matchEntities, type ActualState, type GoldenSet, type Scorecard } from "./score.js";
 import { aggregateScorecards, type AggregateScorecard, type MetricStats } from "./aggregate.js";
 import {
   classifyRelationDrops,
   aggregateRelationDrops,
+  entityRecallByType,
   type EmittedRelation,
   type RelationDropBreakdown,
+  type TypeRecall,
 } from "./diagnostics.js";
 import type { SerializedScene } from "./scene-record.js";
 
@@ -59,7 +61,12 @@ async function runOnce(
   scenes: SerializedScene[],
   golden: GoldenSet,
   extractor: ReturnType<typeof _makeDefaultExtractor>,
-): Promise<{ card: Scorecard; drops: RelationDropBreakdown }> {
+): Promise<{
+  card: Scorecard;
+  drops: RelationDropBreakdown;
+  typeRecall: TypeRecall[];
+  missedGolden: string[];
+}> {
   const dir = await mkdtemp(join(tmpdir(), "eval-run-"));
 
   // Capture every relation the extractor EMITTED (raw, pre-filter) so we can
@@ -101,8 +108,14 @@ async function runOnce(
   const persistedNames = entities.flatMap((e) => [e.canonical, ...e.aliases]);
   const drops = classifyRelationDrops(emitted, persistedNames, CONF_THRESHOLD);
 
+  // Which golden entities were missed, and per-type recall — relations depend on
+  // abstract entity types (thread/event/concept/truth) being extracted at all.
+  const matching = await matchEntities(actual.entities, golden.entities, getWorldEmbedding);
+  const typeRecall = entityRecallByType(golden.entities, matching.unmatchedGolden);
+  const missedGolden = matching.unmatchedGolden.map((g) => `${g.canonical} (${g.type})`);
+
   const card = await scoreExtraction(actual, golden, getWorldEmbedding);
-  return { card, drops };
+  return { card, drops, typeRecall, missedGolden };
 }
 
 function band(s: MetricStats): string {
@@ -148,6 +161,21 @@ function printRelationDrops(d: RelationDropBreakdown, runs: number): void {
   }
 }
 
+// Per-type entity recall (worst first) + the specific golden entities missed in
+// the final run. Relations connect abstract entity types, so a type the
+// extractor under-produces caps the relation recall built on it.
+function printEntityRecallByType(rows: TypeRecall[], missed: string[]): void {
+  console.log("");
+  console.log("Entity recall by golden type (final run, worst first)");
+  for (const r of rows) {
+    console.log(`  ${r.type.padEnd(9)} ${fmt(r.recall)}  (${r.matched}/${r.total})`);
+  }
+  if (missed.length > 0) {
+    console.log(`  missed golden entities (${missed.length}):`);
+    for (const m of missed) console.log(`    ${m}`);
+  }
+}
+
 async function main(): Promise<void> {
   if (!process.env["ANTHROPIC_API_KEY"]) {
     console.error("Eval needs ANTHROPIC_API_KEY (the shipping extractor calls the real LLM).");
@@ -177,21 +205,26 @@ async function main(): Promise<void> {
 
   const cards: Scorecard[] = [];
   const drops: RelationDropBreakdown[] = [];
+  let lastTypeRecall: TypeRecall[] = [];
+  let lastMissed: string[] = [];
   for (let i = 0; i < RUNS; i++) {
     console.log(`--- run ${i + 1}/${RUNS} ---`);
-    const { card, drops: d } = await runOnce(scenes, golden, extractor);
+    const { card, drops: d, typeRecall, missedGolden } = await runOnce(scenes, golden, extractor);
     console.log(
-      `  entity F1 ${fmt(card.entity.f1)}  dedup ${fmt(card.dedup.score)}  temporal ${card.temporal.correct}/${card.temporal.total}`,
+      `  entity F1 ${fmt(card.entity.f1)}  recall ${fmt(card.entity.recall)}  dedup ${fmt(card.dedup.score)}  temporal ${card.temporal.correct}/${card.temporal.total}`,
     );
     console.log(
       `  relations: ${d.emitted} emitted → ${d.survived} survived, ${d.droppedLowConfidence} low-conf, ${d.droppedEndpointUnresolved} unresolved`,
     );
     cards.push(card);
     drops.push(d);
+    lastTypeRecall = typeRecall;
+    lastMissed = missedGolden;
   }
 
   printAggregate(aggregateScorecards(cards));
   printRelationDrops(aggregateRelationDrops(drops), RUNS);
+  printEntityRecallByType(lastTypeRecall, lastMissed);
 }
 
 main().catch((e) => {

--- a/packages/core/src/rag/extraction.ts
+++ b/packages/core/src/rag/extraction.ts
@@ -331,8 +331,20 @@ export function _makeDefaultExtractor(
       `- type: one of ${LORE_TYPES.join(", ")}\n` +
       `- summary: one self-contained sentence using the canonical name, not pronouns\n` +
       `- aliases: other names used in the scene for the same entity\n` +
-      `- Extract an entity ONLY if it is both NAMED and CONSEQUENTIAL — a proper\n` +
-      `  noun that the ongoing story will refer back to. When in doubt, leave it out.\n` +
+      `- Extract an entity if it is CONSEQUENTIAL — the ongoing story will refer\n` +
+      `  back to it. Cover ALL these kinds, not just people and places:\n` +
+      `    person / creature: named individuals\n` +
+      `    place: named locations\n` +
+      `    faction: named groups, orders, or networks (e.g. "The Eld", "Anchor Network")\n` +
+      `    material: significant objects, relics, or tokens (e.g. "Iron Map", "Bone Token")\n` +
+      `    event: a discrete happening the story treats as a landmark — a fire, a duel,\n` +
+      `      a banishment, a vow fulfilled (e.g. "Root-Cellar Fire", "Caldren's Circle Duel")\n` +
+      `    thread: a vow, quest, or obligation a character is pursuing or holds\n` +
+      `      (e.g. "Find a New Colony", "Caldren's Wardenship", "Lona's Captaincy")\n` +
+      `    concept / truth: a named phenomenon, force, lineage, debt, or world-fact\n` +
+      `      (e.g. "The Answering", "Mai's Sword-Line", "Harvest Debt")\n` +
+      `  A consequential vow, event, faction, or named phenomenon counts EVEN WHEN it is\n` +
+      `  not a classic proper noun — give it a specific canonical name drawn from the scene.\n` +
       `- Do NOT extract: player character stats or moves; emotional or transient\n` +
       `  states ("X is afraid"); implied facts ("X is alive"); generic/unnamed\n` +
       `  background ("a guard", "some merchants", "the road", "the crowd"); or\n` +

--- a/packages/core/src/rag/extraction.ts
+++ b/packages/core/src/rag/extraction.ts
@@ -302,108 +302,137 @@ const EXTRACTION_SYSTEM_PROMPT =
   "You are a knowledge-graph extractor for a solo RPG campaign. " +
   "Return ONLY valid JSON matching the requested schema. No prose, no markdown fences.";
 
+// Render an entity list as the `id|canonical|type|summary :: current: ...` block
+// both passes show the model. New (just-extracted) entities carry no relations,
+// so no "-> " arrows appear for them.
+function renderEntityContext(entities: LoreSearchHit[]): string {
+  if (entities.length === 0) return "(none)";
+  return entities
+    .map((e) => {
+      const rels =
+        e.relations && e.relations.length > 0
+          ? ` :: current: ${e.relations
+              .map((r) => `${r.relation}->${r.to}`)
+              .join(", ")}`
+          : "";
+      return `${e.id}|${e.canonical}|${e.type}|${e.summary}${rels}`;
+    })
+    .join("\n");
+}
+
+// One LLM call: send the prompt, strip fences/prose, parse the first JSON object.
+async function callExtractorJson(
+  client: AnthropicLike,
+  userPrompt: string,
+  opts?: { model?: string; temperature?: number },
+): Promise<{ entities?: ExtractedEntity[]; relations?: ExtractedRelation[] }> {
+  const response = await client.messages.create({
+    model: opts?.model ?? DEFAULT_EXTRACTION_MODEL,
+    max_tokens: 4096,
+    ...(opts?.temperature !== undefined ? { temperature: opts.temperature } : {}),
+    system: EXTRACTION_SYSTEM_PROMPT,
+    messages: [{ role: "user", content: userPrompt }],
+  });
+
+  let text = response.content
+    .flatMap((b) =>
+      b.type === "text" && typeof b.text === "string" ? [b.text] : [],
+    )
+    .join("")
+    .trim();
+
+  if (text.length === 0) {
+    throw new Error("Empty extraction response from Anthropic");
+  }
+
+  const jsonMatch = text.match(/\{[\s\S]*\}/);
+  if (jsonMatch) text = jsonMatch[0];
+
+  return JSON.parse(text) as {
+    entities?: ExtractedEntity[];
+    relations?: ExtractedRelation[];
+  };
+}
+
+// Single-pass prompt: entities + relations in one call. (A two-pass split was
+// trialed — entities then relations over a fixed vocabulary — and measured as a
+// negative result: ~2x cost, no precision/dedup recovery, since entity
+// over-extraction is intrinsic to the entity pass, not driven by relation
+// pressure. Reverted to single-pass.)
+function buildExtractionPrompt(sceneText: string, existingContext: string): string {
+  return (
+    `Scene text:\n${sceneText}\n\n` +
+    `Existing lore entities (id|canonical|type|summary :: current relations):\n${existingContext}\n\n` +
+    `Extract only what is newly established or explicitly changed in this scene.\n\n` +
+    `ENTITY RULES:\n` +
+    `- canonical: specific noun phrase, ≤5 words (e.g. "Ashfen Market Quarter" not "the market")\n` +
+    `- type: one of ${LORE_TYPES.join(", ")}\n` +
+    `- summary: one self-contained sentence using the canonical name, not pronouns\n` +
+    `- aliases: other names used in the scene for the same entity\n` +
+    `- Extract an entity if it is CONSEQUENTIAL — the ongoing story will refer\n` +
+    `  back to it. Cover ALL these kinds, not just people and places:\n` +
+    `    person / creature: named individuals\n` +
+    `    place: named locations\n` +
+    `    faction: named groups, orders, or networks (e.g. "The Eld", "Anchor Network")\n` +
+    `    material: significant objects, relics, or tokens (e.g. "Iron Map", "Bone Token")\n` +
+    `    event: a discrete happening the story treats as a landmark — a fire, a duel,\n` +
+    `      a banishment, a vow fulfilled (e.g. "Root-Cellar Fire", "Caldren's Circle Duel")\n` +
+    `    thread: a vow, quest, or obligation a character is pursuing or holds\n` +
+    `      (e.g. "Find a New Colony", "Caldren's Wardenship", "Lona's Captaincy")\n` +
+    `    concept / truth: a named phenomenon, force, lineage, debt, or world-fact\n` +
+    `      (e.g. "The Answering", "Mai's Sword-Line", "Harvest Debt")\n` +
+    `  A consequential vow, event, faction, or named phenomenon counts EVEN WHEN it is\n` +
+    `  not a classic proper noun — give it a specific canonical name drawn from the scene.\n` +
+    `- Extract a thing ONLY if the ongoing story will REFER BACK to it as a DURABLE\n` +
+    `  anchor. One entity per durable thing, NOT one per beat. If a vow, event, or\n` +
+    `  place recurs under slightly different wording, REUSE the existing canonical\n` +
+    `  name from the list above instead of coining a new variant.\n` +
+    `- Do NOT extract: player character stats, moves, or mechanical outcomes\n` +
+    `  ("Combat Track Maxed", "Hip-Powered Counter"); one-off beats the story will\n` +
+    `  not return to ("Caldren's Boast", "Dalla's Ultimatum"); emotional or transient\n` +
+    `  states ("X is afraid"); implied facts ("X is alive"); generic/unnamed\n` +
+    `  background ("a guard", "some merchants", "the road", "the crowd"); or\n` +
+    `  anything already captured in the existing entities list above\n\n` +
+    `RELATION RULES:\n` +
+    `- relation: SCREAMING_SNAKE_CASE, verb-first (e.g. LEADS, GUARDS, MEMBER_OF, ALLIED_WITH,\n` +
+    `  ENEMY_OF, LOCATED_IN, CREATED_BY, BOUND_TO, SEEKS, OPPOSES, HOLDS_TITLE, SERVES,\n` +
+    `  KILLED_BY, TAGGED_AS — invent a clear verb label if none of these fit)\n` +
+    `- notes: one self-contained sentence elaborating the relation\n` +
+    `- supersedes: true ONLY when this relation explicitly replaces a prior known state\n` +
+    `  (a title stripped, an alliance broken, a location changed); false otherwise\n` +
+    `- IMPORTANT: when the scene ends or changes a state shown in an existing entity's\n` +
+    `  "current:" relations (e.g. a LOCATED_IN/HOLDS_TITLE ended by banishment, exile,\n` +
+    `  death, or a move), emit the new relation with supersedes:true and reuse the SAME\n` +
+    `  from/to canonical names shown there, so the prior fact is found and invalidated\n` +
+    `- Do NOT extract: player character as from-entity unless a new named relationship is\n` +
+    `  established, generic spatial relations ("X is in the room"), duplicate relations\n` +
+    `  already present in existing entities\n\n` +
+    `Return ONLY this JSON object:\n` +
+    `{\n` +
+    `  "entities": [\n` +
+    `    { "canonical": string, "type": string, "summary": string, "aliases": string[], "excerpt": string, "confidence": number }\n` +
+    `  ],\n` +
+    `  "relations": [\n` +
+    `    { "from": string, "to": string, "relation": string, "notes": string, "supersedes": boolean, "excerpt": string, "confidence": number }\n` +
+    `  ]\n` +
+    `}`
+  );
+}
+
 export function _makeDefaultExtractor(
   client: AnthropicLike,
   opts?: { model?: string; temperature?: number },
 ): Extractor {
   return async (sceneText, existingEntities) => {
-    const existingContext =
-      existingEntities.length > 0
-        ? existingEntities
-            .map((e) => {
-              const rels =
-                e.relations && e.relations.length > 0
-                  ? ` :: current: ${e.relations
-                      .map((r) => `${r.relation}->${r.to}`)
-                      .join(", ")}`
-                  : "";
-              return `${e.id}|${e.canonical}|${e.type}|${e.summary}${rels}`;
-            })
-            .join("\n")
-        : "(none)";
-
-    const userPrompt =
-      `Scene text:\n${sceneText}\n\n` +
-      `Existing lore entities (id|canonical|type|summary :: current relations):\n${existingContext}\n\n` +
-      `Extract only what is newly established or explicitly changed in this scene.\n\n` +
-      `ENTITY RULES:\n` +
-      `- canonical: specific noun phrase, ≤5 words (e.g. "Ashfen Market Quarter" not "the market")\n` +
-      `- type: one of ${LORE_TYPES.join(", ")}\n` +
-      `- summary: one self-contained sentence using the canonical name, not pronouns\n` +
-      `- aliases: other names used in the scene for the same entity\n` +
-      `- Extract an entity if it is CONSEQUENTIAL — the ongoing story will refer\n` +
-      `  back to it. Cover ALL these kinds, not just people and places:\n` +
-      `    person / creature: named individuals\n` +
-      `    place: named locations\n` +
-      `    faction: named groups, orders, or networks (e.g. "The Eld", "Anchor Network")\n` +
-      `    material: significant objects, relics, or tokens (e.g. "Iron Map", "Bone Token")\n` +
-      `    event: a discrete happening the story treats as a landmark — a fire, a duel,\n` +
-      `      a banishment, a vow fulfilled (e.g. "Root-Cellar Fire", "Caldren's Circle Duel")\n` +
-      `    thread: a vow, quest, or obligation a character is pursuing or holds\n` +
-      `      (e.g. "Find a New Colony", "Caldren's Wardenship", "Lona's Captaincy")\n` +
-      `    concept / truth: a named phenomenon, force, lineage, debt, or world-fact\n` +
-      `      (e.g. "The Answering", "Mai's Sword-Line", "Harvest Debt")\n` +
-      `  A consequential vow, event, faction, or named phenomenon counts EVEN WHEN it is\n` +
-      `  not a classic proper noun — give it a specific canonical name drawn from the scene.\n` +
-      `- Do NOT extract: player character stats or moves; emotional or transient\n` +
-      `  states ("X is afraid"); implied facts ("X is alive"); generic/unnamed\n` +
-      `  background ("a guard", "some merchants", "the road", "the crowd"); or\n` +
-      `  anything already captured in the existing entities list above\n\n` +
-      `RELATION RULES:\n` +
-      `- relation: SCREAMING_SNAKE_CASE, verb-first (e.g. LEADS, GUARDS, MEMBER_OF, ALLIED_WITH,\n` +
-      `  ENEMY_OF, LOCATED_IN, CREATED_BY, BOUND_TO, SEEKS, OPPOSES, HOLDS_TITLE, SERVES,\n` +
-      `  KILLED_BY, TAGGED_AS — invent a clear verb label if none of these fit)\n` +
-      `- notes: one self-contained sentence elaborating the relation\n` +
-      `- supersedes: true ONLY when this relation explicitly replaces a prior known state\n` +
-      `  (a title stripped, an alliance broken, a location changed); false otherwise\n` +
-      `- IMPORTANT: when the scene ends or changes a state shown in an existing entity's\n` +
-      `  "current:" relations (e.g. a LOCATED_IN/HOLDS_TITLE ended by banishment, exile,\n` +
-      `  death, or a move), emit the new relation with supersedes:true and reuse the SAME\n` +
-      `  from/to canonical names shown there, so the prior fact is found and invalidated\n` +
-      `- Do NOT extract: player character as from-entity unless a new named relationship is\n` +
-      `  established, generic spatial relations ("X is in the room"), duplicate relations\n` +
-      `  already present in existing entities\n\n` +
-      `Return ONLY this JSON object:\n` +
-      `{\n` +
-      `  "entities": [\n` +
-      `    { "canonical": string, "type": string, "summary": string, "aliases": string[], "excerpt": string, "confidence": number }\n` +
-      `  ],\n` +
-      `  "relations": [\n` +
-      `    { "from": string, "to": string, "relation": string, "notes": string, "supersedes": boolean, "excerpt": string, "confidence": number }\n` +
-      `  ]\n` +
-      `}`;
-
-    const response = await client.messages.create({
-      model: opts?.model ?? DEFAULT_EXTRACTION_MODEL,
-      max_tokens: 4096,
-      ...(opts?.temperature !== undefined
-        ? { temperature: opts.temperature }
-        : {}),
-      system: EXTRACTION_SYSTEM_PROMPT,
-      messages: [{ role: "user", content: userPrompt }],
-    });
-
-    let text = response.content
-      .flatMap((b) =>
-        b.type === "text" && typeof b.text === "string" ? [b.text] : [],
-      )
-      .join("")
-      .trim();
-
-    if (text.length === 0) {
-      throw new Error("Empty extraction response from Anthropic");
-    }
-
-    // Extract first JSON object from the response, tolerating surrounding prose
-    // or markdown fences the model may add despite the system prompt.
-    const jsonMatch = text.match(/\{[\s\S]*\}/);
-    if (jsonMatch) text = jsonMatch[0];
-
-    const parsed = JSON.parse(text) as ExtractionResult;
-    parsed.entities = parsed.entities.filter((e) =>
+    const parsed = await callExtractorJson(
+      client,
+      buildExtractionPrompt(sceneText, renderEntityContext(existingEntities)),
+      opts,
+    );
+    const entities = (parsed.entities ?? []).filter((e) =>
       LORE_TYPES.includes(e.type),
     );
-    return parsed;
+    return { entities, relations: parsed.relations ?? [] };
   };
 }
 

--- a/plugins/ironsworn/.claude-plugin/plugin.json
+++ b/plugins/ironsworn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ironsworn",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "description": "Solo Ironsworn GM companion — fiction-first, dice-driven, with a living lore graph",
   "author": {
     "name": "Karim Naguib"


### PR DESCRIPTION
## Summary

This branch began as an attempt to improve `extract_session_lore` quality and ended by **changing the v1 strategy**. It lands the reusable tooling + measured findings, plus the design spec and implementation plan for the new direction.

### What's here

- **Relation-drop diagnostics** (`packages/core/eval/diagnostics.ts`) — classifies relation loss into "never emitted" (prompt) vs "emitted then dropped" (plumbing); per-type entity recall; near-duplicate + false-positive dumps. Reusable eval tooling, fully unit-tested.
- **Type-aware extraction prompt** — lifts relation recall **0.15 → 0.24 (+60% median, 5-run)** and entity recall 0.74 → ~0.85 by extracting the abstract types golden relations hinge on (event/thread/faction). Comes with an entity-precision/dedup cost, audited as ~⅓ real name fragmentation, ~⅔ a loose-matcher artifact. (Two-pass extraction was trialed and reverted as a measured negative result.)
- **Design spec + implementation plan** for **point-of-entry structured recording** — the pivot the findings motivated: capture canon (entities **and relations**) on the beat at narration time; demote extraction to optional backfill. See `docs/superpowers/specs/2026-06-27-point-of-entry-recording-design.md` and the plan alongside it.

### Why the pivot

Batch extraction is a lossy prose→structure reconstruction. Relation recall caps because relations are never recorded where they're known (the GM narrates them, then a second LLM tries to recover them). The fix isn't a better extractor — it's recording structure at the source. This PR's spec reconciles four claims in `docs/design/agentic-rpg-v1.md` accordingly (notably inverting "extraction quality is the highest-leverage component").

Implementation of the pivot proceeds on a separate branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)