### PR TITLE
Point-of-entry structured recording (v0.37.0)

### DIFF
--- a/docs/design/agentic-rpg-v1.md
+++ b/docs/design/agentic-rpg-v1.md
@@ -131,10 +131,16 @@ Storage isn't the hard part. The world DB (#166, landed in #169) gives
 us a place to put facts — necessary, not sufficient. The actual failure
 modes for a storyteller, several already observable in Zura play:
 
-1. **Extraction quality.** If `extract_session_lore` produces
-   near-duplicates, mis-typed relations, or misses load-bearing facts,
-   the graph is noise with provenance. Highest-leverage component;
-   currently treated as carry-forward.
+1. **Capture at point of entry.** The highest-leverage fix is *not* better
+   extraction — batch extraction is a lossy prose→structure reconstruction that
+   lacks the author's knowledge of what is canonical and reliable name grounding.
+   The GM, at narration time, has both. Canon (entities **and relations**) should
+   be recorded on the beat via `record_beat`; extraction is demoted to optional
+   backfill. (Established 2026-06 after measurement: relation recall caps because
+   relations were never recorded where known; a two-pass extractor was a measured
+   negative result; the dedup regression was largely name fragmentation from
+   re-deriving names independently. See
+   `docs/superpowers/specs/2026-06-27-point-of-entry-recording-design.md`.)
 2. **Temporal truth.** Who's alive *now*? Who holds the post *now*?
    `knowledge-graph.md` explicitly defers bi-temporal validity ("until
    NPC churn forces it"). For a storyteller this is wrong — narrating a
@@ -155,11 +161,11 @@ pattern: rules are commodity data plus pure functions.
 
 ### v1 priorities, in order
 
-> **Status (as of 2026-06-21):** #1 ✅ done · #2 ❌ not started ·
-> #3 🟡 substantially done · #4 ❌ not started · #5 ❌ not started ·
-> #6 ❌ deferred by design. The gating decision (#1) is closed and the
-> DuckDB substrate is locked, which unblocks the rest. Next pickup: #2
-> (extraction evaluation harness).
+> **Status (as of 2026-06-27):** #1 ✅ done · #2 ✅ done ·
+> #3 ❌ not started · #4 🟡 substantially done · #5 ❌ not started ·
+> #6 ❌ not started · #7 ❌ deferred by design. Point-of-entry structured
+> recording (#2) is the active completed item; the DuckDB substrate is locked.
+> Next pickup: #3 (extraction evaluation as backfill-quality measurement).
 
 1. **Graphiti spike (gating decision).** ✅ **Resolved (2026-06-16): Path B.**
    Promote OQ1 from open question
@@ -173,11 +179,18 @@ pattern: rules are commodity data plus pure functions.
    embedded backend, Kuzu, is archived and deprecated by Graphiti) and
    committed to Path B (DuckDB). Graphiti's *extraction approach* was
    adopted into the DuckDB extractor. See `docs/spikes/2026-06-graphiti.md`.
-2. **Extraction evaluation harness.** Build a fixed set of Zura scenes
-   with known-correct entities and relations, scored on every prompt
-   or model change. Without this, extraction quality is vibes.
-   Required regardless of which way the Graphiti spike resolves.
-3. **Temporal truth.** 🟡 **Substantially done (landed 2026-06; spike
+2. **Point-of-entry structured recording.** ✅ **Done (2026-06-27).** The
+   highest-leverage coherence improvement is authorial capture at the moment of
+   narration, not batch extraction. `record_beat` now carries optional `entities`
+   and `relations` payloads; the GM records canon on the beat using exact grounded
+   names. Extraction is demoted to optional backfill. See
+   `docs/superpowers/specs/2026-06-27-point-of-entry-recording-design.md`.
+3. **Extraction evaluation (backfill-quality measurement).** Build a fixed set
+   of Zura scenes with known-correct entities and relations, scored on every
+   prompt or model change. *This is no longer the primary quality lever* —
+   point-of-entry recording is. The harness measures backfill quality and guards
+   against regressions in the fallback path.
+4. **Temporal truth.** 🟡 **Substantially done (landed 2026-06; spike
    Phases 1–2, preserved through the Path B rollback).** Reverse the
    bi-temporal deferral in `knowledge-graph.md`. If the Graphiti spike
    adopts Graphiti, bi-temporal edges come for free. If it doesn't, add
@@ -190,17 +203,17 @@ pattern: rules are commodity data plus pure functions.
    **Remaining:** arbitrary historical "as-of `<timestamp>`" reads —
    reads currently filter to *current* facts only, not a queryable past
    state.
-4. **Write-time contradiction surfacing.** On `upsert_entity` /
+5. **Write-time contradiction surfacing.** On `upsert_entity` /
    `link`, run a similarity check against existing canon and flag
    apparent contradictions (different summary for an existing alias;
    a relation that conflicts with one already on the graph) for the
    canonize ritual to adjudicate. Don't reject — surface.
-5. **Retrieval discipline.** Tighten the fiction-grounding protocol
+6. **Retrieval discipline.** Tighten the fiction-grounding protocol
    into a hard tool-use pattern, not a prompt convention. Read tools
    return entity refs plus *what the agent should re-read before
    narrating* (e.g., "you fetched X but didn't fetch X's recent
    scenes — call recall first").
-6. **Then the platform work.** System / setting / craft package
+7. **Then the platform work.** System / setting / craft package
    splits, npm distribution, paid stacks, alt-frontend candidates,
    future-proofing extension points. Keep the boundaries the doc
    already establishes (they cost little in code); defer the
@@ -776,14 +789,19 @@ Per "one tool per query pattern, not per concept" (start-from-scratch).
   `recall` unification is its own follow-up.
 - `record_scene(summary, beats, place_entity, refs)` — *shipped (#169):*
   resolves names to entity UUIDs, auto-stubs unknowns as campaign-scoped
-  entities, writes `scene_entity_refs`.
+  entities, writes `scene_entity_refs`. `record_beat` carries optional
+  `entities` and `relations` payloads; canon recorded on the beat via these
+  fields is the primary path to the knowledge graph (point-of-entry recording).
 - `upsert_entity(kind, name, summary, metadata)` — *shipped (#169);*
   `upsert_npc` / `upsert_lore` kept as one-release aliases.
 - `link(from, to, label, metadata?)` — replaces v0.x `link_lore`.
 - `canonize_entity(id)` / `canonize_relation(id)` and the
   `decanonize_*(id, into_campaign)` inverses — *shipped (#169).* Entities
   and relations canonize independently.
-- `extract_session_lore()` — batch extraction from recent scenes.
+- `extract_session_lore()` — *optional backfill only.* Batch LLM extraction
+  from recent scenes; use if the GM suspects canon was missed. Deduplicates
+  against recorded canon via exact-match idempotency. Not the primary
+  canon-capture path.
 
 **Player-directive tools (system-agnostic, in core):**
 
@@ -1134,9 +1152,12 @@ introducing or narrating anything that might be canon, call:
 
 1. `recall(query=<entity-or-concept>, kind?, limit=5)` — does this exist?
 2. If multiple matches → disambiguate via aliases, then continue
-3. If no match → free to invent, then `upsert_entity(...)` after the
-   scene resolves
+3. If no match → free to invent; include the new entity in the beat's
+   `entities` payload using the exact name chosen here
 4. If match → narrate consistent with the recorded summary + relations
+5. `record_beat(...)` carrying `entities` (new canon this beat establishes,
+   using exact grounded names) and `relations` (links the beat asserts);
+   a beat that establishes a new entity or relationship **must** carry it
 
 This is the single biggest contributor to long-campaign coherence. It's
 craft, not mechanics; it lives with skills, not the rules engine.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -74,6 +74,14 @@ export type { ExtractedEntity, ExtractedRelation, ExtractionResult, ExtractionRe
 export { pushBeat, drainNotices, replayFailures, shutdown, _setRecordBeatFn, _resetRecordBeatFn } from "./rag/beat-queue.js";
 export type { BeatQueueEntry } from "./rag/beat-queue.js";
 
+// RAG — beat-canon
+export {
+  recordBeatCanon,
+  type BeatEntity,
+  type BeatRelation,
+  type BeatCanonResult,
+} from "./rag/beat-canon.js";
+
 // Checkpoint
 export { startPeriodicCheckpoint, recordMutation } from "./checkpoint.js";
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -82,6 +82,9 @@ export {
   type BeatCanonResult,
 } from "./rag/beat-canon.js";
 
+// RAG — graph health
+export { fragmentationClusters, relationCoverage } from "./rag/graph-health.js";
+
 // Checkpoint
 export { startPeriodicCheckpoint, recordMutation } from "./checkpoint.js";
 

--- a/packages/core/src/rag/beat-canon.test.ts
+++ b/packages/core/src/rag/beat-canon.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { recordBeatCanon } from "./beat-canon.js";
+import { upsertLore, getLore, exportLore } from "./lore.js";
+import { recordScene } from "./scenes.js";
+
+let _ollamaReady: boolean | null = null;
+async function ollamaAvailable(): Promise<boolean> {
+  if (_ollamaReady !== null) return _ollamaReady;
+  try {
+    const baseUrl = process.env["OLLAMA_BASE_URL"] ?? "http://localhost:11434";
+    const res = await fetch(`${baseUrl}/api/embed`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model: "nomic-embed-text", input: "t" }),
+    });
+    _ollamaReady = res.ok;
+  } catch {
+    _ollamaReady = false;
+  }
+  return _ollamaReady;
+}
+
+let dir: string;
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "beat-canon-test-"));
+});
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+describe("recordBeatCanon — entities", () => {
+  it("reuses an existing entity by exact canonical match (no duplicate)", async () => {
+    if (!(await ollamaAvailable())) return;
+    await upsertLore(dir, { canonical: "Lona", type: "person", summary: "A healer in Caldren." });
+    const sceneId = await recordScene(dir, "Lona tends the sick.");
+
+    const r = await recordBeatCanon(dir, sceneId,
+      [{ canonical: "Lona", type: "person", summary: "A healer." }], []);
+
+    expect(r.entities_reused).toBe(1);
+    expect(r.entities_created).toBe(0);
+    const { entities } = await exportLore(dir);
+    expect(entities.filter((e) => e.canonical.toLowerCase() === "lona").length).toBe(1);
+  });
+
+  it("creates a new campaign-scoped entity when not found", async () => {
+    if (!(await ollamaAvailable())) return;
+    const sceneId = await recordScene(dir, "Vera guards the gate of Stonehaven.");
+
+    const r = await recordBeatCanon(dir, sceneId,
+      [{ canonical: "Stonehaven", type: "place", summary: "A fortified settlement." }], []);
+
+    expect(r.entities_created).toBe(1);
+    expect(await getLore(dir, "Stonehaven")).not.toBeNull();
+  });
+
+  it("skips an entity with an invalid type", async () => {
+    if (!(await ollamaAvailable())) return;
+    const sceneId = await recordScene(dir, "Something happens.");
+    const r = await recordBeatCanon(dir, sceneId,
+      [{ canonical: "Bogus", type: "notatype" as never, summary: "x" }], []);
+    expect(r.entities_created).toBe(0);
+    expect(r.skipped.length).toBe(1);
+  });
+});
+
+describe("recordBeatCanon — relations", () => {
+  it("links a relation when both endpoints already exist", async () => {
+    if (!(await ollamaAvailable())) return;
+    await upsertLore(dir, { canonical: "Vera", type: "person", summary: "A guard." });
+    await upsertLore(dir, { canonical: "Stonehaven", type: "place", summary: "A settlement." });
+    const sceneId = await recordScene(dir, "Vera guards Stonehaven.");
+
+    const r = await recordBeatCanon(dir, sceneId, [],
+      [{ from: "Vera", to: "Stonehaven", label: "GUARDS" }]);
+
+    expect(r.relations_linked).toBe(1);
+    const { relations } = await exportLore(dir);
+    expect(relations.some((x) => x.relation === "GUARDS")).toBe(true);
+  });
+
+  it("resolves an endpoint created in the same call (entities then relations)", async () => {
+    if (!(await ollamaAvailable())) return;
+    const sceneId = await recordScene(dir, "Lona serves the Thornwood.");
+    const r = await recordBeatCanon(dir, sceneId,
+      [
+        { canonical: "Lona", type: "person", summary: "A healer." },
+        { canonical: "Thornwood", type: "faction", summary: "A faction." },
+      ],
+      [{ from: "Lona", to: "Thornwood", label: "MEMBER_OF" }]);
+    expect(r.entities_created).toBe(2);
+    expect(r.relations_linked).toBe(1);
+  });
+
+  it("skips a relation with an unresolved endpoint and reports it", async () => {
+    if (!(await ollamaAvailable())) return;
+    await upsertLore(dir, { canonical: "Oracle", type: "person", summary: "A seer." });
+    const sceneId = await recordScene(dir, "The oracle serves the hidden god.");
+
+    const r = await recordBeatCanon(dir, sceneId, [],
+      [{ from: "Oracle", to: "Hidden God", label: "SERVES" }]);
+
+    expect(r.relations_linked).toBe(0);
+    expect(r.skipped.length).toBe(1);
+    expect(r.skipped[0]).toContain("Hidden God");
+  });
+
+  it("invalidates a prior relation when supersedes is true", async () => {
+    if (!(await ollamaAvailable())) return;
+    await upsertLore(dir, { canonical: "Caldren", type: "person", summary: "A warden." });
+    await upsertLore(dir, { canonical: "Holtfen", type: "place", summary: "A village." });
+    const scene1 = await recordScene(dir, "Caldren leads Holtfen.");
+    await recordBeatCanon(dir, scene1, [], [{ from: "Caldren", to: "Holtfen", label: "HOLDS_TITLE" }]);
+    const scene2 = await recordScene(dir, "Caldren is banished from Holtfen.");
+
+    await recordBeatCanon(dir, scene2, [],
+      [{ from: "Caldren", to: "Holtfen", label: "BANISHED_FROM", supersedes: true }]);
+
+    const { relations } = await exportLore(dir);
+    const prior = relations.find((x) => x.relation === "HOLDS_TITLE");
+    expect(prior!.invalid_at).not.toBeNull();
+  });
+
+  it("is idempotent — re-recording the same canon adds no duplicates", async () => {
+    if (!(await ollamaAvailable())) return;
+    const sceneId = await recordScene(dir, "Vera guards Stonehaven.");
+    const beatEntities = [
+      { canonical: "Vera", type: "person" as const, summary: "A guard." },
+      { canonical: "Stonehaven", type: "place" as const, summary: "A settlement." },
+    ];
+    const beatRels = [{ from: "Vera", to: "Stonehaven", label: "GUARDS" }];
+    await recordBeatCanon(dir, sceneId, beatEntities, beatRels);
+    const r2 = await recordBeatCanon(dir, sceneId, beatEntities, beatRels);
+
+    expect(r2.entities_created).toBe(0);
+    expect(r2.entities_reused).toBe(2);
+    const { entities, relations } = await exportLore(dir);
+    expect(entities.filter((e) => e.canonical === "Vera").length).toBe(1);
+    expect(relations.filter((x) => x.relation === "GUARDS").length).toBe(1);
+  });
+});

--- a/packages/core/src/rag/beat-canon.ts
+++ b/packages/core/src/rag/beat-canon.ts
@@ -76,9 +76,15 @@ export async function recordBeatCanon(
     const fromEntity = await getLore(campaignPath, r.from);
     const toEntity = await getLore(campaignPath, r.to);
     if (fromEntity === null || toEntity === null) {
-      const missing = fromEntity === null ? r.from : r.to;
+      const missing = [
+        fromEntity === null ? r.from : null,
+        toEntity === null ? r.to : null,
+      ]
+        .filter(Boolean)
+        .map((name) => `"${name}"`)
+        .join(" and ");
       result.skipped.push(
-        `relation ${r.from} -[${r.label}]-> ${r.to}: "${missing}" not found — ground it or add it to entities`,
+        `relation ${r.from} -[${r.label}]-> ${r.to}: ${missing} not found — ground it or add it to entities`,
       );
       continue;
     }

--- a/packages/core/src/rag/beat-canon.ts
+++ b/packages/core/src/rag/beat-canon.ts
@@ -1,0 +1,100 @@
+import {
+  upsertLore,
+  getLore,
+  linkLore,
+  invalidateRelations,
+  LORE_TYPES,
+  type LoreType,
+} from "./lore.js";
+import { getScene } from "./scenes.js";
+
+export interface BeatEntity {
+  canonical: string;
+  type: LoreType;
+  summary: string;
+  aliases?: string[];
+}
+
+export interface BeatRelation {
+  from: string;
+  to: string;
+  label: string;
+  notes?: string;
+  supersedes?: boolean;
+}
+
+export interface BeatCanonResult {
+  entities_created: number;
+  entities_reused: number;
+  relations_linked: number;
+  skipped: string[];
+}
+
+// Resolve + write the structured canon a beat establishes. Entities first
+// (exact-match reuse via getLore, else create campaign-scoped), then relations
+// (both endpoints must resolve against the graph, which now includes the
+// just-created entities). Unresolved relation endpoints are skipped with a
+// notice — never auto-stubbed — to preserve the exact-match cleanliness that
+// makes point-of-entry recording fragmentation-free.
+export async function recordBeatCanon(
+  campaignPath: string,
+  sceneId: string,
+  entities: BeatEntity[] = [],
+  relations: BeatRelation[] = [],
+): Promise<BeatCanonResult> {
+  const result: BeatCanonResult = {
+    entities_created: 0,
+    entities_reused: 0,
+    relations_linked: 0,
+    skipped: [],
+  };
+
+  const scene = await getScene(campaignPath, sceneId);
+  const validAt = scene?.timestamp;
+
+  for (const e of entities) {
+    if (!LORE_TYPES.includes(e.type)) {
+      result.skipped.push(`entity "${e.canonical}": invalid type "${e.type}"`);
+      continue;
+    }
+    const existing = await getLore(campaignPath, e.canonical);
+    if (existing !== null) {
+      result.entities_reused++;
+      continue;
+    }
+    await upsertLore(campaignPath, {
+      canonical: e.canonical,
+      type: e.type,
+      summary: e.summary,
+      aliases: e.aliases,
+      provenance: { source_kind: "beat", source_id: sceneId },
+    });
+    result.entities_created++;
+  }
+
+  for (const r of relations) {
+    const fromEntity = await getLore(campaignPath, r.from);
+    const toEntity = await getLore(campaignPath, r.to);
+    if (fromEntity === null || toEntity === null) {
+      const missing = fromEntity === null ? r.from : r.to;
+      result.skipped.push(
+        `relation ${r.from} -[${r.label}]-> ${r.to}: "${missing}" not found — ground it or add it to entities`,
+      );
+      continue;
+    }
+    if (r.supersedes && validAt) {
+      await invalidateRelations(campaignPath, fromEntity.id, toEntity.id, validAt);
+    }
+    await linkLore(campaignPath, {
+      from: fromEntity.id,
+      to: toEntity.id,
+      relation: r.label,
+      notes: r.notes,
+      valid_at: validAt,
+      provenance: { source_kind: "beat", source_id: sceneId },
+    });
+    result.relations_linked++;
+  }
+
+  return result;
+}

--- a/packages/core/src/rag/beat-queue.test.ts
+++ b/packages/core/src/rag/beat-queue.test.ts
@@ -5,7 +5,7 @@ import * as os from "os";
 import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { pushBeat, drainNotices, replayFailures, shutdown, _setRecordBeatFn, _resetRecordBeatFn } from "./beat-queue.js";
+import { pushBeat, drainNotices, replayFailures, shutdown, _setRecordBeatFn, _resetRecordBeatFn, _setRecordBeatCanonFn, _resetRecordBeatCanonFn } from "./beat-queue.js";
 import { recordScene } from "./scenes.js";
 import { getLore } from "./lore.js";
 
@@ -58,11 +58,13 @@ describe("BeatQueue", () => {
   });
 
   afterEach(() => {
+    _resetRecordBeatCanonFn();
     cleanupTmpDir(campaignPath);
   });
 
   afterAll(() => {
     _resetRecordBeatFn();
+    _resetRecordBeatCanonFn();
   });
 
   describe("worker error recovery", () => {
@@ -338,6 +340,67 @@ describe("BeatQueue", () => {
       expect(mockRecordBeat).toHaveBeenCalledTimes(1);
       expect(mockRecordBeat).toHaveBeenCalledWith(campaignPath, "s1", { kind: "narration", text: "good" });
     });
+  });
+});
+
+describe("BeatQueue — canon failure isolation", () => {
+  let campaignPath: string;
+  let mockRecordBeat: ReturnType<typeof mock<(cp: string, sid: string, beat: unknown) => Promise<number>>>;
+
+  beforeEach(async () => {
+    campaignPath = makeTmpDir();
+    mockRecordBeat = mock(async () => 0);
+    _setRecordBeatFn(mockRecordBeat as unknown as (cp: string, sid: string, beat: import("./scenes.js").BeatInput) => Promise<number>);
+    await shutdown(campaignPath);
+  });
+
+  afterEach(() => {
+    _resetRecordBeatCanonFn();
+    cleanupTmpDir(campaignPath);
+  });
+
+  afterAll(() => {
+    _resetRecordBeatFn();
+    _resetRecordBeatCanonFn();
+  });
+
+  it("resolves settled (beat saved) even when recordBeatCanon throws", async () => {
+    // Beat write succeeds; canon write throws.
+    // The entry MUST resolve (not reject), a notice MUST be queued, and the beat MUST be recorded.
+    mockRecordBeat.mockImplementation(async () => 0);
+    _setRecordBeatCanonFn(async () => { throw new Error("Ollama down"); });
+
+    const entry = await pushBeat(campaignPath, "scene-1", {
+      kind: "narration",
+      text: "Vera guards Stonehaven.",
+      entities: [{ canonical: "Vera", type: "person", summary: "A guard." }],
+      relations: [],
+    });
+
+    // Must resolve — the beat was saved even though canon failed
+    await entry.settled;
+
+    expect(mockRecordBeat).toHaveBeenCalledTimes(1);
+
+    const notices = drainNotices(campaignPath);
+    expect(notices.length).toBeGreaterThan(0);
+    expect(notices.some((n) => n.includes("beat canon write failed") && n.includes("scene-1"))).toBe(true);
+  });
+
+  it("does NOT write a sidecar when only the canon write fails", async () => {
+    // A canon failure must never trigger the beat-replay sidecar
+    mockRecordBeat.mockImplementation(async () => 0);
+    _setRecordBeatCanonFn(async () => { throw new Error("Ollama down"); });
+
+    const entry = await pushBeat(campaignPath, "scene-1", {
+      kind: "narration",
+      text: "canon-only failure",
+      entities: [{ canonical: "X", type: "person", summary: "s" }],
+    });
+    await entry.settled;
+
+    const sidecar = path.join(campaignPath, "beat-failures.jsonl");
+    expect(fs.existsSync(sidecar)).toBe(false);
   });
 });
 

--- a/packages/core/src/rag/beat-queue.test.ts
+++ b/packages/core/src/rag/beat-queue.test.ts
@@ -2,7 +2,33 @@ import { describe, it, expect, beforeEach, afterEach, afterAll, mock } from "bun
 import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import { pushBeat, drainNotices, replayFailures, shutdown, _setRecordBeatFn, _resetRecordBeatFn } from "./beat-queue.js";
+import { recordScene } from "./scenes.js";
+import { getLore } from "./lore.js";
+
+// ---------------------------------------------------------------------------
+// Ollama availability check (same pattern as extraction.test.ts)
+// ---------------------------------------------------------------------------
+
+let _ollamaReady: boolean | null = null;
+async function ollamaAvailable(): Promise<boolean> {
+  if (_ollamaReady !== null) return _ollamaReady;
+  try {
+    const baseUrl = process.env["OLLAMA_BASE_URL"] ?? "http://localhost:11434";
+    const res = await fetch(`${baseUrl}/api/embed`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model: "nomic-embed-text", input: "t" }),
+    });
+    _ollamaReady = res.ok;
+  } catch {
+    _ollamaReady = false;
+  }
+  return _ollamaReady;
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -312,5 +338,34 @@ describe("BeatQueue", () => {
       expect(mockRecordBeat).toHaveBeenCalledTimes(1);
       expect(mockRecordBeat).toHaveBeenCalledWith(campaignPath, "s1", { kind: "narration", text: "good" });
     });
+  });
+});
+
+describe("pushBeat — structured canon", () => {
+  it("writes a beat's entities and relations, surfacing skips as notices", async () => {
+    if (!(await ollamaAvailable())) return;
+    const dir = await mkdtemp(join(tmpdir(), "beat-queue-canon-"));
+    const sceneId = await recordScene(dir, "Vera guards Stonehaven; a stranger watches.");
+
+    const entry = await pushBeat(dir, sceneId, {
+      kind: "narration",
+      text: "Vera guards Stonehaven.",
+      entities: [
+        { canonical: "Vera", type: "person", summary: "A guard." },
+        { canonical: "Stonehaven", type: "place", summary: "A settlement." },
+      ],
+      relations: [
+        { from: "Vera", to: "Stonehaven", label: "GUARDS" },
+        { from: "Vera", to: "The Stranger", label: "WATCHED_BY" }, // unresolved → skipped
+      ],
+    });
+    await entry.settled;
+
+    expect(await getLore(dir, "Vera")).not.toBeNull();
+    expect(await getLore(dir, "Stonehaven")).not.toBeNull();
+    const notices = drainNotices(dir);
+    expect(notices.some((n) => n.includes("The Stranger"))).toBe(true);
+
+    await rm(dir, { recursive: true, force: true });
   });
 });

--- a/packages/core/src/rag/beat-queue.ts
+++ b/packages/core/src/rag/beat-queue.ts
@@ -2,11 +2,14 @@ import * as fs from "fs";
 import * as path from "path";
 import { recordBeat as _defaultRecordBeat } from "./scenes.js";
 import type { BeatInput } from "./scenes.js";
-import { recordBeatCanon } from "./beat-canon.js";
+import { recordBeatCanon as _defaultRecordBeatCanon } from "./beat-canon.js";
+import type { BeatEntity, BeatRelation, BeatCanonResult } from "./beat-canon.js";
 
 type RecordBeatFn = (campaignPath: string, sceneId: string, beat: BeatInput) => Promise<number>;
+type RecordBeatCanonFn = (campaignPath: string, sceneId: string, entities: BeatEntity[] | undefined, relations: BeatRelation[] | undefined) => Promise<BeatCanonResult>;
 
 let _recordBeat: RecordBeatFn = _defaultRecordBeat;
+let _recordBeatCanon: RecordBeatCanonFn = _defaultRecordBeatCanon;
 
 export function _setRecordBeatFn(fn: RecordBeatFn): void {
   _recordBeat = fn;
@@ -14,6 +17,14 @@ export function _setRecordBeatFn(fn: RecordBeatFn): void {
 
 export function _resetRecordBeatFn(): void {
   _recordBeat = _defaultRecordBeat;
+}
+
+export function _setRecordBeatCanonFn(fn: RecordBeatCanonFn): void {
+  _recordBeatCanon = fn;
+}
+
+export function _resetRecordBeatCanonFn(): void {
+  _recordBeatCanon = _defaultRecordBeatCanon;
 }
 
 export interface BeatQueueEntry {
@@ -132,16 +143,10 @@ async function _runWorker(campaignPath: string): Promise<void> {
 
   while (queue.length > 0) {
     const entry = queue[0]!;
+    let beatWriteOk = false;
     try {
       entry.beatIndex = await _recordBeat(campaignPath, entry.sceneId, entry.beat);
-      const { entities, relations } = entry.beat;
-      if ((entities && entities.length > 0) || (relations && relations.length > 0)) {
-        const canon = await recordBeatCanon(campaignPath, entry.sceneId, entities, relations);
-        for (const skip of canon.skipped) {
-          _queueNotice(campaignPath, `[core] beat canon skipped: ${skip}`);
-        }
-      }
-      entry._resolve();
+      beatWriteOk = true;
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
       const sidecarOk = _appendSidecar(campaignPath, entry);
@@ -151,7 +156,33 @@ async function _runWorker(campaignPath: string): Promise<void> {
       _queueNotice(campaignPath, `[core] beat write failed for scene ${entry.sceneId}: ${msg}. ${noticeDetail}`);
       process.stderr.write(`[core] beat-queue: failed to persist beat for scene ${entry.sceneId}: ${msg}\n`);
       entry._reject(e);
+      queue.shift();
+      continue;
     }
+
+    if (beatWriteOk) {
+      // Canon write is a best-effort enrichment step. A failure here must NOT
+      // replay the beat (which is already durably stored), so it gets its own
+      // isolated try/catch that queues a notice and still resolves the entry.
+      const { entities, relations } = entry.beat;
+      if ((entities && entities.length > 0) || (relations && relations.length > 0)) {
+        try {
+          const canon = await _recordBeatCanon(campaignPath, entry.sceneId, entities, relations);
+          for (const skip of canon.skipped) {
+            _queueNotice(campaignPath, `[core] beat canon skipped: ${skip}`);
+          }
+        } catch (e) {
+          const msg = e instanceof Error ? e.message : String(e);
+          _queueNotice(
+            campaignPath,
+            `[core] beat canon write failed for scene ${entry.sceneId}: ${msg}. The beat was saved; its structured canon was not.`,
+          );
+          process.stderr.write(`[core] beat-queue: canon write failed for scene ${entry.sceneId}: ${msg}\n`);
+        }
+      }
+      entry._resolve();
+    }
+
     queue.shift();
   }
 

--- a/packages/core/src/rag/beat-queue.ts
+++ b/packages/core/src/rag/beat-queue.ts
@@ -2,6 +2,7 @@ import * as fs from "fs";
 import * as path from "path";
 import { recordBeat as _defaultRecordBeat } from "./scenes.js";
 import type { BeatInput } from "./scenes.js";
+import { recordBeatCanon } from "./beat-canon.js";
 
 type RecordBeatFn = (campaignPath: string, sceneId: string, beat: BeatInput) => Promise<number>;
 
@@ -133,6 +134,13 @@ async function _runWorker(campaignPath: string): Promise<void> {
     const entry = queue[0]!;
     try {
       entry.beatIndex = await _recordBeat(campaignPath, entry.sceneId, entry.beat);
+      const { entities, relations } = entry.beat;
+      if ((entities && entities.length > 0) || (relations && relations.length > 0)) {
+        const canon = await recordBeatCanon(campaignPath, entry.sceneId, entities, relations);
+        for (const skip of canon.skipped) {
+          _queueNotice(campaignPath, `[core] beat canon skipped: ${skip}`);
+        }
+      }
       entry._resolve();
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);

--- a/packages/core/src/rag/graph-health.test.ts
+++ b/packages/core/src/rag/graph-health.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "bun:test";
+import { fragmentationClusters, relationCoverage } from "./graph-health.js";
+
+describe("fragmentationClusters", () => {
+  it("groups same-type entities whose names are in a subset relation", () => {
+    const clusters = fragmentationClusters([
+      { canonical: "Lago Rhian", type: "person", aliases: [] },
+      { canonical: "Lago", type: "person", aliases: [] },
+      { canonical: "Ashfen Settlement", type: "place", aliases: [] },
+      { canonical: "Ashfen", type: "place", aliases: [] },
+      { canonical: "Caldren", type: "person", aliases: [] },
+    ]);
+    const flat = clusters.map((c) => c.names.sort());
+    expect(flat).toContainEqual(["Lago", "Lago Rhian"]);
+    expect(flat).toContainEqual(["Ashfen", "Ashfen Settlement"]);
+    expect(flat.flat()).not.toContain("Caldren"); // stands alone
+  });
+
+  it("does not cluster distinct same-pattern names (neither is a subset)", () => {
+    const clusters = fragmentationClusters([
+      { canonical: "Ashfen Harvest Vow", type: "thread", aliases: [] },
+      { canonical: "Greyhollow Harvest Vow", type: "thread", aliases: [] },
+    ]);
+    expect(clusters.length).toBe(0); // each has a unique discriminator token
+  });
+
+  it("does not cluster a subset-named entity of a different type", () => {
+    // "Caldren" (person) must not merge with "Caldren's Wardenship" (thread).
+    const clusters = fragmentationClusters([
+      { canonical: "Caldren", type: "person", aliases: [] },
+      { canonical: "Caldren Wardenship", type: "thread", aliases: [] },
+    ]);
+    expect(clusters.length).toBe(0);
+  });
+});
+
+describe("relationCoverage", () => {
+  it("reports the fraction of entities with at least one relation", () => {
+    const cov = relationCoverage(
+      [{ id: "a" }, { id: "b" }, { id: "c" }, { id: "d" }],
+      [{ from_id: "a", to_id: "b" }],
+    );
+    expect(cov.total).toBe(4);
+    expect(cov.withRelation).toBe(2); // a and b
+    expect(cov.ratio).toBeCloseTo(0.5);
+  });
+});

--- a/packages/core/src/rag/graph-health.ts
+++ b/packages/core/src/rag/graph-health.ts
@@ -1,0 +1,62 @@
+// Golden-free graph-health indicators, runnable against any world's graph.
+// Fragmentation: candidate duplicate nodes detected among the graph's OWN
+// entities — same type, and one canonical's token set a strict subset of the
+// other ("Lago" ⊂ "Lago Rhian"). Relation coverage: how connected the graph is.
+// Indicators, not scores.
+
+const STOPWORDS = new Set(["of", "the", "a", "at", "for"]);
+
+function tokens(name: string): Set<string> {
+  return new Set(
+    name
+      .toLowerCase()
+      .replace(/['']s\b/g, "")
+      .replace(/[^a-z0-9\s]/g, " ")
+      .split(/\s+/)
+      .filter((t) => t.length > 0 && !STOPWORDS.has(t)),
+  );
+}
+
+// True when one token set is a strict subset of the other (different sizes).
+function subsetMerge(a: Set<string>, b: Set<string>): boolean {
+  if (a.size === 0 || b.size === 0 || a.size === b.size) return false;
+  const [small, big] = a.size < b.size ? [a, b] : [b, a];
+  for (const t of small) if (!big.has(t)) return false;
+  return true;
+}
+
+export function fragmentationClusters(
+  entities: { canonical: string; type: string; aliases: string[] }[],
+): { type: string; names: string[] }[] {
+  const toks = entities.map((e) => tokens(e.canonical));
+  const parent = entities.map((_, i) => i);
+  const find = (i: number): number => (parent[i] === i ? i : (parent[i] = find(parent[i]!)));
+  for (let i = 0; i < entities.length; i++) {
+    for (let j = i + 1; j < entities.length; j++) {
+      if (entities[i]!.type !== entities[j]!.type) continue; // same-type only
+      if (subsetMerge(toks[i]!, toks[j]!)) parent[find(i)] = find(j);
+    }
+  }
+  const groups = new Map<number, string[]>();
+  for (let i = 0; i < entities.length; i++) {
+    const root = find(i);
+    (groups.get(root) ?? groups.set(root, []).get(root)!).push(entities[i]!.canonical);
+  }
+  return [...groups.values()]
+    .filter((names) => names.length > 1)
+    .map((names) => ({ type: entities.find((e) => names.includes(e.canonical))!.type, names }));
+}
+
+export function relationCoverage(
+  entities: { id: string }[],
+  relations: { from_id: string; to_id: string }[],
+): { withRelation: number; total: number; ratio: number } {
+  const connected = new Set<string>();
+  for (const r of relations) {
+    connected.add(r.from_id);
+    connected.add(r.to_id);
+  }
+  const withRelation = entities.filter((e) => connected.has(e.id)).length;
+  const total = entities.length;
+  return { withRelation, total, ratio: total === 0 ? 0 : withRelation / total };
+}

--- a/packages/core/src/rag/lore.ts
+++ b/packages/core/src/rag/lore.ts
@@ -23,7 +23,7 @@ export const LORE_TYPES = [
 export type LoreType = (typeof LORE_TYPES)[number];
 
 export interface ProvenanceInput {
-  source_kind: "manual" | "scene" | "document" | "extraction";
+  source_kind: "manual" | "scene" | "document" | "extraction" | "beat";
   source_id?: string;
   excerpt?: string;
   confidence?: number;

--- a/packages/core/src/rag/scenes.ts
+++ b/packages/core/src/rag/scenes.ts
@@ -1,6 +1,7 @@
 import { type DuckDBValue } from "@duckdb/node-api";
 import { resolveWorldContext } from "../world.js";
 import { getWorldDb, openWorldWriteConn, peekWorldDb, getWorldEmbedding } from "./world-db.js";
+import type { BeatEntity, BeatRelation } from "./beat-canon.js";
 
 // NOTE: Local DB plumbing (initDb, getDb, openWriteConn, getEmbedding from old scenes.duckdb)
 // has been removed. All reads/writes now target world.duckdb via getWorldDb(ctx).
@@ -31,6 +32,9 @@ export interface BeatInput {
   speaker?: string;
   text: string;
   metadata?: Record<string, unknown>;
+  // Structured canon this beat establishes (point-of-entry recording).
+  entities?: BeatEntity[];
+  relations?: BeatRelation[];
 }
 
 export interface Beat {

--- a/plugins/ironsworn/.claude-plugin/plugin.json
+++ b/plugins/ironsworn/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ironsworn",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "description": "Solo Ironsworn GM companion — fiction-first, dice-driven, with a living lore graph",
   "author": {
     "name": "Karim Naguib"

--- a/plugins/ironsworn/agents/ironsworn-gm.md
+++ b/plugins/ironsworn/agents/ironsworn-gm.md
@@ -184,10 +184,13 @@ Complication and opportunity should feel inevitable in retrospect, like they wer
 
 Before narrating any fiction that introduces or invokes a place, NPC, faction, or past event:
 
-1. **Ground first** — Call `recall` for the subject. It returns entities, their recent scenes, and community summaries in one call. For a specific place, pass `near: { entity: "<place-id>" }` to restrict results to entities connected to that place.
-2. **If results exist** — Weave them in. Honor what's already established: voice, faction ties, past beats.
-3. **If no results** — You are inventing something new. Narrate it, then call `upsert_entity` (or its `upsert_lore` alias) after the beat to record it. It lands campaign-scoped; canonize it later only if it becomes true for the whole world.
-4. **Never contradict** — If a roll or oracle says something that conflicts with established lore, treat the conflict itself as the complication.
+1. **Ground first** — Call `recall` (or `search_lore` for a specific scope) for the subject before you name it.
+2. **Narrate** the beat.
+3. **Record the beat with its canon** — call `record_beat` carrying:
+   - `entities`: any new canon the beat established, **using the exact canonical names that grounding returned** (reuse them; never coin a variant like "Lago" when canon says "Lago Rhian");
+   - `relations`: the relationships the beat asserted between those entities (`{ from, to, label }`).
+   **MANDATORY:** a beat that establishes a new entity or a relationship MUST carry it in that same `record_beat` call. Recording the prose without its structured canon is forbidden, exactly like a summary-only scene.
+4. **Never contradict** established canon — if a roll or oracle conflicts with it, treat the conflict itself as the complication.
 
 Every fiction-touching skill invokes this protocol. See each skill's SKILL.md for the reminder.
 

--- a/plugins/ironsworn/commands/extract-session-lore.md
+++ b/plugins/ironsworn/commands/extract-session-lore.md
@@ -2,6 +2,8 @@
 description: Extract lore entities and relations from all unprocessed scenes this session
 ---
 
+Optional backfill. The GM records canon on the beat during play; run this only to catch lore from scenes where structured recording was missed. It dedups against already-recorded entities and relations.
+
 Call the `extract_session_lore` MCP tool to batch-extract lore from all scenes recorded since the last extraction run.
 
 After the tool returns, report the results to the player in a brief, friendly summary:

--- a/plugins/ironsworn/scribe/src/tools/narrative.ts
+++ b/plugins/ironsworn/scribe/src/tools/narrative.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { recordScene, getScene, updateScene, deleteScene, recordBeat, recordBeats, type BeatInput } from "@agentic-rpg/core";
 import { openThread, closeThread } from "../state/threads.js";
 import { upsertNpc, getNpc } from "@agentic-rpg/core";
-import { getLore, upsertLore } from "@agentic-rpg/core";
+import { getLore, upsertLore, LORE_TYPES } from "@agentic-rpg/core";
 import { loadCharacter, saveCharacter, ProgressTrack } from "../state/character.js";
 import { recordMutation } from "@agentic-rpg/core";
 import { pushBeat, drainNotices } from "@agentic-rpg/core";
@@ -185,8 +185,31 @@ export function register(server: McpServer, campaignPath: string): void {
       wait: z.boolean().optional().describe(
         "If true, block until the beat is fully persisted before returning. Default: false (fire-and-forget)."
       ),
+      entities: z
+        .array(
+          z.object({
+            canonical: z.string(),
+            type: z.enum(LORE_TYPES),
+            summary: z.string(),
+            aliases: z.array(z.string()).optional(),
+          }),
+        )
+        .optional()
+        .describe("Canon this beat establishes. Reuse exact canonical names from grounding; new names create campaign-scoped entities."),
+      relations: z
+        .array(
+          z.object({
+            from: z.string(),
+            to: z.string(),
+            label: z.string(),
+            notes: z.string().optional(),
+            supersedes: z.boolean().optional(),
+          }),
+        )
+        .optional()
+        .describe("Relationships this beat asserts between known entities (existing or in this beat's `entities`). Endpoints that resolve to neither are skipped with a notice."),
     },
-    async ({ scene_id, kind, text, speaker, metadata, wait }) => {
+    async ({ scene_id, kind, text, speaker, metadata, wait, entities, relations }) => {
       // Validate scene exists synchronously — cheap read, surfaces errors immediately
       const existing = await getScene(campaignPath, scene_id);
       if (existing === null) {
@@ -196,7 +219,7 @@ export function register(server: McpServer, campaignPath: string): void {
         };
       }
 
-      const entry = await pushBeat(campaignPath, scene_id, { kind, text, speaker, metadata });
+      const entry = await pushBeat(campaignPath, scene_id, { kind, text, speaker, metadata, entities, relations });
 
       if (wait) {
         try {

--- a/plugins/ironsworn/skills/ironsworn-scene-craft/SKILL.md
+++ b/plugins/ironsworn/skills/ironsworn-scene-craft/SKILL.md
@@ -58,7 +58,7 @@ Before the first sentence:
 1. `recall` for the place and any faces on stage. Returns entities + their recent scenes + community summaries in one call. Pass `near: { entity: "<place-id>" }` to restrict to entities connected to this place.
 2. `list_threads` (k=3–5) — pick one to surface as visible tension.
 
-Never invent against the lore graph. If recall returns nothing, you may invent — then `upsert_entity` so the next scene matches.
+Never invent against the lore graph. If recall returns nothing, you may invent — then record the new entity in that same `record_beat` call (in `entities`) so the next scene matches.
 
 Record the canon a beat establishes **on the beat** — `record_beat` with `entities` and `relations`, reusing exact grounded names. Don't leave relations for later extraction.
 

--- a/plugins/ironsworn/skills/ironsworn-scene-craft/SKILL.md
+++ b/plugins/ironsworn/skills/ironsworn-scene-craft/SKILL.md
@@ -60,6 +60,8 @@ Before the first sentence:
 
 Never invent against the lore graph. If recall returns nothing, you may invent — then `upsert_entity` so the next scene matches.
 
+Record the canon a beat establishes **on the beat** — `record_beat` with `entities` and `relations`, reusing exact grounded names. Don't leave relations for later extraction.
+
 ---
 
 ## Framing — open with three things, one short paragraph


### PR DESCRIPTION
## Summary

Lets the GM record world canon — entities **and relations** — on the beat at narration time, instead of reconstructing it from prose via batch LLM extraction. This is the v1 strategy pivot motivated by PR #192's findings: relation recall caps because relations were never recorded where they're known, and re-deriving names independently caused fragmentation.

## What's here (6 tasks, TDD, subagent-driven with per-task + final review)

- **`recordBeatCanon`** (`packages/core/src/rag/beat-canon.ts`) — resolves entity/relation names against the existing graph (exact-match reuse via `getLore`, else create campaign-scoped), writes them with beat provenance. The back half of `extractLoreFromScene` without the LLM.
- **Beat-queue wiring** — `BeatInput` gains optional `entities`/`relations`; the async worker writes the canon after the beat row, surfacing skips as notices. Canon-write failures are isolated from the beat-durability/replay path (a final-review Critical: a canon failure must not cause the already-persisted beat to be replayed/duplicated).
- **`record_beat` MCP tool** — exposes `entities`/`relations` params.
- **Golden-free graph-health checks** (`graph-health.ts`) — fragmentation clusters (same-type strict-subset) + relation coverage, runnable against any world's graph.
- **Protocol/prompts** — Fiction Grounding Protocol now records relations on the beat (reusing exact grounded names); `extract_session_lore` reframed as optional backfill.
- **v1 design doc reconciled** — inverts the old "extraction quality is the highest-leverage component" claim; extraction demoted to backfill.

## Key properties

- Exact-match dedup only at point of entry (no fuzzy/embedding dedup — naming is deliberate because the GM grounds first).
- Unresolved relation endpoints skipped with a notice, never auto-stubbed.
- Greenfield only; prompt-discipline reliability; backfill extraction retained as the safety net.

## Testing

Core suite **381 pass, 0 fail** (incl. new beat-canon, graph-health, and canon-failure-isolation tests). Design + plan: `docs/superpowers/specs/2026-06-27-point-of-entry-recording-design.md`, `docs/superpowers/plans/2026-06-27-point-of-entry-recording.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)